### PR TITLE
Fix build for U-Boot 2016.11 and later.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
@@ -35,8 +35,8 @@ index 0000000..3c1ecd6
 +  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 +*/
 +
-+#ifndef CONFIG_MENDER_H
-+#define CONFIG_MENDER_H
++#ifndef HEADER_CONFIG_MENDER_H
++#define HEADER_CONFIG_MENDER_H
 +
 +#include <config_mender_defines.h>
 +
@@ -85,7 +85,7 @@ index 0000000..3c1ecd6
 +
 +#define CONFIG_FAT_WRITE
 +
-+#endif /* CONFIG_MENDER_H */
++#endif /* HEADER_CONFIG_MENDER_H */
 diff --git a/include/env_mender.h b/include/env_mender.h
 new file mode 100644
 index 0000000..d13d0b1
@@ -110,8 +110,8 @@ index 0000000..d13d0b1
 +  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 +*/
 +
-+#ifndef ENV_MENDER_H
-+#define ENV_MENDER_H
++#ifndef HEADER_ENV_MENDER_H
++#define HEADER_ENV_MENDER_H
 +
 +#include <config_mender_defines.h>
 +
@@ -158,7 +158,7 @@ index 0000000..d13d0b1
 +    "then reset; "                                                      \
 +    "fi\0"
 +
-+#endif /* ENV_MENDER_H */
++#endif /* HEADER_ENV_MENDER_H */
 -- 
 2.7.4
 


### PR DESCRIPTION
Based on following user feedback:

Tested meta-mender on U-boot 2016.11 and get following:
| Error: You must add new CONFIG options using Kconfig
| The following new ad-hoc CONFIG options were detected:
| CONFIG_MENDER_H
|
| Please add these via Kconfig instead. Find a suitable Kconfig
| file and add a 'config' or 'menuconfig' option.

This is because of [PATCH 1/2] Generic boot code for Mender.

It is probably not the best naming convention to begin a header file
name with CONFIG_ since this is obviously now interpreted as
configuration option and hence the error.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>