### PR TITLE
Dockerfile: reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM ubuntu:trusty
 
-RUN apt-get -y update
-RUN apt-get -y upgrade
+# Install QEMU/KVM
+RUN apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get -y install qemu-kvm qemu-system-arm && \
+    rm -rf /var/lib/apt/lists/*
 
 #Use: --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf when building
 ARG VEXPRESS_IMAGE
 ARG UBOOT_ELF
-
-# Install QEMU/KVM
-RUN apt-get -y install qemu-kvm qemu-system-arm
 
 ADD $UBOOT_ELF ./
 ADD $VEXPRESS_IMAGE ./


### PR DESCRIPTION
The current images are large ~700MB, this should reduce the size of
intermediate snapshots thus trimming the image to something like ~220MB.

@GregorioDiStefano can you try that in your environment?
