### PR TITLE
Change the name of boot partition to /uboot.

### DIFF
--- a/classes/sdimg.bbclass
+++ b/classes/sdimg.bbclass
@@ -107,7 +107,7 @@ IMAGE_CMD_sdimg() {
     mkfs.ext3 -F "${WORKDIR}/data.ext3" -d "${WORKDIR}/data"
 
     cat > "${WORKDIR}/mender-sdimg.wks" <<EOF
-part /u-boot --source fsimage --sourceparams=file="${WORKDIR}/boot.vfat"     --ondisk mmcblk0 --fstype=vfat --label boot     --align $SDIMG_PARTITION_ALIGNMENT_KB --active
+part /uboot  --source fsimage --sourceparams=file="${WORKDIR}/boot.vfat"     --ondisk mmcblk0 --fstype=vfat --label boot     --align $SDIMG_PARTITION_ALIGNMENT_KB --active
 part /       --source fsimage --sourceparams=file="${WORKDIR}/active.ext3"   --ondisk mmcblk0 --fstype=ext3 --label platform --align $SDIMG_PARTITION_ALIGNMENT_KB
 part /       --source fsimage --sourceparams=file="${WORKDIR}/inactive.ext3" --ondisk mmcblk0 --fstype=ext3 --label platform --align $SDIMG_PARTITION_ALIGNMENT_KB
 part /data   --source fsimage --sourceparams=file="${WORKDIR}/data.ext3"     --ondisk mmcblk0 --fstype=ext3 --label data     --align $SDIMG_PARTITION_ALIGNMENT_KB

--- a/recipes-bsp/u-boot/u-boot-fw-utils_2015.10.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_2015.10.bbappend
@@ -9,7 +9,7 @@ BOOTENV_SIZE_vexpress-qemu = "0x40000"
 # Configure fw_printenv so that it looks in the right place for the environment.
 do_configure_fw_printenv () {
     cat > ${D}${sysconfdir}/fw_env.config <<EOF
-/u-boot/uboot.env 0x0000 ${BOOTENV_SIZE}
+/uboot/uboot.env 0x0000 ${BOOTENV_SIZE}
 EOF
 }
 addtask do_configure_fw_printenv before do_package after do_install

--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -5,5 +5,5 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # Where the U-Boot environment resides; for devices with SD card support ONLY!
-/dev/mmcblk0p1       /u-boot              auto       defaults,sync,auto    0  0
+/dev/mmcblk0p1       /uboot               auto       defaults,sync,auto    0  0
 /dev/mmcblk0p5       /data                auto       defaults,auto         0  0

--- a/recipes-core/base-files/base-files_3.%.bbappend
+++ b/recipes-core/base-files/base-files_3.%.bbappend
@@ -3,6 +3,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 #TODO: ${@bb.utils.contains("MACHINE_FEATURES", "sd", "packagegroup-mender-sd", "", d)}
 #./meta/recipes-core/packagegroups/packagegroup-base.bb
 do_install_append () {
-    install -d ${D}/u-boot
+    install -d ${D}/uboot
     install -d ${D}/data
 }


### PR DESCRIPTION
As there is some limitation in older versions of u-boot that
environment utilities (fw_printenv and fe_setenv) can read environment
location consisting of 16 characters at most.
Changing partition name from /u-boot to /uboot will cause that
'/uboot/uboot.env' string will be 16 characters long.