### PR TITLE
Add missing kernel and device tree files for Beaglebone on krogoth.

### DIFF
--- a/classes/mender-sdimg.bbclass
+++ b/classes/mender-sdimg.bbclass
@@ -87,6 +87,8 @@ python() {
 
 IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic} dosfstools-native mtools-native"
 
+IMAGE_INSTALL_append_beaglebone = " kernel-devicetree kernel-image-zimage"
+
 IMAGE_CMD_sdimg() {
     set -e
 


### PR DESCRIPTION
The issue is already fixed on master.

This is in relation to:
https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta-yocto-bsp/conf/machine/beaglebone.conf?id=3a73fe0efcb7aeefcca7011bba887caad03d4d03

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>