### PR TITLE
Make sure Mender runs after network-online target is met

### DIFF
--- a/recipes-mender/mender/files/mender.service
+++ b/recipes-mender/mender/files/mender.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Mender OTA update service
+After=network-online.target network.target
+Requires=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
a HTTP call right after starting mender will fail, because the network stack is not completely up and functional.

note: if we would move to sysv, we'd have to adjust that script as well, maybe it's smarter to fix this in the client?