### PR TITLE
Sdimg cleanup

### DIFF
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -21,7 +21,7 @@
 SDIMG_DATA_PART_DIR ?= ""
 
 # Size of the first (FAT) partition, that contains the bootloader
-SDIMG_PART1_SIZE_MB ?= "128"
+SDIMG_BOOT_PART_SIZE_MB ?= "128"
 
 # For performance reasons, we try to align the partitions to the SD
 # card's erase block. It is impossible to know this information with
@@ -68,7 +68,7 @@ IMAGE_CMD_sdimg() {
     ln -sfn "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.ext3" \
         "${WORKDIR}/part2.tmp"
 
-    PART1_SIZE=$(expr ${SDIMG_PART1_SIZE_MB} \* 2048)
+    PART1_SIZE=$(expr ${SDIMG_BOOT_PART_SIZE_MB} \* 2048)
     SDIMG_PARTITION_ALIGNMENT_KB=$(expr ${SDIMG_PARTITION_ALIGNMENT_MB} \* 1024)
 
     dd if=/dev/zero of="${WORKDIR}/fat.dat" count=${PART1_SIZE}


### PR DESCRIPTION
```
commit 9571036460bd10e054b6b2c3a1ad92d26c6f37b4
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Thu May 26 10:28:48 2016

    Add SDIMG_DATA_PART_SIZE_MB variable.
    
    This requires changing how we construct the data partition, since the
    --size parameter for the partition doesn't do what you'd expect:
    Instead of using it as the size of the partition, it adds it to the
    size of the partition. We are pretty used to constructing our own
    file systems now, so do that instead.
    
    Also change the names of temporary file system files to be more
    consistent.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 4d4b7cbdab99e22d5d8b74d216a54e8de4f50fd8
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Thu May 26 09:56:02 2016

    Rename SDIMG_PART1_SIZE_MB to SDIMG_BOOT_PART_SIZE_MB.
    
    Partition 1 is an implementation detail, the important thing is that
    it is the boot partition.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```