### PR TITLE
u-boot: Switch Raspberry Pi to store env on MMC, after 2a8ea346aa0d.

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender.io-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender.io-requirements.patch
@@ -15,14 +15,15 @@ diff --git a/include/configs/rpi-common.h b/include/configs/rpi-common.h
 index 2c3b026..505a2fe 100644
 --- a/include/configs/rpi-common.h
 +++ b/include/configs/rpi-common.h
-@@ -107,15 +107,14 @@
+@@ -107,16 +107,13 @@
  /* Environment */
  #define CONFIG_ENV_SIZE			SZ_16K
- #define CONFIG_ENV_IS_IN_FAT
+-#define CONFIG_ENV_IS_IN_FAT
 -#define FAT_ENV_INTERFACE		"mmc"
 -#define FAT_ENV_DEVICE_AND_PART		"0:1"
 -#define FAT_ENV_FILE			"uboot.env"
- #define CONFIG_FAT_WRITE
+-#define CONFIG_FAT_WRITE
++#define CONFIG_ENV_IS_IN_MMC
  #define CONFIG_ENV_VARS_UBOOT_CONFIG
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
  #define CONFIG_CONSOLE_MUX


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>