### PR TITLE
docker/entrypoint: allow for taking command line parameters

### DIFF
--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_SDIMG="core-image-full-cmdline-vexpress-qemu.sdimg" UBOOT_ELF="u-boot.elf" ./mender-qemu
+QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_SDIMG="core-image-full-cmdline-vexpress-qemu.sdimg" UBOOT_ELF="u-boot.elf" ./mender-qemu $*


### PR DESCRIPTION
Since mender-qemu allows for passing parameters to the underlying qemu
process, enable passing command line parameters directly to entrypoint
wrapper.

So it's possible to run like this (to enable a snapshot of sd card image in qemu):
```
docker run mender-client -snapshot
```

@GregorioDiStefano @kacf @pasinskim 
