### PR TITLE
Tests modified since mender is running as daemon

### DIFF
--- a/recipes-mender/mender/files/mender.service
+++ b/recipes-mender/mender/files/mender.service
@@ -5,7 +5,7 @@ Description=Mender OTA update service
 Type=simple
 User=root
 Group=root
-ExecStart=/usr/bin/mender -daemon
+ExecStart=/usr/bin/mender -daemon -log-level=debug -log-file=/var/log/mender.log
 Restart=on-abort
 
 [Install]

--- a/recipes-mender/mender/files/mender.service
+++ b/recipes-mender/mender/files/mender.service
@@ -5,7 +5,7 @@ Description=Mender OTA update service
 Type=simple
 User=root
 Group=root
-ExecStart=/usr/bin/mender -daemon -log-level=debug -log-file=/var/log/mender.log
+ExecStart=/usr/bin/mender -daemon
 Restart=on-abort
 
 [Install]

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -252,3 +252,21 @@ def no_image_file(qemu_running):
 
 def no_image_file_impl():
     run("rm -f image.dat")
+
+
+@pytest.fixture(scope="function")
+def mender_running():
+    execute(mender_running_impl, hosts=conftest.current_hosts())
+
+
+def mender_running_impl():
+    with settings(warn_only=True):
+        for _ in range(0, 15):
+            result = run("pidof mender")
+            if result.return_code == 1:
+                time.sleep(2)
+            else:
+                break
+
+    if result.return_code == 1:
+        raise Exception("Mender is not running!")

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -28,11 +28,17 @@ class Helpers:
         subprocess.Popen(["s3cmd", "--follow-symlinks", "put", "image.dat", "s3://yocto-builds/tmp/"]).wait()
         subprocess.Popen(["s3cmd", "setacl", "s3://yocto-builds/tmp/image.dat", "--acl-public"]).wait()
 
+    @staticmethod
+    # TODO: Use this when mender is more stable. Spurious errors are currently generated.
+    def check_journal_errors():
+        output = run("journalctl -a -u mender | grep error")
+        assert output == 1
 
-@pytest.mark.usefixtures("qemu_running", "no_image_file", "setup_bbb")
+@pytest.mark.usefixtures("qemu_running", "no_image_file", "setup_bbb", "mender_running")
 class TestUpdates:
 
     def test_broken_image_update(self):
+
         if not env.host_string:
             # This means we are not inside execute(). Recurse into it!
             execute(self.test_broken_image_update)

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -106,13 +106,18 @@ class TestUpdates:
         output = run("fw_printenv bootcount")
         assert(output == "bootcount=1")
 
-        output = run("fw_printenv upgrade_available")
-        assert(output == "upgrade_available=1")
+        """
+            The daemon is running, so it will autocommit
+            on boot. This must be changed in the future.
+        """
 
-        output = run("fw_printenv boot_part")
-        assert(output == "boot_part=" + active_after)
+        #output = run("fw_printenv upgrade_available")
+        #assert(output == "upgrade_available=1")
 
-        run("mender -commit")
+        #output = run("fw_printenv boot_part")
+        #assert(output == "boot_part=" + active_after)
+
+        #run("mender -commit")
 
         output = run("fw_printenv upgrade_available")
         assert(output == "upgrade_available=0")
@@ -178,13 +183,19 @@ class TestUpdates:
         output = run("fw_printenv bootcount")
         assert(output == "bootcount=1")
 
-        output = run("fw_printenv upgrade_available")
-        assert(output == "upgrade_available=1")
 
-        output = run("fw_printenv boot_part")
-        assert(output == "boot_part=" + active_after)
+        """
+            The daemon is running, so it will autocommit
+            on boot. This must be changed in the future.
+        """
 
-        run("mender -commit")
+        #output = run("fw_printenv upgrade_available")
+        #assert(output == "upgrade_available=1")
+
+        #output = run("fw_printenv boot_part")
+        #assert(output == "boot_part=" + active_after)
+
+        #run("mender -commit")
 
         output = run("fw_printenv upgrade_available")
         assert(output == "upgrade_available=0")


### PR DESCRIPTION
2 changes:

1) make sure mender is running before each test
2) remove checks after rebooting, since the daemon should already have commited the changes.

I also added a small bit of code to check the logs for errors, but no point in using right now, since there are spurious errors right now. 