### PR TITLE
Don't make mender run as a service by default

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -5,6 +5,7 @@ MENDER_SERVER_URL ?= "https://mender-api-gateway"
 MENDER_CERT_LOCATION ?= "${sysconfdir}/mender/server.crt"
 # Tenant token
 MENDER_TENANT_TOKEN ?= "dummy"
+SYSTEMD_AUTO_ENABLE ?= "disable"
 
 #From oe-meta-go (https://github.com/mem/oe-meta-go)
 DEPENDS = "go-cross godep"


### PR DESCRIPTION
Currently we have 1 Jenkins job taking care of 2 different Yocto builds, and for performing testing.

1) We test without the mender service
2) We publish a standalone client
3) We integrate new qemu builds into the docker integration framework, where mender runs as a service

By disabling the mender service by running by default, 1&2 work out of the box, and 3) simply requires adidng the mender.service file to the right places.

Currently, with the mender service enabled, its more work.

@kacf 