### PR TITLE
Fix core-image-full-cmdline.env error when building fresh Mender image.

### DIFF
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -41,7 +41,10 @@ IMAGE_UENV_TXT_FILE ?= "uEnv.txt"
 
 ########## CONFIGURATION END ##########
 
+inherit image
 inherit image_types
+
+addtask do_rootfs_wicenv before do_image_sdimg
 
 WKS_FULL_PATH = "${WORKDIR}/mender-sdimg.wks"
 


### PR DESCRIPTION
This fixes an error of the type:

```
Couldn't get bitbake variable from .../poky/build/tmp/sysroots/vexpress-qemu/imgdata/core-image-full-cmdline.env.
File .../poky/build/tmp/sysroots/vexpress-qemu/imgdata/core-image-full-cmdline.env doesn't exist.
Traceback (most recent call last):
  File ".../poky/scripts/wic", line 321, in <module>
    sys.exit(main(sys.argv[1:]))
  File ".../poky/scripts/wic", line 316, in main
    return hlp.invoke_subcommand(args, parser, hlp.wic_help_usage, subcommands)
  File ".../poky/scripts/lib/wic/help.py", line 95, in invoke_subcommand
    subcommands.get(args[0], subcommand_error)[0](args[1:], usage)
  File ".../poky/scripts/wic", line 222, in wic_create_subcommand
    if not os.path.isdir(rootfs_dir):
  File ".../poky/build/tmp/sysroots/x86_64-linux/usr/lib/python2.7/genericpath.py", line 49, in isdir
    st = os.stat(s)
TypeError: coercing to Unicode: need string or buffer, NoneType found
WARNING: exit code 1 from a shell command.
ERROR: Function failed: do_image_sdimg (log file is located at .../poky/build/tmp/work/vexpress_qemu-poky-linux-gnueabi/core-image-full-cmdline/1.0-r0/temp/log.do_image_sdimg.22296)
```

It is not clear when this error was introduced in poky, but at some
point this file stopped being generated automatically. What we need to
do is the same thing that the regular image generation does: Call
do_rootfs_wicenv in order to populate the file before we get to the
image creation, which calls wic, which needs the file.

This file hardly changes after it has been generated, which means that
the error only happens if you've never built an image before, and you
start by building a Mender image. If you've either built a non-Mender
image or an Mender image from a previous working build, you won't see
the error, because the file will already be there.