### PR TITLE
build with poky master

### DIFF
--- a/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -3,12 +3,3 @@
 require u-boot-mender.inc
 
 DEPENDS = "u-boot"
-
-# Configure fw_printenv so that it looks in the right place for the environment.
-do_configure_fw_printenv () {
-    cat > ${D}${sysconfdir}/fw_env.config <<EOF
-/uboot/uboot.env 0x0000 ${BOOTENV_SIZE}
-EOF
-}
-addtask do_configure_fw_printenv before do_package after do_install
-

--- a/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -3,3 +3,14 @@
 require u-boot-mender.inc
 
 DEPENDS = "u-boot"
+
+do_compile_append() {
+    # create fw_env.config file
+    cat > ${WORKDIR}/fw_env.config <<EOF
+/uboot/uboot.env 0x0000 ${BOOTENV_SIZE}
+EOF
+}
+
+do_install_append() {
+    install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
+}

--- a/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/recipes-bsp/u-boot/u-boot-mender.inc
@@ -65,13 +65,6 @@ EOF
 }
 addtask do_provide_mender_defines after do_patch before do_configure
 
-do_compile_append() {
-    # create fw_env.config file
-    cat > ${WORKDIR}/fw_env.config <<EOF
-/uboot/uboot.env 0x0000 ${BOOTENV_SIZE}
-EOF
-}
-
 do_deploy_prepend() {
     # Create empty environment. Just so that the file is available.
     mkdir -p ${DEPLOYDIR}


### PR DESCRIPTION
Fixes build with poky master, builds on top of #87. `fw_env.config` will be generated and shipped by `u-boot-fw-utils` only.

@kacf @GregorioDiStefano @pasinskim 