### PR TITLE
Fix persistent symlink error if sdimg building has failed once.

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -152,8 +152,8 @@ IMAGE_CMD_sdimg() {
     dd if=/dev/zero of=${WORKDIR}/rootfs.$FSTYPE count=0 seek=$ROOTFS_SIZE bs=1M
     mkfs.$FSTYPE -F -i 4096 ${WORKDIR}/rootfs.$FSTYPE -d ${IMAGE_ROOTFS}
     stat ${WORKDIR}/rootfs.$FSTYPE
-    ln -s ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/active
-    ln -s ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/inactive
+    ln -sf ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/active
+    ln -sf ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/inactive
 
     MENDER_PARTITION_ALIGNMENT_KB=$(expr ${MENDER_PARTITION_ALIGNMENT_MB} \* 1024)
 


### PR DESCRIPTION
If you tried to build sdimg once, and it failed somewhere in the late
stages, you could never build it again because the symlinks would
already exist. Fix by forcing creation even if they exist already.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>