### PR TITLE
cleanup  & device identity work

### DIFF
--- a/recipes-mender/mender/files/mender.conf
+++ b/recipes-mender/mender/files/mender.conf
@@ -1,7 +1,7 @@
 {
   "pollIntervalSeconds": 60,
-  "ServerURL": MENDER_SERVER,
-  "DeviceID": DEVICE_ID,
+  "ServerURL": "MENDER_SERVER",
+  "DeviceID": "DEVICE_ID",
   "ServerCertificate": "",
   "ClientProtocol": "http",
   "HttpsClient": {

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -41,7 +41,6 @@ do_install() {
   install -m 0644 ${WORKDIR}/mender.service ${D}/${systemd_unitdir}/system
 
   #install configuration
-  install -d ${D}/${sysconfdir}
   install -d ${D}/${sysconfdir}/mender
   install -m 0644 ${WORKDIR}/mender.conf ${D}/${sysconfdir}/mender
 }

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -30,13 +30,13 @@ do_compile() {
   PATH="${B}/bin:$PATH"
   export PATH
 
-  cd "${S}"
-  godep go build -o "${B}/mender"
+  cd ${S}
+  godep go build -o ${B}/mender
 }
 
 do_install() {
-  install -d "${D}/${bindir}"
-  install -m 0755 "${B}/mender" "${D}/${bindir}"
+  install -d ${D}/${bindir}
+  install -m 0755 ${B}/mender ${D}/${bindir}
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/mender.service ${D}/${systemd_unitdir}/system
 

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -36,7 +36,9 @@ do_compile() {
 
 do_install() {
   install -d ${D}/${bindir}
-  install -m 0755 ${B}/mender ${D}/${bindir}
+  install -t ${D}/${bindir} -m 0755 \
+          ${B}/mender ${S}/support/mender-device-identity
+
   install -d ${D}/${systemd_unitdir}/system
   install -m 0644 ${WORKDIR}/mender.service ${D}/${systemd_unitdir}/system
 


### PR DESCRIPTION
A short series of patches for mender recipe.

The first 3 patches introduce cleanups (removing unnecessary quotations, slashes etc.).

The 4th patch ships `mender-device-identity` in mender package.

The last patch introduces a fix to `mender.conf` so that the default config is at least a valid JSON.

@kacf @GregorioDiStefano @pasinskim 