### PR TITLE
sysvinit support & systemd no auto enable

### DIFF
--- a/recipes-mender/mender/files/sysvinit-mender
+++ b/recipes-mender/mender/files/sysvinit-mender
@@ -1,0 +1,34 @@
+### BEGIN INIT INFO
+# Provides:             mender
+# Required-Start:       $time
+# Required-Stop:        $time
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    Mender OTA Client
+### END INIT INFO
+
+set -e
+
+case "$1" in
+  start)
+        echo -n "Starting Mender OTA Client: "
+        start-stop-daemon -S -b -n mender -a /usr/bin/mender -- -daemon
+        echo "done"
+        ;;
+  stop)
+        echo -n "Stopping Mender OTA Client: "
+        start-stop-daemon -K -n mender
+        echo "done"
+        ;;
+  restart)
+        $0 stop
+        $0 start
+        ;;
+  *)
+        echo "Usage: mender { start | stop | restart }" >&2
+        exit 1
+        ;;
+esac
+
+exit 0
+

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -7,6 +7,7 @@ MENDER_CERT_LOCATION ?= ""
 #From oe-meta-go (https://github.com/mem/oe-meta-go)
 DEPENDS = "go-cross godep"
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
 
 inherit go
 


### PR DESCRIPTION
The series starts witha small cleanup of how we handle B. Right now we just use the default `B=${S}`, but that's a bit inconvenient due to fake $GOPATH we need to create for the build, thus polluting `${S}`.

The second patch will prevent mender service being automatically enabled in systemd setups.

The last patch adds a sysvinit startup script and required recipe support. Similarly to systemd variant, the service is disabled by default.

@pasinskim @kacf @eysteins @GregorioDiStefano 