### PR TITLE
mender-sdimg: workaround get_bitbake_var() parsing issues

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -124,10 +124,10 @@ IMAGE_CMD_sdimg() {
                           ${MENDER_DATA_PART_SIZE_MB} - \
                           ${MENDER_PARTITIONING_OVERHEAD_MB} - \
                           $boot_env_size_mb)
-    ROOTFS_SIZE=$(expr $REMAINING_SIZE / 2)
+    CALC_ROOTFS_SIZE=$(expr $REMAINING_SIZE / 2)
 
     # create rootfs
-    dd if=/dev/zero of=${WORKDIR}/rootfs.$FSTYPE count=0 seek=$ROOTFS_SIZE bs=1M
+    dd if=/dev/zero of=${WORKDIR}/rootfs.$FSTYPE count=0 seek=$CALC_ROOTFS_SIZE bs=1M
     mkfs.$FSTYPE -F -i 4096 ${WORKDIR}/rootfs.$FSTYPE -d ${IMAGE_ROOTFS}
     ln -sf ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/active
     ln -sf ${WORKDIR}/rootfs.$FSTYPE ${WORKDIR}/inactive


### PR DESCRIPTION
`BitbakeVars._parse_line()` may incorrectly interpret lines containing
'<key>=<value>' pattern as those containing legitimate bitbake variables. When
<key> name concides with a known bitbake variable, one may observe unexpected
value returned by `get_bitbake_var(<key>)`.

In meta-mender case, IMAGE_CMD_sdimg defines ROOTFS_SIZE variable. OE-core commit
db08ffee0ad1451f3bf710f4d1b623938ba9aefb introduced a fallback mechanism for
setting partition size that uses ROOTFS_SIZE. Querying ROOTFS_SIZE while
meta-mender is included in layers leads to unexpected results.

@kacf @pasinskim 