### PR TITLE
mender-image: drop .artifactimg suffix in favor of .mender

### DIFF
--- a/classes/mender-artifactimg.bbclass
+++ b/classes/mender-artifactimg.bbclass
@@ -1,14 +1,14 @@
 
-IMAGE_DEPENDS_artifactimg = "artifacts-native"
+IMAGE_DEPENDS_mender = "artifacts-native"
 
 ARTIFACTIMG_FSTYPE  ?= "ext4"
-IMAGE_CMD_artifactimg = "artifacts write rootfs-image \
+IMAGE_CMD_mender = "artifacts write rootfs-image \
                       -i ${IMAGE_ID} -t ${DEVICE_TYPE}\
                       -u ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${ARTIFACTIMG_FSTYPE} \
-                      -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.artifactimg \
+                      -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender \
                       "
 
-IMAGE_CMD_artifactimg[vardepsexclude] += "IMAGE_ID"
+IMAGE_CMD_mender[vardepsexclude] += "IMAGE_ID"
 
 python() {
     fslist = d.getVar('IMAGE_FSTYPES', None).split()
@@ -16,6 +16,6 @@ python() {
         if fs in ["ext2", "ext3", "ext4"]:
             # We need to have the filesystem image generated already. Make it
             # dependent on all image types we support.
-            d.setVar('IMAGE_TYPEDEP_artifactimg_append', " " + fs)
+            d.setVar('IMAGE_TYPEDEP_mender_append', " " + fs)
             d.setVar('ARTIFACTIMG_FSTYPE', fs)
 }

--- a/classes/mender-image.bbclass
+++ b/classes/mender-image.bbclass
@@ -9,4 +9,4 @@ inherit mender-image-buildinfo
 
 #Make sure we are creating sdimg with all needed partitioning.
 IMAGE_CLASSES += "mender-sdimg mender-artifactimg"
-IMAGE_FSTYPES_append = " sdimg artifactimg"
+IMAGE_FSTYPES_append = " sdimg mender"


### PR DESCRIPTION
Change artifact image generation to use `.mender` suffix instead of
`.artifactimg`. Leave the class name unchanged to avoid `mender` phrase
popping up too many times.

@kacf @pasinskim @GregorioDiStefano @eysteins 