### PR TITLE
Fix incorrect error for systemd when compiling vexpress-qemu.

### DIFF
--- a/classes/mender-systemd.bbclass
+++ b/classes/mender-systemd.bbclass
@@ -16,6 +16,6 @@ VIRTUAL-RUNTIME_initscripts_vexpress-qemu = ""
 # kernel feature CONFIG_FHANDLE is not enabled.
 
 python() {
-    if not bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d):
+    if d.getVar('MACHINE', False) != 'vexpress-qemu' and not bb.utils.contains('DISTRO_FEATURES', 'systemd', True, False, d):
         raise Exception("systemd is required in DISTRO_FEATURES when using mender-full or mender-systemd classes. See mender-systemd.bbclass for an example of how to enable.")
 }


### PR DESCRIPTION
It is actually enabled for vexpress-qemu by default, but because of
the way bitbake variables are resolved, it comes too late for the test
to pick it up, so skip the check in that case.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>