### PR TITLE
beaglebone: Disable feature which breaks internal MMC detection.

### DIFF
--- a/meta-mender-beaglebone/recipes-bsp/u-boot/patches/0001-Disable-feature-which-breaks-internal-MMC-detection.patch
+++ b/meta-mender-beaglebone/recipes-bsp/u-boot/patches/0001-Disable-feature-which-breaks-internal-MMC-detection.patch
@@ -1,0 +1,29 @@
+From 805d62c1efe11647a3a68815a773650f015c7a22 Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@mender.io>
+Date: Fri, 16 Dec 2016 08:02:54 +0100
+Subject: [PATCH] Disable feature which breaks internal MMC detection.
+
+This problem was introduced in U-Boot in commit 80b24fcd3083515e6b961,
+due to the addition of the CONFIG_DM_MMC option.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+---
+ configs/am335x_evm_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/am335x_evm_defconfig b/configs/am335x_evm_defconfig
+index e5a1696..2033d38 100644
+--- a/configs/am335x_evm_defconfig
++++ b/configs/am335x_evm_defconfig
+@@ -41,7 +41,7 @@ CONFIG_DFU_MMC=y
+ CONFIG_DFU_NAND=y
+ CONFIG_DFU_RAM=y
+ CONFIG_DM_I2C=y
+-CONFIG_DM_MMC=y
++# CONFIG_DM_MMC is not set
+ # CONFIG_DM_MMC_OPS is not set
+ CONFIG_SPI_FLASH=y
+ CONFIG_SPI_FLASH_WINBOND=y
+-- 
+2.7.4
+

--- a/meta-mender-beaglebone/recipes-bsp/u-boot/u-boot_2016.11.bbappend
+++ b/meta-mender-beaglebone/recipes-bsp/u-boot/u-boot_2016.11.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+SRC_URI_append_beaglebone = " file://0001-Disable-feature-which-breaks-internal-MMC-detection.patch"


### PR DESCRIPTION
This problem was introduced in U-Boot in commit 80b24fcd3083515e6b961,
due to the addition of the CONFIG_DM_MMC option.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>