### PR TITLE
Automatically add the '-s' command line argument to pytest

### DIFF
--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -19,7 +19,7 @@ test. Normally this is the "*.ext3" image inside of your build directory, in
 "tmp/deploy/images/vexpress-qemu". Then run the tests with:
 
 ```
-$ py.test -s
+$ py.test
 ```
 
 

--- a/tests/acceptance/pytest.ini
+++ b/tests/acceptance/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -s


### PR DESCRIPTION
pytest must be called with the '-s' argument or else it will not function correctly.

I've added a pytest.ini file that automatically adds the argument on execution. 