### PR TITLE
Unquoted variable leads to parsing error

### DIFF
--- a/classes/mender-sdimg.bbclass
+++ b/classes/mender-sdimg.bbclass
@@ -86,7 +86,7 @@ IMAGE_CMD_sdimg() {
     mkfs.vfat "${WORKDIR}/boot.vfat"
 
     # Copy boot files to boot partition
-    for file in ${IMAGE_BOOT_FILES}
+    for file in "${IMAGE_BOOT_FILES}"
     do
         mcopy -i "${WORKDIR}/boot.vfat" -s ${DEPLOY_DIR_IMAGE}/$file ::
     done


### PR DESCRIPTION
I've been trying to build mender for my raspberry pi 3, and got the following error: 

```
  LexToken(NEWLINE,'\n',0,0)
  LexToken(Do,'do',0,0)
  LexToken(NEWLINE,'\n',0,0)
  LexToken(TOKEN,'mcopy',0,0)
  LexToken(TOKEN,'-i',0,0)
```

After quoting the ${IMAGE_BOOT_FILES}, it seems to have fixed the issue..I guess I am getting this error because the variable is not set. 