### PR TITLE
mender: fix local file access

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -50,7 +50,7 @@ do_compile() {
   oe_runmake V=1 install
 
   #prepare Mender configuration file
-  cp ${S}/mender.conf ${B}
+  cp ${WORKDIR}/mender.conf ${B}
   sed -i -e 's#[@]MENDER_SERVER_URL[@]#${MENDER_SERVER_URL}#' ${B}/mender.conf
   sed -i -e 's#[@]MENDER_CERT_LOCATION[@]#${MENDER_CERT_LOCATION}#' ${B}/mender.conf
 
@@ -74,12 +74,12 @@ do_install() {
           ${S}/support/mender-device-identity
 
   install -d ${D}/${systemd_unitdir}/system
-  install -m 0644 ${S}/mender.service ${D}/${systemd_unitdir}/system
+  install -m 0644 ${WORKDIR}/mender.service ${D}/${systemd_unitdir}/system
 
   #install configuration
   install -d ${D}/${sysconfdir}/mender
   install -m 0644 ${B}/mender.conf ${D}/${sysconfdir}/mender
 
   #install server certificate
-  install -m 0444 ${S}/server.crt ${D}/${sysconfdir}/mender
+  install -m 0444 ${WORKDIR}/server.crt ${D}/${sysconfdir}/mender
 }


### PR DESCRIPTION
Fix access to mender.conf & mender.service local files. The files are
fetched to ${WORKDIR} not ${S}.

Addresses the root cause of #60 