### PR TITLE
meta-mender-selftest: oe-selftest support

### DIFF
--- a/meta-mender-selftest/README.md
+++ b/meta-mender-selftest/README.md
@@ -1,0 +1,15 @@
+## meta-mender-selftest
+
+OE selftest layer for mender Yocto support. Before using it, you need to add it
+to `BBLAYERS` like this:
+
+```
+BBLAYERS ?= " \
+  ...
+  <your-path>/meta-mender/meta-mender-selftest \
+  ...
+```
+
+Tests can be listed with `oe-selftest --list-tests-by module mender`. Individual
+tests are run by `oe-selftest -r mender.Mender.test_hello`. See `oe-selftest
+--help` for details.

--- a/meta-mender-selftest/conf/layer.conf
+++ b/meta-mender-selftest/conf/layer.conf
@@ -1,0 +1,13 @@
+# Layer configuration for meta-mender
+# Copyright 2016 Mender Software AS
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-selftest"
+BBFILE_PATTERN_mender-selftest = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-selftest = "6"

--- a/meta-mender-selftest/lib/oeqa/selftest/mender.py
+++ b/meta-mender-selftest/lib/oeqa/selftest/mender.py
@@ -1,0 +1,8 @@
+
+"""Test cases for mender."""
+
+from oeqa.selftest.base import oeSelfTest
+
+class Mender(oeSelfTest):
+    def test_hello(self):
+        self.assertTrue(True)


### PR DESCRIPTION
See README for details. Basically you can implement the same things as are implemented for OE core right here: https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/lib/oeqa/selftest

Perhaps instead of using a separate selftest layer is a bit of an overkill. The tests could be part of meta-mender-core after all. We can revise it later though, if we decide this PR is something that we want do or not.

@kacf @pasinskim @GregorioDiStefano 
