### PR TITLE
MEN-749: Add acceptance test for redundant U-Boot environment.

### DIFF
--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -129,13 +129,18 @@ def ssh_prep_args_impl(tool):
     return (cmd, host, port)
 
 
-def determine_active_passive_part(mount_output):
+def determine_active_passive_part(bitbake_variables):
     """Given the output from mount, determine the currently active and passive
-    partition numbers, returning them as a pair in that order."""
-    if mount_output.find("/dev/mmcblk0p2") >= 0:
-        return ("2", "3")
-    elif mount_output.find("/dev/mmcblk0p3") >= 0:
-        return ("3", "2")
+    partitions, returning them as a pair in that order."""
+
+    mount_output = run("mount")
+    a = bitbake_variables["MENDER_ROOTFS_PART_A"]
+    b = bitbake_variables["MENDER_ROOTFS_PART_B"]
+
+    if mount_output.find(a) >= 0:
+        return (a, b)
+    elif mount_output.find(b) >= 0:
+        return (b, a)
     else:
         raise Exception("Could not determine active partition. Mount output: %s"
                         % mount_output)

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -141,12 +141,6 @@ def determine_active_passive_part(mount_output):
                         % mount_output)
 
 
-def part_device(part_number):
-    """Given partition number (but string type), return the device for that
-    partition."""
-    return "/dev/mmcblk0p" + part_number
-
-
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.
 def put(file, local_path = ".", remote_path = "."):
     (scp, host, port) = scp_prep_args()


### PR DESCRIPTION
Because it bricks the device if it fails, it's currently disabled, but
should be enabled as part of MEN-480.

The last commit is the actual test, the rest is just a few cleanups.