### PR TITLE
Use dosfstools instead of mkfs.vfat

### DIFF
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -48,7 +48,7 @@ WKS_FULL_PATH = "${WORKDIR}/mender-sdimg.wks"
 # We need to have the ext3 image generated already
 IMAGE_TYPEDEP_sdimg = "ext3"
 
-IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic}"
+IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic} dosfstools"
 
 IMAGE_CMD_sdimg() {
     mkdir -p "${WORKDIR}"


### PR DESCRIPTION
Package suggested from @kacf in order to fix building on Jenkins


```
diff --git a/classes/sdimg.bbclass b/classes/sdimg.bbclass
index 0cb42c9..6c8d530 100644
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -48,7 +48,7 @@ WKS_FULL_PATH = "${WORKDIR}/mender-sdimg.wks"
 # We need to have the ext3 image generated already
 IMAGE_TYPEDEP_sdimg = "ext3"
 
-IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic}"
+IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic} dosfstools"
 
 IMAGE_CMD_sdimg() {
     mkdir -p "${WORKDIR}"
```