### PR TITLE
mender: provide sane default for MENDER_CERT_LOCATION

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Mender tool for doing OTA software updates."
 HOMEPAGE = "https://mender.io/"
 
 MENDER_SERVER_URL ?= "https://mender.io"
-MENDER_CERT_LOCATION ?= ""
+MENDER_CERT_LOCATION ?= "${sysconfdir}/mender/server.crt"
 
 #From oe-meta-go (https://github.com/mem/oe-meta-go)
 DEPENDS = "go-cross godep"


### PR DESCRIPTION
Right now MENER_CERT_LOCATION is empty, so the client will not try to use the trusted certificate when talking to the backend.