### PR TITLE
Fix license warning in mender-artifact.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.bb
@@ -1,6 +1,12 @@
 DESCRIPTION = "Mender artifact information"
 HOMEPAGE = "https://mender.io"
 LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+FILESPATH = "${COMMON_LICENSE_DIR}"
+SRC_URI = "file://Apache-2.0"
+
+S = "${WORKDIR}"
 
 inherit allarch
 


### PR DESCRIPTION
It's a fully generated package, with no source, so a license is kind
of pointless. Nevertheless, make the build system happy and provide
the Apache-2.0 license.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>