### PR TITLE
mender-sdimg: do not use full path when symlinking sdimg

### DIFF
--- a/classes/mender-sdimg.bbclass
+++ b/classes/mender-sdimg.bbclass
@@ -180,5 +180,5 @@ EOF
         dd if="${DEPLOY_DIR_IMAGE}/${IMAGE_BOOTLOADER_FILE}" of="${outimgname}" bs=512 seek=${IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET} conv=notrunc
     fi
 
-    ln -sfn "${outimgname}" "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.sdimg"
+    ln -sfn "${IMAGE_NAME}.sdimg" "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}-${MACHINE}.sdimg"
 }


### PR DESCRIPTION
Do not use full path for the source file when symlinking sdimg, as none
of the other 'helper' symlinks do that.

Before:
```
lrwxrwxrwx 2 mborzecki mborzecki        59 10-05 10:52 core-image-minimal-vexpress-qemu.ext4 -> core-image-minimal-vexpress-qemu-20161005085209.rootfs.ext4
lrwxrwxrwx 2 mborzecki mborzecki        63 10-05 10:51 core-image-minimal-vexpress-qemu.manifest -> core-image-minimal-vexpress-qemu-20161005085138.rootfs.manifest
lrwxrwxrwx 2 mborzecki mborzecki        61 10-05 10:52 core-image-minimal-vexpress-qemu.mender -> core-image-minimal-vexpress-qemu-20161005085209.rootfs.mender
lrwxrwxrwx 1 mborzecki mborzecki        61 10-05 10:51 core-image-minimal-vexpress-qemu.qemuboot.conf -> core-image-minimal-vexpress-qemu-20161005085138.qemuboot.conf
lrwxrwxrwx 1 mborzecki mborzecki       124 10-05 10:57 core-image-minimal-vexpress-qemu.sdimg -> /home/mborzecki/yocto/heads/mender-bbb/tmp/deploy/images/vexpress-qemu/core-image-minimal-vexpress-qemu-20161005085722.sdimg
lrwxrwxrwx 2 mborzecki mborzecki        62 10-05 10:52 core-image-minimal-vexpress-qemu.tar.bz2 -> core-image-minimal-vexpress-qemu-20161005085209.rootfs.tar.bz2
```

After:
```
lrwxrwxrwx 2 mborzecki mborzecki        59 10-05 10:52 core-image-minimal-vexpress-qemu.ext4 -> core-image-minimal-vexpress-qemu-20161005085209.rootfs.ext4
lrwxrwxrwx 2 mborzecki mborzecki        63 10-05 10:51 core-image-minimal-vexpress-qemu.manifest -> core-image-minimal-vexpress-qemu-20161005085138.rootfs.manifest
lrwxrwxrwx 2 mborzecki mborzecki        61 10-05 10:52 core-image-minimal-vexpress-qemu.mender -> core-image-minimal-vexpress-qemu-20161005085209.rootfs.mender
lrwxrwxrwx 1 mborzecki mborzecki        61 10-05 10:51 core-image-minimal-vexpress-qemu.qemuboot.conf -> core-image-minimal-vexpress-qemu-20161005085138.qemuboot.conf
lrwxrwxrwx 1 mborzecki mborzecki        53 10-05 10:52 core-image-minimal-vexpress-qemu.sdimg -> core-image-minimal-vexpress-qemu-20161005085252.sdimg
lrwxrwxrwx 2 mborzecki mborzecki        62 10-05 10:52 core-image-minimal-vexpress-qemu.tar.bz2 -> core-image-minimal-vexpress-qemu-20161005085209.rootfs.tar.bz2
```

@kacf @pasinskim @GregorioDiStefano 