### PR TITLE
Default to empty images in docker build.

### DIFF
--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -6,15 +6,23 @@ RUN apt-get -y update && \
     apt-get -y install qemu-kvm qemu-system-arm && \
     rm -rf /var/lib/apt/lists/*
 
-#Use: --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf when building
-ARG VEXPRESS_IMAGE
-ARG UBOOT_ELF
+# Use: --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg
+# --build-arg UBOOT_ELF=u-boot.elf when building
+# Or use "docker run -v $BUILDDIR:/mnt/build" to get build artifacts from local
+# hard drive.
+ARG VEXPRESS_IMAGE=scripts/docker/empty-file
+ARG UBOOT_ELF=scripts/docker/empty-file
 
-ADD $UBOOT_ELF ./
-ADD $VEXPRESS_IMAGE ./
+ADD $UBOOT_ELF ./u-boot.elf
+ADD $VEXPRESS_IMAGE ./core-image-full-cmdline-vexpress-qemu.sdimg
 
 ADD scripts/mender-qemu ./
 ADD scripts/docker/entrypoint.sh ./
+
+# Delete images if they are empty. This is to save space if the artifacts are
+# mounted on /mnt/build instead.
+RUN if [ `stat -c %s core-image-full-cmdline-vexpress-qemu.sdimg` -eq 0 ]; then rm -f core-image-full-cmdline-vexpress-qemu.sdimg; fi
+RUN if [ `stat -c %s u-boot.elf` -eq 0 ]; then rm -f u-boot.elf; fi
 
 RUN chmod +x entrypoint.sh mender-qemu
 EXPOSE 8822

--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -1,2 +1,12 @@
 #!/bin/bash
+
+set -x -e
+
+if [ -e /mnt/build/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.sdimg ]; then
+    cp /mnt/build/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.sdimg .
+fi
+if [ -e /mnt/build/tmp/deploy/images/vexpress-qemu/u-boot.elf ]; then
+    cp /mnt/build/tmp/deploy/images/vexpress-qemu/u-boot.elf .
+fi
+
 QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_SDIMG="core-image-full-cmdline-vexpress-qemu.sdimg" UBOOT_ELF="u-boot.elf" ./mender-qemu $*


### PR DESCRIPTION
This is primarily for development, where instead of creating a new
docker image every time you've built a new Yocto image, you grab them
from /mnt/build mount point instead. The image won't work unless you
specify either the arguments or the mount, but this was the case
before this patch as well.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>