### PR TITLE
Test improvements

### DIFF
--- a/tests/acceptance/.gitignore
+++ b/tests/acceptance/.gitignore
@@ -1,4 +1,3 @@
 *.pyc
 /.cache
 /__pycache__
-/image.dat

--- a/tests/acceptance/test_sdimg.py
+++ b/tests/acceptance/test_sdimg.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from fabric.api import *
+
+import pytest
+import subprocess
+import os
+
+# Make sure common is imported after fabric, because we override some functions.
+from common import *
+
+class EmbeddedBootloader:
+    loader = None
+    offset = 0
+
+    def __init__(self, loader, offset):
+        self.loader = loader
+        self.offset = offset
+
+@pytest.fixture(scope="session")
+def embedded_bootloader():
+    assert(os.environ.get('BUILDDIR', False), "BUILDDIR must be set")
+
+    current_dir = os.open(".", os.O_RDONLY)
+    os.chdir(os.environ['BUILDDIR'])
+
+    output = subprocess.Popen(["bitbake", "-e", "core-image-minimal"], stdout=subprocess.PIPE)
+    loader_base = None
+    loader_dir = None
+    loader = None
+    offset = 0
+    for line in output.stdout:
+        line = line.strip()
+        if line.startswith('IMAGE_BOOTLOADER_FILE="') and line.endswith('"'):
+            loader_base = line.split('=', 2)[1][1:-1]
+        elif line.startswith('IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET="') and line.endswith('"'):
+            offset = int(line.split('=', 2)[1][1:-1]) * 512
+        elif line.startswith('DEPLOY_DIR_IMAGE="') and line.endswith('"'):
+            loader_dir = line.split('=', 2)[1][1:-1]
+
+    if loader_base is not None and loader_base != "":
+        loader = os.path.join(loader_dir, loader_base)
+
+    output.wait()
+    os.fchdir(current_dir)
+
+    return EmbeddedBootloader(loader, offset)
+
+class TestSdimg:
+    def test_bootloader_embed(self, embedded_bootloader, latest_sdimg):
+        """Test that IMAGE_BOOTLOADER_FILE causes the bootloader to be embedded
+        correctly in the resulting sdimg. If the variable has not been defined,
+        the test is skipped."""
+
+        if embedded_bootloader.loader is None:
+            pytest.skip("No embedded bootloader specified")
+
+        original = os.open(embedded_bootloader.loader, os.O_RDONLY)
+        embedded = os.open(latest_sdimg, os.O_RDONLY)
+        os.lseek(embedded, embedded_bootloader.offset, 0)
+
+        checked = 0
+        block_size = 4096
+        while True:
+            org_read = os.read(original, block_size)
+            org_read_size = len(org_read)
+            emb_read = os.read(embedded, org_read_size)
+
+            assert(org_read == emb_read), "Embedded bootloader is not identical to the file specified in IMAGE_BOOTLOADER_FILE"
+
+            if org_read_size < block_size:
+                break
+
+        os.close(original)
+        os.close(embedded)

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -73,13 +73,13 @@ class TestUpdates:
         assert(output.find("no space left on device") >= 0)
         assert(output.find("ret_code=0") < 0)
 
-    def test_network_based_image_update(self):
+    def test_network_based_image_update(self, image_dat):
         http_server_location = pytest.config.getoption("--http-server")
         bbb = pytest.config.getoption("--bbb")
 
         if not env.host_string:
             # This means we are not inside execute(). Recurse into it!
-            execute(self.test_network_based_image_update)
+            execute(self.test_network_based_image_update, image_dat)
             return
 
         output = run("mount")


### PR DESCRIPTION
```
commit e00aa6fab6d93465b8eaf74aabeff912273e5ebc
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Wed Oct 19 12:59:34 2016

    Add test for IMAGE_BOOTLOADER_FILE bitbake option.

    At the time of writing, this test will in fact be skipped on all
    platforms we currently test. But it's a nice test to keep around for
    when a platform that uses IMAGE_BOOTLOADER_FILE comes around.

    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 741df67e274afc74dbd20a4ae1922cc00d7ae267
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Wed Oct 19 12:58:26 2016

    Add autodetection of correct image to use for tests.

    It simply uses the newest image of each type: ext4, sdimg and mender.

    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```
