### PR TITLE
mender: set build dir

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -7,6 +7,7 @@ MENDER_CERT_LOCATION ?= ""
 #From oe-meta-go (https://github.com/mem/oe-meta-go)
 DEPENDS = "go-cross godep"
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
 
 inherit go
 


### PR DESCRIPTION
Poky bitbake setup defaults to B=S what is inconvenient in case of
mender as we need to create a mock GOPATH structure for the sake of
build. Make sure to set B to something remotely reasonable.
