### PR TITLE
Prevent multiple ${IMAGE_BOOT_FILES} entries from breaking the build.

### DIFF
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -82,7 +82,10 @@ IMAGE_CMD_sdimg() {
     fi
 
     # Copy boot files to boot partition
-    mcopy -i "${WORKDIR}/fat.dat" -s ${DEPLOY_DIR_IMAGE}/${IMAGE_BOOT_FILES} ::
+    for file in ${IMAGE_BOOT_FILES}
+    do
+        mcopy -i "${WORKDIR}/fat.dat" -s ${DEPLOY_DIR_IMAGE}/$file ::
+    done
 
     rm -rf "${WORKDIR}/data" || true
     if [ -n "${SDIMG_DATA_PART_DIR}" ]; then


### PR DESCRIPTION
Since we prepend the path we need to do it one by one.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>