### PR TITLE
Add support for Raspberry Pi boards

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -97,7 +97,7 @@ python() {
             d.setVar('IMAGE_TYPEDEP_sdimg_append', " " + fs)
 }
 
-IMAGE_DEPENDS_sdimg = "${IMAGE_DEPENDS_wic} dosfstools-native mtools-native"
+IMAGE_DEPENDS_sdimg += "${IMAGE_DEPENDS_wic} dosfstools-native mtools-native"
 
 IMAGE_CMD_sdimg() {
     set -e

--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -1,0 +1,40 @@
+# meta-mender-raspberrypi
+
+This Yocto layers contains recipes which enables support of building Mender client for Raspberry Pi boards.
+
+**NOTE!**. To be able to support update of Linux kernel and DTB these are installed to `/boot` on rootfs. This breaks support of user configurations based on `config.txt` because the Raspberry Pi boot firmware requires that the DTB file is in the same partition as the boot firmware files (mmcblk0p1). Boot firmware normally patches the DTB file based on configurations in `config.txt`.
+
+Above should not pose any problems if you do not require any changes in `config.txt` and the default configuration certainly is enough to run Mender client.
+
+## Dependencies
+
+This layer depends on:
+
+    URI: git://git.yoctoproject.org/meta-raspberrypi
+    branch: master
+    revision: HEAD
+
+in addition to `meta-mender` dependencies.
+
+## Build instructions
+
+- Read [the Mender documentation on Building a Mender Yocto image](https://docs.mender.io/Artifacts/Building-Mender-Yocto-image) for Mender specific configuration.
+- Set MACHINE to one of the following
+    - raspberrypi
+    - raspberrypi0
+    - raspberrypi2
+    - raspberrypi3
+- Add following to your local.conf (including configuration required by meta-mender-core)
+
+        KERNEL_IMAGETYPE = "uImage"
+
+        MENDER_PARTITION_ALIGNMENT_MB = "4"
+        MENDER_BOOT_PART_SIZE_MB = "40"
+
+        IMAGE_DEPENDS_sdimg += " bcm2835-bootfiles"
+
+        # raspberrypi files aligned with mender layout requirements
+        IMAGE_BOOT_FILES_append = " boot.scr u-boot.bin;${SDIMG_KERNELIMAGE}"
+        IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
+
+- Run `bitbake <image name>`

--- a/meta-mender-raspberrypi/conf/layer.conf
+++ b/meta-mender-raspberrypi/conf/layer.conf
@@ -1,0 +1,13 @@
+# Board specific layer configuration for meta-mender
+# Copyright 2016 Mirza Krak
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-raspberrypi"
+BBFILE_PATTERN_mender-raspberrypi = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-raspberrypi = "6"

--- a/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -1,0 +1,10 @@
+
+do_deploy_append() {
+    # Recently the default clock rate for uart changed to 48 MHz. This is
+    # setup by boot firmware. This update has not been aligned in u-boot nor in
+    # Linux yet.
+    #
+    # Override the default with the previous default which is 3 MHz. This
+    # workaround can be dropped once the configuration aligns upstream.
+    sed -i '/#init_uart_clock/ c\init_uart_clock=3000000' ${DEPLOYDIR}/bcm2835-bootfiles/config.txt
+}

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi/boot.cmd
@@ -1,0 +1,8 @@
+run mender_setup
+setenv fdtfile bcm2708-rpi-b.dtb
+setenv bootargs earlyprintk console=tty0 console=ttyAMA0 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+mmc dev ${mender_uboot_dev}
+load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
+load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr_r}
+run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi0/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi0/boot.cmd
@@ -1,0 +1,8 @@
+run mender_setup
+setenv fdtfile bcm2708-rpi-b.dtb
+setenv bootargs earlyprintk console=tty0 console=ttyAMA0 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+mmc dev ${mender_uboot_dev}
+load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
+load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr_r}
+run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi2/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi2/boot.cmd
@@ -1,0 +1,8 @@
+run mender_setup
+setenv fdtfile bcm2709-rpi-2-b.dtb
+setenv bootargs earlyprintk console=tty0 console=ttyAMA0 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+mmc dev ${mender_uboot_dev}
+load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
+load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr_r}
+run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi3/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi3/boot.cmd
@@ -1,0 +1,8 @@
+run mender_setup
+setenv fdtfile bcm2710-rpi-3-b.dtb
+setenv bootargs earlyprintk console=tty0 console=ttyAMA0 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+mmc dev ${mender_uboot_dev}
+load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
+load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr_r}
+run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend_rpi := "${THISDIR}/files:"

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender.io-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender.io-requirements.patch
@@ -1,0 +1,38 @@
+From 3267334937464b9c84b812f20fb12cab8b8dd0d5 Mon Sep 17 00:00:00 2001
+From: Mirza Krak <mirza.krak@gmail.com>
+Date: Sun, 30 Oct 2016 21:39:10 +0100
+Subject: [PATCH 1/1] CONFIGS: rpi: enable mender.io requirements
+
+Which are CONFIG_BOOTCOUNT_ENV and CONFIG_BOOTCOUNT_LIMIT.
+
+Mender.io also requires that FAT_ENV_INTERFACE, FAT_ENV_DEVICE_AND_PART
+and FAT_ENV_FILE are not present in the configuration.
+---
+ include/configs/rpi-common.h | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/rpi-common.h b/include/configs/rpi-common.h
+index 2c3b026..505a2fe 100644
+--- a/include/configs/rpi-common.h
++++ b/include/configs/rpi-common.h
+@@ -107,15 +107,14 @@
+ /* Environment */
+ #define CONFIG_ENV_SIZE			SZ_16K
+ #define CONFIG_ENV_IS_IN_FAT
+-#define FAT_ENV_INTERFACE		"mmc"
+-#define FAT_ENV_DEVICE_AND_PART		"0:1"
+-#define FAT_ENV_FILE			"uboot.env"
+ #define CONFIG_FAT_WRITE
+ #define CONFIG_ENV_VARS_UBOOT_CONFIG
+ #define CONFIG_SYS_LOAD_ADDR		0x1000000
+ #define CONFIG_CONSOLE_MUX
+ #define CONFIG_SYS_CONSOLE_IS_IN_ENV
+ #define CONFIG_PREBOOT			"usb start"
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
+ 
+ /* Shell */
+ #define CONFIG_SYS_MAXARGS		16
+-- 
+2.1.4
+

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,0 +1,1 @@
+require u-boot-raspberrypi.inc

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend_rpi := "${THISDIR}/patches:"
+
+BOOTENV_SIZE_rpi ?= "0x4000"
+
+SRC_URI_append_rpi = " file://0001-CONFIGS-rpi-enable-mender.io-requirements.patch"

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,1 @@
+require u-boot-raspberrypi.inc


### PR DESCRIPTION
This pull request adds support to build mender for Raspberry Pi boards. I have only tested this on a Raspberry Pi 2.

This adds a dependency on (when building for a Raspberry Pi board):
```
URI: git://git.yoctoproject.org/meta-raspberrypi
branch: master
revision: HEAD
```
Following needs to be added to local.conf when building for Raspberry Pi`s:
```
MACHINE ?= "raspberrypi2"

KERNEL_IMAGETYPE = "uImage"

INHERIT += "mender-full"

DISTRO_FEATURES_append = " systemd"
VIRTUAL-RUNTIME_init_manager = "systemd"
DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
VIRTUAL-RUNTIME_initscripts = ""
IMAGE_FSTYPES = "ext4"

MENDER_ARTIFACT_NAME = "my-mender-image-1.0"
MENDER_PARTITION_ALIGNMENT_MB = "4"
MENDER_BOOT_PART_SIZE_MB = "40"

MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append = " bcm2835-bootfiles"

# raspberrypi files aligned with mender layout requirements
IMAGE_BOOT_FILES_append = " boot.scr u-boot.bin;${SDIMG_KERNELIMAGE}"
IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
```