### PR TITLE
mender: recreate full Go import path under GOPATH for build

### DIFF
--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -38,6 +38,8 @@ FILES_${PN} += "${systemd_unitdir}/system/mender.service \
 # like. We disable those checks here.
 INSANE_SKIP_${PN} = "ldflags"
 
+GO_IMPORT = "github.com/mendersoftware/mender"
+
 do_compile() {
   GOPATH="${B}:${S}"
   export GOPATH
@@ -47,12 +49,12 @@ do_compile() {
   # mender is using vendored dependencies, any 3rd party libraries go to into
   # /vendor directory inside mender source tree. In order for `go build` to pick
   # up vendored deps from our source tree, the mender source tree itself must be
-  # located inside $GOPATH/src, for instance $GOPATH/src/mender
+  # located inside $GOPATH/src/${GO_IMPORT}
   #
-  # recreate temporary $GOPATH/src/mender structure and link our source tree
-  mkdir -p ${B}/src
-  test -e ${B}/src/mender || ln -s ${S} ${B}/src/mender
-  cd ${B}/src/mender
+  # recreate temporary $GOPATH/src/${GO_IMPORT} structure and link our source tree
+  mkdir -p ${B}/src/$(dirname ${GO_IMPORT})
+  test -e ${B}/src/${GO_IMPORT} || ln -s ${S} ${B}/src/${GO_IMPORT}
+  cd ${B}/src/${GO_IMPORT}
 
   # run verbose build, we should see which dependencies are pulled in
   oe_runmake V=1 install


### PR DESCRIPTION
Since commit a625568f4564dea0c4bcde009ef4157215e072cd, mender imports
its local modules (github.com/mendersoftware/mender/utils in this case).
For this to work, we need to recreate a complete GOPATH structure,
including github.com/mendersoftware/mender import path, for the build to
work.

@kacf @pasinskim @GregorioDiStefano 