### PR TITLE
Remove Go workaround that has been fixed upstream.

### DIFF
--- a/recipes-devtools/go/go-cross_%.bbappend
+++ b/recipes-devtools/go/go-cross_%.bbappend
@@ -1,16 +1,2 @@
-do_install() {
-  install -d "${D}${bindir}" "${D}${GOROOT_FINAL}"
-  tar -C "${WORKDIR}/go-${PV}/go" -cf - bin lib src pkg test |
-  tar -C "${D}${GOROOT_FINAL}" -xf -
-  mv "${D}${GOROOT_FINAL}/bin/"* "${D}${bindir}/"
-
-  for t in gcc g++ ; do
-    cat > ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t} <<EOT
-#!/bin/sh
-exec ${TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
-EOT
-    chmod +x ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t}
-  done
-}
-
+# Go binaries are not understood by the strip tool.
 INHIBIT_SYSROOT_STRIP = "1"

--- a/recipes-devtools/go/go-native_%.bbappend
+++ b/recipes-devtools/go/go-native_%.bbappend
@@ -1,16 +1,2 @@
-do_install() {
-  install -d "${D}${bindir}" "${D}${GOROOT_FINAL}"
-  tar -C "${WORKDIR}/go-${PV}/go" -cf - bin lib src pkg test |
-  tar -C "${D}${GOROOT_FINAL}" -xf -
-  mv "${D}${GOROOT_FINAL}/bin/"* "${D}${bindir}/"
-
-  for t in gcc g++ ; do
-    cat > ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t} <<EOT
-#!/bin/sh
-exec ${TARGET_PREFIX}${t} ${TARGET_CC_ARCH} --sysroot=${STAGING_DIR_TARGET} "\$@"
-EOT
-    chmod +x ${D}${GOROOT_FINAL}/bin/${TARGET_PREFIX}${t}
-  done
-}
-
+# Go binaries are not understood by the strip tool.
 INHIBIT_SYSROOT_STRIP = "1"


### PR DESCRIPTION
See 5b5171e81439269f6a1ad59f82d32d6b1a23335d in oe-meta-go.

The remaining part should also be fixed upstream soon, at which point
both of these files can be removed.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>