### PR TITLE
Removing deprecated DeviceID key

### DIFF
--- a/recipes-mender/mender/files/mender.conf
+++ b/recipes-mender/mender/files/mender.conf
@@ -1,6 +1,5 @@
 {
   "ClientProtocol": "http",
-  "DeviceID": "3a11a5bf-521f-4889-832b-a9d5e2e79f5a",
   "HttpsClient": {
     "Certificate": "",
     "Key": ""


### PR DESCRIPTION
@bboozzoo I see DeviceID is no longer referenced in the client, I think this was lingering artifact 