### PR TITLE
Add panic option to bootloader boot arguments.

### DIFF
--- a/recipes-bsp/u-boot/files/0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch
+++ b/recipes-bsp/u-boot/files/0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch
@@ -1,0 +1,25 @@
+From ba9c44739ac981b6b66f4b61992965421cd4cf71 Mon Sep 17 00:00:00 2001
+From: Marcin Pasinski <marcin.pasinski@cfengine.com>
+Date: Mon, 18 Apr 2016 14:55:13 +0200
+Subject: [PATCH] Add kernel panic option to vexpress boot arguments
+
+---
+ include/configs/vexpress_common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/vexpress_common.h b/include/configs/vexpress_common.h
+index 98f6ae9..16af4c7 100644
+--- a/include/configs/vexpress_common.h
++++ b/include/configs/vexpress_common.h
+@@ -230,7 +230,7 @@
+ 		"root=/dev/sda1 rw\0" \
+ 		"mtd=armflash:1M@0x800000(uboot),7M@0x1000000(kernel)," \
+ 			"24M@0x2000000(initrd)\0" \
+-		"flashargs=setenv bootargs root=${root} console=${console} " \
++		"flashargs=setenv bootargs root=${root} console=${console} panic=3" \
+ 			"mem=${dram} mtdparts=${mtd} mmci.fmax=190000 " \
+ 			"devtmpfs.mount=0  vmalloc=256M\0" \
+ 		"bootflash=run flashargs; " \
+-- 
+1.9.1
+

--- a/recipes-bsp/u-boot/files/uEnv.txt
+++ b/recipes-bsp/u-boot/files/uEnv.txt
@@ -15,6 +15,6 @@ loadfdt=load mmc ${mmcdev}:${boot_part} ${fdtaddr} ${boot_dir}${fdtfile}
 
 setbootpart=if test -n ${boot_part}; then echo Booting from partition ${boot_part}; else echo No active boot partition set, setting 2 as active partition; setenv boot_part 2; fi
 loadfiles=run loadkernel; run loadfdt
-mmcargs=setenv mmcroot /dev/mmcblk0p${boot_part}; setenv bootargs console=tty0 console=${console} root=${mmcroot}
+mmcargs=setenv mmcroot /dev/mmcblk0p${boot_part}; setenv bootargs console=tty0 console=${console} root=${mmcroot} panic=3
 uenvcmd=run setbootpart; run loadfiles; run mmcargs; bootz ${loadaddr} - ${fdtaddr}
 

--- a/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/recipes-bsp/u-boot/u-boot-mender.inc
@@ -1,9 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append_beaglebone = " file://0001-beaglebone-mender-specific-configuration.patch \
-                             file://uEnv.txt"
+                              file://uEnv.txt"
 
-SRC_URI_append_vexpress-qemu = " file://0001-Enable-boot-code-specifically-for-the-U-Boot-QEMU-sc.patch"
+SRC_URI_append_vexpress-qemu = " file://0001-Enable-boot-code-specifically-for-the-U-Boot-QEMU-sc.patch \
+                                 file://0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch"
 
 SRC_URI_append = " file://0002-Add-missing-header-which-fails-on-recent-GCC.patch"
 


### PR DESCRIPTION
Having panic option set as a part of boot arguments we will be able
to restart boot process once booting kernel will hang.