### PR TITLE
Dockerize meta-mender Yocto image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:trusty
+
+RUN apt-get -y update
+RUN apt-get -y upgrade
+
+#Use: --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf when building
+ARG VEXPRESS_IMAGE
+ARG UBOOT_ELF
+
+# Install QEMU/KVM
+RUN apt-get -y install qemu-kvm qemu-system-arm
+
+ADD $UBOOT_ELF ./
+ADD $VEXPRESS_IMAGE ./
+
+ADD scripts/mender-qemu ./
+ADD scripts/docker/entrypoint.sh ./
+
+RUN chmod +x entrypoint.sh mender-qemu
+EXPOSE 8822
+ENTRYPOINT ["./entrypoint.sh"]

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_SDIMG="core-image-full-cmdline-vexpress-qemu.sdimg" UBOOT_ELF="u-boot.elf" ./mender-qemu

--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -6,7 +6,7 @@
 #
 # if image name is not provided, the script will attempt to run
 # core-image-full-cmdline
-
+#
 
 # NOTE: current settings forward
 #           ssh: port 8822
@@ -37,12 +37,16 @@ else
     BUILDTMP=${BUILDDIR}/tmp-glibc
 fi
 
+UBOOT_ELF=${UBOOT_ELF:-"${BUILDTMP}/deploy/images/vexpress-qemu/u-boot.elf"}
+VEXPRESS_SDIMG=${VEXPRESS_SDIMG:-"${BUILDTMP}/deploy/images/vexpress-qemu/${IMAGE_NAME}-vexpress-qemu.sdimg"}
+QEMU_SYSTEM_ARM=${QEMU_SYSTEM_ARM:-"${BUILDTMP}/sysroots/x86_64-linux/usr/bin/qemu-system-arm"}
+
 QEMU_AUDIO_DRV=none \
-    ${BUILDTMP}/sysroots/x86_64-linux/usr/bin/qemu-system-arm \
+    $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
     -m 1G \
-    -kernel ${BUILDTMP}/deploy/images/vexpress-qemu/u-boot.elf \
-    -drive file=${BUILDTMP}/deploy/images/vexpress-qemu/${IMAGE_NAME}-vexpress-qemu.sdimg,if=sd,format=raw \
+    -kernel "$UBOOT_ELF" \
+    -drive file="$VEXPRESS_SDIMG",if=sd,format=raw \
     -net nic \
     -net user,hostfwd=tcp::8822-:22 \
     -display vnc=:23 \


### PR DESCRIPTION
This allows us to run the mender qemu environment inside of Docker.

As soon as I get a hold of the docker hub credentials, I will integrate this with the build machine, and push the latest container to docker hub.
 
I've added this since it would facilitate running the latest mender qemu image, and we will need this for integration testing. 

I also changed mender-qemu with some default parameters, and use qemu-system-arm from PATH.