### PR TITLE
raspberrypi: u-boot: adjust mender patches for 2016.11

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
@@ -1,11 +1,11 @@
-From 3267334937464b9c84b812f20fb12cab8b8dd0d5 Mon Sep 17 00:00:00 2001
+From eb40f711ee831be664d0bd4f7c4dbce7c2521cba Mon Sep 17 00:00:00 2001
 From: Mirza Krak <mirza.krak@gmail.com>
-Date: Sun, 30 Oct 2016 21:39:10 +0100
-Subject: [PATCH 1/1] CONFIGS: rpi: enable mender.io requirements
+Date: Sun, 30 Oct 2016 21:28:43 +0100
+Subject: [PATCH 1/1] configs: rpi: enable mender requirements
 
 Which are CONFIG_BOOTCOUNT_ENV and CONFIG_BOOTCOUNT_LIMIT.
 
-Mender.io also requires that FAT_ENV_INTERFACE, FAT_ENV_DEVICE_AND_PART
+Mender also requires that FAT_ENV_INTERFACE, FAT_ENV_DEVICE_AND_PART
 and FAT_ENV_FILE are not present in the configuration.
 
 Signed-off-by: Mirza Krak <mirza.krak@gmail.com>

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender.io-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender.io-requirements.patch
@@ -7,15 +7,17 @@ Which are CONFIG_BOOTCOUNT_ENV and CONFIG_BOOTCOUNT_LIMIT.
 
 Mender.io also requires that FAT_ENV_INTERFACE, FAT_ENV_DEVICE_AND_PART
 and FAT_ENV_FILE are not present in the configuration.
----
- include/configs/rpi-common.h | 5 ++---
- 1 file changed, 2 insertions(+), 3 deletions(-)
 
-diff --git a/include/configs/rpi-common.h b/include/configs/rpi-common.h
-index 2c3b026..505a2fe 100644
---- a/include/configs/rpi-common.h
-+++ b/include/configs/rpi-common.h
-@@ -107,15 +107,14 @@
+Signed-off-by: Mirza Krak <mirza.krak@gmail.com>
+---
+ include/configs/rpi.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/rpi.h b/include/configs/rpi.h
+index 45c8234..265b69a 100644
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -120,13 +120,13 @@
  /* Environment */
  #define CONFIG_ENV_SIZE			SZ_16K
  #define CONFIG_ENV_IS_IN_FAT
@@ -23,16 +25,14 @@ index 2c3b026..505a2fe 100644
 -#define FAT_ENV_DEVICE_AND_PART		"0:1"
 -#define FAT_ENV_FILE			"uboot.env"
  #define CONFIG_FAT_WRITE
++
  #define CONFIG_ENV_VARS_UBOOT_CONFIG
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
- #define CONFIG_CONSOLE_MUX
- #define CONFIG_SYS_CONSOLE_IS_IN_ENV
  #define CONFIG_PREBOOT			"usb start"
 +#define CONFIG_BOOTCOUNT_ENV
 +#define CONFIG_BOOTCOUNT_LIMIT
- 
+
  /* Shell */
  #define CONFIG_SYS_MAXARGS		16
--- 
+--
 2.1.4
-

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
@@ -2,4 +2,4 @@ FILESEXTRAPATHS_prepend_rpi := "${THISDIR}/patches:"
 
 BOOTENV_SIZE_rpi ?= "0x4000"
 
-SRC_URI_append_rpi = " file://0001-CONFIGS-rpi-enable-mender.io-requirements.patch"
+SRC_URI_append_rpi = " file://0001-CONFIGS-rpi-enable-mender-requirements.patch"


### PR DESCRIPTION
rpi-common.h has been renamed to rpi.h.

While at it changed mender.io occurrences to mender.

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>