### PR TITLE
mender: workaround go install

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -58,9 +58,14 @@ do_compile() {
 do_install() {
   install -d ${D}/${bindir}
 
-  # mender is picked up from our fake GOPATH=${B}
+  GOOS=$(eval $(go env) && echo $GOOS)
+  GOARCH=$(eval $(go env) && echo $GOARCH)
+  # mender is picked up from our fake GOPATH=${B}/bin; because go build is so
+  # consistent, if it's a cross compilation build, binaries will be in
+  # ${GOPATH}/bin/${GOOS}_${GOARCH}, howver if it's not, the binaries are in
+  # ${GOPATH}/bin; handle cross compiled case only
   install -t ${D}/${bindir} -m 0755 \
-          ${B}/bin/mender \
+          ${B}/bin/${GOOS}_${GOARCH}/mender \
           ${S}/support/mender-device-identity
 
   install -d ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
Workaround go install inconsistency when installing host or cross
compiled binaries. Runnin go install, the built packages end up only in
${GOPATH}/bin or ${GOPATH}/bin/${GOOS}_${GOARCH}, the latter case being
true only for cross-compiled (from go's perspective) builds.

Guessing if we're go is cross-compiling is too much overhead, assume
that we're always cross-compiling. This works for the general case, but
will break if target is the same arch as host.