### PR TITLE
add recipe for mender-artifact

### DIFF
--- a/classes/mender-image-buildinfo.bbclass
+++ b/classes/mender-image-buildinfo.bbclass
@@ -6,7 +6,7 @@ IMAGE_BUILDINFO_VARS = "DISTRO DATETIME PN IMAGE_ID DEVICE_TYPE"
 
 buildinfo_mender () {
 mkdir -p ${IMAGE_ROOTFS}${sysconfdir}/mender
-cat > ${IMAGE_ROOTFS}${sysconfdir}/mender/build_mender << END
+cat > ${IMAGE_ROOTFS}${sysconfdir}/mender/artifact-info << END
 ------------------------
 Mender device manifest:|
 ------------------------

--- a/classes/mender-install.bbclass
+++ b/classes/mender-install.bbclass
@@ -34,4 +34,8 @@ MENDER_DATA_PART ?= "${MENDER_STORAGE_DEVICE_BASE}5"
 
 PREFERRED_VERSION_go_cross = "1.6%"
 
-IMAGE_INSTALL_append = " mender ca-certificates"
+IMAGE_INSTALL_append = " \
+    mender \
+    ca-certificates \
+    mender-artifact \
+    "

--- a/classes/mender-uboot.bbclass
+++ b/classes/mender-uboot.bbclass
@@ -7,3 +7,4 @@ IMAGE_BOOT_ENV_FILE ?= "uboot.env"
 IMAGE_BOOT_FILES_append = " ${IMAGE_BOOT_ENV_FILE}"
 
 EXTRA_IMAGEDEPENDS += "u-boot"
+PACKAGECONFIG_append_pn-mender = " u-boot"

--- a/classes/mender-uboot.bbclass
+++ b/classes/mender-uboot.bbclass
@@ -7,6 +7,3 @@ IMAGE_BOOT_ENV_FILE ?= "uboot.env"
 IMAGE_BOOT_FILES_append = " ${IMAGE_BOOT_ENV_FILE}"
 
 EXTRA_IMAGEDEPENDS += "u-boot"
-
-DEPENDS_mender_append = " u-boot u-boot-fw-utils"
-RDEPENDS_mender_append = " u-boot u-boot-fw-utils"

--- a/recipes-mender/mender-artifact/mender-artifact.bb
+++ b/recipes-mender/mender-artifact/mender-artifact.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Mender artifact information"
+HOMEPAGE = "https://mender.io"
+LICENSE = "Apache-2.0"
+
+inherit allarch
+
+PV = "0.1"
+
+do_compile() {
+    echo "# populate this file with build info" > ${B}/artifact-info
+}
+
+do_install() {
+    install -d ${D}${sysconfdir}/mender
+    install -t ${D}${sysconfdir}/mender ${B}/artifact-info
+    ln -s artifact-info ${D}${sysconfdir}/mender/build_mender
+}
+
+FILES_${PN} += " \
+    ${sysconfdir}/mender/artifact-info \
+    ${sysconfdir}/mender/build_mender \
+"

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -40,8 +40,9 @@ INSANE_SKIP_${PN} = "ldflags"
 
 GO_IMPORT = "github.com/mendersoftware/mender"
 
+PACKAGECONFIG[u-boot] = ",,,u-boot-fw-utils"
+
 RDEPENDS_${PN} += " \
-    u-boot-fw-utils \
     mender-artifact \
     "
 

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -40,6 +40,10 @@ INSANE_SKIP_${PN} = "ldflags"
 
 GO_IMPORT = "github.com/mendersoftware/mender"
 
+RDEPENDS_${PN} += " \
+    u-boot-fw-utils \
+    "
+
 do_compile() {
   GOPATH="${B}:${S}"
   export GOPATH

--- a/recipes-mender/mender/mender_0.1.bb
+++ b/recipes-mender/mender/mender_0.1.bb
@@ -42,6 +42,7 @@ GO_IMPORT = "github.com/mendersoftware/mender"
 
 RDEPENDS_${PN} += " \
     u-boot-fw-utils \
+    mender-artifact \
     "
 
 do_compile() {


### PR DESCRIPTION
The series adds a recipe for mender-artifact package. The package delivers `${sysconfdir}/mender/artifact-info`. The file is populated in rootfs preprocessing.

In order to preserve backwards compatibility with, `${sysconfdir}/mender/build_mender` is a symlink to `artifact-info`.

Setting mender dependencies in `mender-uboot` is not a good idea and bitbake correctly raises a warning when parsing recipes. `RDEPENDS` of mender were moved to mender recipe. `u-boot` was dropped from `[R]DEPENDS`, as it should get built & installed as a result of machine setup. 

`DEPENDS_mender` was removed. AFAIK there's no build dependency on `u-boot` nor on `u-boot-fw-utils`.

@pasinskim @kacf 