### PR TITLE
Add MENDER_ARTIFACT_NAME check to mender-artifact.bb recipe as well.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.bb
@@ -13,6 +13,10 @@ inherit allarch
 PV = "0.1"
 
 do_compile() {
+    if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
+        bberror "Need to define MENDER_ARTIFACT_NAME variable."
+    fi
+
     cat > ${B}/artifact_info << END
 artifact_name=${MENDER_ARTIFACT_NAME}
 END


### PR DESCRIPTION
It's already present in mender-artifactimg.bbclass, which assembles
the .mender file. However, if you only build the initial sdimg, the
check would be skipped, but it's equally important that it is in the
sdimg. So add the check to the mender-artifact.bb recipe, which should
cover both cases.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>