### PR TITLE
Make Ctrl-c not terminate emulator.

### DIFF
--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -19,5 +19,5 @@ QEMU_AUDIO_DRV=none \
     -net nic \
     -net user,hostfwd=tcp::8822-:22 \
     -display vnc=:23 \
-    -serial stdio \
+    -nographic \
     "$@"


### PR DESCRIPTION
It's quite annoying since it's common to press Ctrl-C inside the
emulator. The -nographic argument does some extra magic to avoid that.

Use "Ctrl-a x" instead to terminate emulator.