### PR TITLE
Add support for changed artifact command line interface.

### DIFF
--- a/classes/mender-artifactimg.bbclass
+++ b/classes/mender-artifactimg.bbclass
@@ -3,7 +3,7 @@ IMAGE_DEPENDS_mender = "artifacts-native"
 
 ARTIFACTIMG_FSTYPE  ?= "ext4"
 IMAGE_CMD_mender = "artifacts write rootfs-image \
-                      -i ${IMAGE_ID} -t ${DEVICE_TYPE}\
+                      -n ${IMAGE_ID} -t ${DEVICE_TYPE}\
                       -u ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${ARTIFACTIMG_FSTYPE} \
                       -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender \
                       "

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -50,7 +50,7 @@ class TestUpdates:
 
         # Make a dummy/broken update
         subprocess.call("dd if=/dev/zero of=image.dat bs=1M count=0 seek=8", shell=True)
-        subprocess.call("artifacts write rootfs-image -t %s -i test-update -u image.dat -o image.mender" % image_type, shell=True)
+        subprocess.call("artifacts write rootfs-image -t %s -n test-update -u image.dat -o image.mender" % image_type, shell=True)
         put("image.mender", remote_path="/var/tmp/image.mender")
         run("mender -rootfs /var/tmp/image.mender")
         reboot()
@@ -78,7 +78,7 @@ class TestUpdates:
 
         # Make a too big update
         subprocess.call("dd if=/dev/zero of=image.dat bs=1M count=0 seek=1024", shell=True)
-        subprocess.call("artifacts write rootfs-image -t %s -i test-update-too-big -u image.dat -o image-too-big.mender" % image_type, shell=True)
+        subprocess.call("artifacts write rootfs-image -t %s -n test-update-too-big -u image.dat -o image-too-big.mender" % image_type, shell=True)
         put("image-too-big.mender", remote_path="/var/tmp/image-too-big.mender")
         output = run("mender -rootfs /var/tmp/image-too-big.mender ; echo 'ret_code=$?'")
 


### PR DESCRIPTION
`-i` option was replaced with `-n`.

Signed-off-by: Marcin Pasinski <marcin.pasinski@mender.io>