### PR TITLE
Reverse priority of tmp and tmp-glibc path in qemu launcher script.

### DIFF
--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -31,10 +31,10 @@ else
     IMAGE_NAME=core-image-full-cmdline
 fi
 
-if [ -d ${BUILDDIR}/tmp-glibc ]; then
-    BUILDTMP=${BUILDDIR}/tmp-glibc
-else
+if [ -d ${BUILDDIR}/tmp ]; then
     BUILDTMP=${BUILDDIR}/tmp
+else
+    BUILDTMP=${BUILDDIR}/tmp-glibc
 fi
 
 QEMU_AUDIO_DRV=none \


### PR DESCRIPTION
It is unknown why there are sometimes two paths, but tmp/ appears to
be the one with qemu in it.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>