### PR TITLE
Random QEMU mac address, and lower memory allocation

### DIFF
--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -40,6 +40,7 @@ fi
 UBOOT_ELF=${UBOOT_ELF:-"${BUILDTMP}/deploy/images/vexpress-qemu/u-boot.elf"}
 VEXPRESS_SDIMG=${VEXPRESS_SDIMG:-"${BUILDTMP}/deploy/images/vexpress-qemu/${IMAGE_NAME}-vexpress-qemu.sdimg"}
 QEMU_SYSTEM_ARM=${QEMU_SYSTEM_ARM:-"${BUILDTMP}/sysroots/x86_64-linux/usr/bin/qemu-system-arm"}
+RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
 
 QEMU_AUDIO_DRV=none \
     $QEMU_SYSTEM_ARM \
@@ -47,7 +48,7 @@ QEMU_AUDIO_DRV=none \
     -m 1G \
     -kernel "$UBOOT_ELF" \
     -drive file="$VEXPRESS_SDIMG",if=sd,format=raw \
-    -net nic \
+    -net nic,macaddr="$RANDOM_MAC" \
     -net user,hostfwd=tcp::8822-:22 \
     -display vnc=:23 \
     -nographic \

--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -45,7 +45,7 @@ RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
 QEMU_AUDIO_DRV=none \
     $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
-    -m 1G \
+    -m 512M \
     -kernel "$UBOOT_ELF" \
     -drive file="$VEXPRESS_SDIMG",if=sd,format=raw \
     -net nic,macaddr="$RANDOM_MAC" \


### PR DESCRIPTION
- Random mac address, so we get a random client ID, allowing us to deploy many QEMU clients in docker

- Lower memory from 1G => 512M
