### PR TITLE
raspberrypi: u-boot: move U-boot environment to MMC

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
@@ -5,27 +5,28 @@ Subject: [PATCH 1/1] configs: rpi: enable mender requirements
 
 Which are CONFIG_BOOTCOUNT_ENV and CONFIG_BOOTCOUNT_LIMIT.
 
-Mender also requires that FAT_ENV_INTERFACE, FAT_ENV_DEVICE_AND_PART
-and FAT_ENV_FILE are not present in the configuration.
+Mender also requires that the environment is on MMC
+(CONFIG_ENV_IS_IN_MMC)
 
 Signed-off-by: Mirza Krak <mirza.krak@gmail.com>
 ---
- include/configs/rpi.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ include/configs/rpi.h | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
 
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 45c8234..265b69a 100644
+index 4406366..5bf258b 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -120,13 +120,13 @@
+@@ -118,14 +118,12 @@
+
  /* Environment */
  #define CONFIG_ENV_SIZE			SZ_16K
- #define CONFIG_ENV_IS_IN_FAT
+-#define CONFIG_ENV_IS_IN_FAT
 -#define FAT_ENV_INTERFACE		"mmc"
 -#define FAT_ENV_DEVICE_AND_PART		"0:1"
 -#define FAT_ENV_FILE			"uboot.env"
- #define CONFIG_FAT_WRITE
-+
+-#define CONFIG_FAT_WRITE
++#define CONFIG_ENV_IS_IN_MMC
  #define CONFIG_ENV_VARS_UBOOT_CONFIG
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
  #define CONFIG_PREBOOT			"usb start"
@@ -36,3 +37,4 @@ index 45c8234..265b69a 100644
  #define CONFIG_SYS_MAXARGS		16
 --
 2.1.4
+


### PR DESCRIPTION
Since https://github.com/mendersoftware/meta-
mender/commit/2a8ea346aa0d12da755d36f426164a0e54f757b3, it is expected
that the U-boot environment is on the MMC instead of a file on VFAT
partition.

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>