### PR TITLE
Don't reference WORKSPACE which doesn't exist in local builds.

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -35,7 +35,7 @@ def pytest_addoption(parser):
     parser.addoption("--bbb", action="store_true", default=False,
                      help="the tests are running against a BeagleBone Black")
     parser.addoption("--sdimg-location", action="store",
-                     default=os.path.join(os.environ["WORKSPACE"], "meta-mender/tests/acceptance"),
+                     default=os.getcwd(),
                      help="location to the sdimg you want to install on the bbb")
 
 


### PR DESCRIPTION
We assume that the tests are always executed from the test directory
anyway.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>