### PR TITLE
make qemu vm only allocate 64mb of ram

### DIFF
--- a/scripts/mender-qemu
+++ b/scripts/mender-qemu
@@ -45,7 +45,7 @@ RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
 QEMU_AUDIO_DRV=none \
     $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
-    -m 512M \
+    -m 64M \
     -kernel "$UBOOT_ELF" \
     -drive file="$VEXPRESS_SDIMG",if=sd,format=raw \
     -net nic,macaddr="$RANDOM_MAC" \


### PR DESCRIPTION
This will make using `docker-compose scale` more useful.

Currently, after booting up qemu with the vexpress image, only 12mb of RAM is used.