### PR TITLE
Move identity script to /usr/share/mender/identity.

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -82,7 +82,10 @@ do_install() {
   # ${GOPATH}/bin/${GOOS}_${GOARCH}, howver if it's not, the binaries are in
   # ${GOPATH}/bin; handle cross compiled case only
   install -t ${D}/${bindir} -m 0755 \
-          ${B}/bin/${GOOS}_${GOARCH}/mender \
+          ${B}/bin/${GOOS}_${GOARCH}/mender
+
+  install -d ${D}/${datadir}/mender/identity
+  install -t ${D}/${datadir}/mender/identity -m 0755 \
           ${S}/support/mender-device-identity
 
   install -d ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
It's not needed in PATH, and it's better to keep Mender's private
data/scripts isolated. This also brings it in line with the upcoming
inventory scripts.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>