### PR TITLE
MEN-562: Add experimental patches for using U-Boot without bootlimit support.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/experimental/0001-Generic-bootlimit-patch-without-U-Boot-boot-counter-.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/experimental/0001-Generic-bootlimit-patch-without-U-Boot-boot-counter-.patch
@@ -1,0 +1,63 @@
+From c6d03a9c4d0e1af6eaeb47087a64b374764bc00b Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@mender.io>
+Date: Tue, 8 Nov 2016 14:12:19 +0100
+Subject: [PATCH 1/2] Generic bootlimit patch without U-Boot boot counter
+ support.
+
+Basically we implement it using simple logic in the script.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+---
+ include/config_mender.h | 12 ++++++++----
+ include/env_mender.h    |  9 +++++++++
+ 2 files changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/include/config_mender.h b/include/config_mender.h
+index 3c1ecd6..62c0442 100644
+--- a/include/config_mender.h
++++ b/include/config_mender.h
+@@ -25,13 +25,17 @@
+ # error CONFIG_ENV_IS_IN_FAT is required for Mender to work
+ #endif
+ 
+-#ifndef CONFIG_BOOTCOUNT_LIMIT
+-# error CONFIG_BOOTCOUNT_LIMIT is required for Mender to work
++#ifdef CONFIG_BOOTCOUNT_LIMIT
++# error CONFIG_BOOTCOUNT_LIMIT is incompatible with custom bootlimit patch
+ #endif
+ 
+ /* Currently Mender needs bootcount to reside in environment file. */
+-#ifndef CONFIG_BOOTCOUNT_ENV
+-# error CONFIG_BOOTCOUNT_ENV is required for Mender to work
++#ifdef CONFIG_BOOTCOUNT_ENV
++# error CONFIG_BOOTCOUNT_ENV is incompatible with custom bootlimit patch
++#endif
++
++#ifndef CONFIG_CMD_SETEXPR
++# error CONFIG_CMD_SETEXPR is required when using custom bootlimit patch
+ #endif
+ 
+ #ifdef FAT_ENV_INTERFACE
+diff --git a/include/env_mender.h b/include/env_mender.h
+index 2c43fd3..455a828 100644
+--- a/include/env_mender.h
++++ b/include/env_mender.h
+@@ -44,6 +44,15 @@
+     "mender_uboot_dev=" __stringify(MENDER_UBOOT_STORAGE_DEVICE) "\0"   \
+                                                                         \
+     "mender_setup="                                                     \
++    "if test ${upgrade_available} -eq 1; then "                         \
++    "    if test ${bootcount} -ge ${bootlimit}; then "                  \
++    "        echo \"Boot count exceeded. Running altbootcmd.\"; "       \
++    "        run altbootcmd; "                                          \
++    "    else "                                                         \
++    "        setexpr bootcount ${bootcount} + 1; "                      \
++    "        saveenv; "                                                 \
++    "    fi; "                                                          \
++    "fi; "                                                              \
+     "setenv mender_kernel_root " MENDER_STORAGE_DEVICE_BASE "${mender_boot_part}; " \
+     "setenv mender_uboot_root " MENDER_UBOOT_STORAGE_INTERFACE " " __stringify(MENDER_UBOOT_STORAGE_DEVICE) ":${mender_boot_part}; " \
+     "setenv expand_bootargs setenv bootargs ${bootargs}; "              \
+-- 
+2.7.4
+

--- a/meta-mender-qemu/recipes-bsp/u-boot/patches/experimental/0002-Enable-custom-bootlimit-code-for-vexpress-qemu.patch
+++ b/meta-mender-qemu/recipes-bsp/u-boot/patches/experimental/0002-Enable-custom-bootlimit-code-for-vexpress-qemu.patch
@@ -1,0 +1,39 @@
+From 74c365ec9e6cdcd2fa924456113d47f09f6bc833 Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@mender.io>
+Date: Tue, 8 Nov 2016 14:19:33 +0100
+Subject: [PATCH 2/2] Enable custom bootlimit code for vexpress-qemu.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+---
+ configs/vexpress_ca9x4_defconfig  | 2 +-
+ include/configs/vexpress_common.h | 2 --
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/configs/vexpress_ca9x4_defconfig b/configs/vexpress_ca9x4_defconfig
+index 2947fc1..11c44fd 100644
+--- a/configs/vexpress_ca9x4_defconfig
++++ b/configs/vexpress_ca9x4_defconfig
+@@ -11,6 +11,6 @@ CONFIG_TARGET_VEXPRESS_CA9X4=y
+ # CONFIG_CMD_FPGA is not set
+ # CONFIG_CMD_ECHO is not set
+ # CONFIG_CMD_ITEST is not set
+-# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_SETEXPR=y
+ # CONFIG_CMD_NFS is not set
+ # CONFIG_CMD_MISC is not set
+diff --git a/include/configs/vexpress_common.h b/include/configs/vexpress_common.h
+index c1a8b33..36539be 100644
+--- a/include/configs/vexpress_common.h
++++ b/include/configs/vexpress_common.h
+@@ -170,8 +170,6 @@
+ #define CONFIG_SYS_LOAD_ADDR		(V2M_BASE + 0x8000)
+ #define LINUX_BOOT_PARAM_ADDR		(V2M_BASE + 0x2000)
+ #define CONFIG_BOOTDELAY		2
+-#define CONFIG_BOOTCOUNT_LIMIT
+-#define CONFIG_BOOTCOUNT_ENV
+ 
+ /* Physical Memory Map */
+ #define CONFIG_NR_DRAM_BANKS		2
+-- 
+2.7.4
+


### PR DESCRIPTION
We implement our own replacement logic in the boot script. This is
only useful if porting Mender to an old U-Boot that doesn't have
bootlimit support.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>