### PR TITLE
Split generic U-Boot patch into payload and integration pieces.

### DIFF
--- a/recipes-bsp/u-boot/files/0001-Generic-boot-code-for-Mender.patch
+++ b/recipes-bsp/u-boot/files/0001-Generic-boot-code-for-Mender.patch
@@ -1,15 +1,13 @@
-From b701b72baa0ba88561e101cca9efe8772207c354 Mon Sep 17 00:00:00 2001
+From a0574f2255d6311c983e5b6e2a46533d6d51f73e Mon Sep 17 00:00:00 2001
 From: Kristian Amlie <kristian.amlie@mender.io>
-Date: Fri, 12 Aug 2016 10:15:11 +0200
-Subject: [PATCH] Generic boot code for Mender.
+Date: Mon, 22 Aug 2016 10:47:08 +0200
+Subject: [PATCH 1/2] Generic boot code for Mender.
 
 Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
 ---
- include/config_mender.h   | 69 +++++++++++++++++++++++++++++++++++++++++++++++
- include/env_default.h     |  3 +++
- include/env_mender.h      | 64 +++++++++++++++++++++++++++++++++++++++++++
- scripts/Makefile.autoconf |  3 ++-
- 4 files changed, 138 insertions(+), 1 deletion(-)
+ include/config_mender.h | 69 +++++++++++++++++++++++++++++++++++++++++++++++++
+ include/env_mender.h    | 64 +++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 133 insertions(+)
  create mode 100644 include/config_mender.h
  create mode 100644 include/env_mender.h
 
@@ -88,27 +86,6 @@ index 0000000..3c1ecd6
 +#define CONFIG_FAT_WRITE
 +
 +#endif /* CONFIG_MENDER_H */
-diff --git a/include/env_default.h b/include/env_default.h
-index 3096576..fcb1086 100644
---- a/include/env_default.h
-+++ b/include/env_default.h
-@@ -10,6 +10,8 @@
- 
- #include <env_callback.h>
- 
-+#include <env_mender.h>
-+
- #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
- env_t environment __PPCENV__ = {
- 	ENV_CRC,	/* CRC Sum */
-@@ -22,6 +24,7 @@ static char default_environment[] = {
- #else
- const uchar default_environment[] = {
- #endif
-+	CONFIG_MENDER_ENV_SETTINGS
- #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
- 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
- #endif
 diff --git a/include/env_mender.h b/include/env_mender.h
 new file mode 100644
 index 0000000..d13d0b1
@@ -179,20 +156,6 @@ index 0000000..d13d0b1
 +    "fi\0"
 +
 +#endif /* ENV_MENDER_H */
-diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
-index 01a739d..4c4067d 100644
---- a/scripts/Makefile.autoconf
-+++ b/scripts/Makefile.autoconf
-@@ -98,7 +98,8 @@ define filechk_config_h
- 	echo \#include \<config_uncmd_spl.h\>;				\
- 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
- 	echo \#include \<asm/config.h\>;				\
--	echo \#include \<config_fallbacks.h\>;)
-+	echo \#include \<config_fallbacks.h\>;				\
-+	echo \#include \<config_mender.h\>;)
- endef
- 
- include/config.h: scripts/Makefile.autoconf create_symlink FORCE
 -- 
 2.7.4
 

--- a/recipes-bsp/u-boot/files/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/recipes-bsp/u-boot/files/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -1,0 +1,49 @@
+From ab8283372f8fbe7339b393d39d29c62b31fe9829 Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@mender.io>
+Date: Mon, 22 Aug 2016 10:47:51 +0200
+Subject: [PATCH 2/2] Integration of Mender boot code into U-Boot.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+---
+ include/env_default.h     | 3 +++
+ scripts/Makefile.autoconf | 3 ++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index 3096576..fcb1086 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -10,6 +10,8 @@
+ 
+ #include <env_callback.h>
+ 
++#include <env_mender.h>
++
+ #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
+ env_t environment __PPCENV__ = {
+ 	ENV_CRC,	/* CRC Sum */
+@@ -22,6 +24,7 @@ static char default_environment[] = {
+ #else
+ const uchar default_environment[] = {
+ #endif
++	CONFIG_MENDER_ENV_SETTINGS
+ #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
+ 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
+ #endif
+diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
+index 01a739d..4c4067d 100644
+--- a/scripts/Makefile.autoconf
++++ b/scripts/Makefile.autoconf
+@@ -98,7 +98,8 @@ define filechk_config_h
+ 	echo \#include \<config_uncmd_spl.h\>;				\
+ 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
+ 	echo \#include \<asm/config.h\>;				\
+-	echo \#include \<config_fallbacks.h\>;)
++	echo \#include \<config_fallbacks.h\>;				\
++	echo \#include \<config_mender.h\>;)
+ endef
+ 
+ include/config.h: scripts/Makefile.autoconf create_symlink FORCE
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -15,6 +15,7 @@ DEPLOYDIR = "${WORKDIR}/deploy-${PN}"
 ################################################################################
 SRC_URI_append = " file://0002-Add-missing-header-which-fails-on-recent-GCC.patch"
 SRC_URI_append = " file://0001-Generic-boot-code-for-Mender.patch"
+SRC_URI_append = " file://0002-Integration-of-Mender-boot-code-into-U-Boot.patch"
 
 ################################################################################
 # Board specific patches


### PR DESCRIPTION
The motivation behind this patch is to separate the pure Mender code,
which is a patch that will never conflict (it only contains new
files), from the integration of that code into U-Boot. Even though the
latter patch is minimal, it may conflict with some U-Boot versions,
since it has to touch some core areas.

If there ever is such a conflict during a user's integration, he may
have to produce his own patch to get around the problem, but that
means he would have to duplicate all the Mender code, which is
unnecessary and also means he won't receive updates to that code
unless he manually ports it.

With the two patches, the payload, which is the Mender code, is
separate, and thus will stay up to date even if the user has made his
own integration patch.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>