### PR TITLE
Fix rootfs always overshooting the alignment by 1MiB.

### DIFF
--- a/classes/mender-sdimg.bbclass
+++ b/classes/mender-sdimg.bbclass
@@ -149,7 +149,7 @@ IMAGE_CMD_sdimg() {
     ROOTFS_SIZE=$(expr $REMAINING_SIZE / 2)
 
     # create rootfs
-    dd if=/dev/zero of=${WORKDIR}/rootfs.$FSTYPE count=1 seek=$ROOTFS_SIZE bs=1M
+    dd if=/dev/zero of=${WORKDIR}/rootfs.$FSTYPE count=0 seek=$ROOTFS_SIZE bs=1M
     mkfs.$FSTYPE -F -i 4096 ${WORKDIR}/rootfs.$FSTYPE -d ${IMAGE_ROOTFS}
     stat ${WORKDIR}/rootfs.$FSTYPE
     ln -s ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/active

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -310,7 +310,7 @@ def bitbake_variables():
     os.chdir(os.environ['BUILDDIR'])
 
     output = subprocess.Popen(["bitbake", "-e", "core-image-minimal"], stdout=subprocess.PIPE)
-    matcher = re.compile('^([A-Za-z][^=]*)="(.*)"$')
+    matcher = re.compile('^(?:export )?([A-Za-z][^=]*)="(.*)"$')
     ret = {}
     for line in output.stdout:
         line = line.strip()

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -324,14 +324,13 @@ def bitbake_variables():
     return ret
 
 @pytest.fixture(scope="function")
-def bitbake_path(request):
+def bitbake_path(request, bitbake_variables):
     """Fixture that enables the same PATH as bitbake does when it builds for the
     test that invokes it."""
 
     old_path = os.environ['PATH']
 
-    # Hardcoded value for now. This should be fetched from bitbake itself.
-    os.environ['PATH'] += os.pathsep + os.path.join(os.environ['BUILDDIR'], "tmp/sysroots/x86_64-linux/usr/bin")
+    os.environ['PATH'] = bitbake_variables['PATH']
 
     def path_restore():
         os.environ['PATH'] = old_path

--- a/tests/acceptance/test_sdimg.py
+++ b/tests/acceptance/test_sdimg.py
@@ -18,9 +18,34 @@ from fabric.api import *
 import pytest
 import subprocess
 import os
+import re
 
 # Make sure common is imported after fabric, because we override some functions.
 from common import *
+
+@pytest.fixture(scope="session")
+def bitbake_variables():
+    """Returns a map of all bitbake variables active for the build."""
+
+    assert(os.environ.get('BUILDDIR', False), "BUILDDIR must be set")
+
+    current_dir = os.open(".", os.O_RDONLY)
+    os.chdir(os.environ['BUILDDIR'])
+
+    output = subprocess.Popen(["bitbake", "-e", "core-image-minimal"], stdout=subprocess.PIPE)
+    matcher = re.compile('^([A-Za-z][^=]*)="(.*)"$')
+    ret = {}
+    for line in output.stdout:
+        line = line.strip()
+        match = matcher.match(line)
+        if match is not None:
+            ret[match.group(1)] = match.group(2)
+
+    output.wait()
+    os.fchdir(current_dir)
+
+    return ret
+
 
 class EmbeddedBootloader:
     loader = None
@@ -31,33 +56,22 @@ class EmbeddedBootloader:
         self.offset = offset
 
 @pytest.fixture(scope="session")
-def embedded_bootloader():
-    assert(os.environ.get('BUILDDIR', False), "BUILDDIR must be set")
-
-    current_dir = os.open(".", os.O_RDONLY)
-    os.chdir(os.environ['BUILDDIR'])
-
-    output = subprocess.Popen(["bitbake", "-e", "core-image-minimal"], stdout=subprocess.PIPE)
-    loader_base = None
-    loader_dir = None
+def embedded_bootloader(bitbake_variables):
+    loader_base = bitbake_variables['IMAGE_BOOTLOADER_FILE']
+    loader_dir = bitbake_variables['DEPLOY_DIR_IMAGE']
     loader = None
-    offset = 0
-    for line in output.stdout:
-        line = line.strip()
-        if line.startswith('IMAGE_BOOTLOADER_FILE="') and line.endswith('"'):
-            loader_base = line.split('=', 2)[1][1:-1]
-        elif line.startswith('IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET="') and line.endswith('"'):
-            offset = int(line.split('=', 2)[1][1:-1]) * 512
-        elif line.startswith('DEPLOY_DIR_IMAGE="') and line.endswith('"'):
-            loader_dir = line.split('=', 2)[1][1:-1]
+    offset = int(bitbake_variables['IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET']) * 512
 
     if loader_base is not None and loader_base != "":
         loader = os.path.join(loader_dir, loader_base)
 
-    output.wait()
-    os.fchdir(current_dir)
-
     return EmbeddedBootloader(loader, offset)
+
+
+def align_up(bytes, alignment):
+    """Rounds bytes up to nearest alignment."""
+    return (int(bytes) + int(alignment) - 1) / int(alignment) * int(alignment)
+
 
 class TestSdimg:
     def test_bootloader_embed(self, embedded_bootloader, latest_sdimg):
@@ -86,3 +100,65 @@ class TestSdimg:
 
         os.close(original)
         os.close(embedded)
+
+    def test_total_size(self, bitbake_variables, latest_sdimg):
+        """Test that the total size of the sdimg is correct."""
+
+        total_size_actual = os.stat(latest_sdimg).st_size
+        total_size_max_expected = int(bitbake_variables['MENDER_STORAGE_TOTAL_SIZE_MB']) * 1024 * 1024
+        total_overhead = int(bitbake_variables['MENDER_PARTITIONING_OVERHEAD_MB']) * 1024 * 1024
+
+        assert(total_size_actual <= total_size_max_expected)
+        assert(total_size_actual >= total_size_max_expected - total_overhead)
+
+    def test_partition_alignment(self, bitbake_path, bitbake_variables, latest_sdimg):
+        """Test that partitions inside the sdimg are aligned correctly, and
+        correct sizes."""
+
+        fdisk = subprocess.Popen(["fdisk", "-l", "-o", "start,end", latest_sdimg], stdout=subprocess.PIPE)
+        payload = False
+        parts_start = []
+        parts_end = []
+        for line in fdisk.stdout:
+            line = line.strip()
+            if payload:
+                match = re.match("^\s*([0-9]+)\s+([0-9]+)\s*$", line)
+                assert(match is not None)
+                parts_start.append(int(match.group(1)) * 512)
+                # +1 because end position is inclusive.
+                parts_end.append((int(match.group(2)) + 1) * 512)
+            elif re.match(".*start.*end.*", line, re.IGNORECASE) is not None:
+                # fdisk precedes the output with lots of uninteresting stuff,
+                # this gets us to the meat (/me wishes for a "machine output"
+                # mode).
+                payload = True
+
+        fdisk.wait()
+
+        alignment = int(bitbake_variables['MENDER_PARTITION_ALIGNMENT_MB']) * 1024 * 1024
+        total_size = int(bitbake_variables['MENDER_STORAGE_TOTAL_SIZE_MB']) * 1024 * 1024
+        part_overhead = int(bitbake_variables['MENDER_PARTITIONING_OVERHEAD_MB']) * 1024 * 1024
+        boot_part_size = int(bitbake_variables['MENDER_BOOT_PART_SIZE_MB']) * 1024 * 1024
+        data_part_size = int(bitbake_variables['MENDER_DATA_PART_SIZE_MB']) * 1024 * 1024
+
+        # First partition should be at the first alignment boundary.
+        assert(parts_start[0] == alignment)
+
+        # Subsequent partitions should start where previous one left off.
+        assert(parts_start[1] == parts_end[0])
+        assert(parts_start[2] == parts_end[1])
+        # Except data partition, which is an extended partition, and starts one
+        # full alignment higher.
+        assert(parts_start[4] == parts_end[2] + alignment)
+
+        # Partitions should extend for their size rounded up to alignment.
+        # No set size for Rootfs partitions, so cannot check them.
+        # Boot partition.
+        assert(parts_end[0] == parts_start[0] + align_up(boot_part_size, alignment))
+        # Data partition.
+        assert(parts_end[4] == parts_start[4] + align_up(data_part_size, alignment))
+
+        # End of the last partition can be smaller than total image size, but
+        # not by more than the calculated overhead..
+        assert(parts_end[4] <= total_size)
+        assert(parts_end[4] >= total_size - part_overhead)

--- a/tests/acceptance/test_sdimg.py
+++ b/tests/acceptance/test_sdimg.py
@@ -23,30 +23,6 @@ import re
 # Make sure common is imported after fabric, because we override some functions.
 from common import *
 
-@pytest.fixture(scope="session")
-def bitbake_variables():
-    """Returns a map of all bitbake variables active for the build."""
-
-    assert(os.environ.get('BUILDDIR', False), "BUILDDIR must be set")
-
-    current_dir = os.open(".", os.O_RDONLY)
-    os.chdir(os.environ['BUILDDIR'])
-
-    output = subprocess.Popen(["bitbake", "-e", "core-image-minimal"], stdout=subprocess.PIPE)
-    matcher = re.compile('^([A-Za-z][^=]*)="(.*)"$')
-    ret = {}
-    for line in output.stdout:
-        line = line.strip()
-        match = matcher.match(line)
-        if match is not None:
-            ret[match.group(1)] = match.group(2)
-
-    output.wait()
-    os.fchdir(current_dir)
-
-    return ret
-
-
 class EmbeddedBootloader:
     loader = None
     offset = 0


### PR DESCRIPTION
Passing count=1 to dd would write one additional sector after the
sparse sectors created by using seek. Avoid that by setting to zero.

Also add acceptance test for verifying that image size, partition
sizes and partition alignments are correct in the image.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>