### PR TITLE
MEN-307: BBB: Don't fall back on internal flash if boot fails.

### DIFF
--- a/recipes-bsp/u-boot/files/0001-beaglebone-mender-specific-configuration.patch
+++ b/recipes-bsp/u-boot/files/0001-beaglebone-mender-specific-configuration.patch
@@ -63,7 +63,7 @@ index 3cf768e..540a82a 100644
  	"mmcloados=run args_mmc; " \
  		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
  			"if run loadfdt; then " \
-@@ -120,56 +137,43 @@
+@@ -120,56 +137,40 @@
  		"else " \
  			"bootz; " \
  		"fi;\0" \
@@ -143,10 +143,7 @@ index 3cf768e..540a82a 100644
 +       "i2c mw 0x24 1 0x3e;" \
 +       "setenv fdtfile am335x-boneblack.dtb; setenv fdtbase am335x-boneblack;" \
 +       "run mmcboot;" \
-+       "setenv mmcdev 1; " \
-+       "setenv bootpart 1:1; " \
-+       "run mmcboot;" \
-+       "run nandboot;"
++       "reset;"
 +
  
  /* NS16550 Configuration */


### PR DESCRIPTION
Instead reset and retry from the memory card. Otherwise we do not fall
back to the previous partition, which is both important for testing,
and it is what Mender is supposed to do.

This removes the safety net of falling back to the internal flash
altogether, but I think this is a separate concern that we can tackle
later, perhaps when we have a bit more clarity on what Mender should
do in such a situation.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>