### PR TITLE
Disable inappropriate binary checks for Go binaries.

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -36,6 +36,10 @@ FILES_${PN} += "${systemd_unitdir}/system/mender.service \
                 ${sysconfdir}/mender.conf \
                "
 
+# Go binaries produce unexpected effects that the Yocto QA mechanism doesn't
+# like. We disable those checks here.
+INSANE_SKIP_${PN} = "ldflags"
+
 do_compile() {
   GOPATH="${B}:${S}"
   export GOPATH


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>