### PR TITLE
Fix (R)DEPENDS mismatch error when building custom u-boot-fw-utils.

### DIFF
--- a/classes/mender-uboot.bbclass
+++ b/classes/mender-uboot.bbclass
@@ -8,4 +8,5 @@ IMAGE_BOOT_FILES_append = " ${IMAGE_BOOT_ENV_FILE}"
 
 EXTRA_IMAGEDEPENDS += "u-boot"
 
+DEPENDS_mender_append = " u-boot u-boot-fw-utils"
 RDEPENDS_mender_append = " u-boot u-boot-fw-utils"


### PR DESCRIPTION
DEPENDS and RDEPENDS need to match when building a custom
u-boot-fw-utils.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>