### PR TITLE
MEN-934: Always respect storage conf when determining rootfs size.

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -9,6 +9,12 @@ IMAGE_CMD_mender () {
         bbfatal "Need to define MENDER_ARTIFACT_NAME variable."
     fi
 
+    rootfs_size=$(stat -Lc %s ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${ARTIFACTIMG_FSTYPE})
+    calc_rootfs_size=$(expr ${MENDER_CALC_ROOTFS_SIZE} \* 1024)
+    if [ $rootfs_size -gt $calc_rootfs_size ]; then
+        bbwarn "Size of rootfs is greater than the calculated partition space ($rootfs_size > $calc_rootfs_size). This image won't fit on a device with the current storage configuration. Make sure IMAGE_ROOTFS_EXTRA_SPACE is set to 0, and try reducing IMAGE_OVERHEAD_FACTOR if it is higher than 1.0."
+    fi
+
     # Trim leading/trailing spaces, and replace spaces with commas for
     # consumption by mender-artifact tool.
     devs_compatible=

--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -6,7 +6,7 @@ IMAGE_CMD_mender () {
     set -x
 
     if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
-        bberror "Need to define MENDER_ARTIFACT_NAME variable."
+        bbfatal "Need to define MENDER_ARTIFACT_NAME variable."
     fi
 
     # Trim leading/trailing spaces, and replace spaces with commas for

--- a/meta-mender-core/classes/mender-install.bbclass
+++ b/meta-mender-core/classes/mender-install.bbclass
@@ -62,6 +62,11 @@ MENDER_BOOT_PART_SIZE_MB ?= "16"
 # erase block is smaller.
 MENDER_PARTITION_ALIGNMENT_MB ?= "8"
 
+# The reserved space between the partition table and the first partition.
+# Most people don't need to set this, and it will be automatically overridden
+# in mender-uboot.bbclass.
+MENDER_STORAGE_RESERVED_RAW_SPACE ??= "0"
+
 # --------------------------- END OF CONFIGURATION -----------------------------
 
 

--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -115,9 +115,8 @@ IMAGE_CMD_sdimg() {
     # exist.
     mkdir -p "${IMAGE_ROOTFS}"
 
-    boot_env_size=$(stat -c '%s' "${DEPLOY_DIR_IMAGE}/uboot.env")
     # Round up to nearest MB.
-    boot_env_size_mb=$(expr \( $boot_env_size + 1048575 \) / 1048576)
+    boot_env_size_mb=$(expr \( ${MENDER_STORAGE_RESERVED_RAW_SPACE} + 1048575 \) / 1048576)
 
     REMAINING_SIZE=$(expr ${MENDER_STORAGE_TOTAL_SIZE_MB} - \
                           ${MENDER_BOOT_PART_SIZE_MB} - \

--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -16,17 +16,6 @@ inherit mender-install
 ########## CONFIGURATION START - you can override these default
 ##########                       values in your local.conf
 
-# Estimate how much space may be lost due to partitioning alignment. Use a
-# simple heuristic for now - 4 partitions * alignment
-def get_overhead(d):
-    align = d.getVar('MENDER_PARTITION_ALIGNMENT_MB', True)
-    if align:
-        return 4 * int(align)
-    return 0
-
-# Overhead lost due to partitioning.
-MENDER_PARTITIONING_OVERHEAD_MB ?= "${@get_overhead(d)}"
-
 python() {
     deprecated_vars = ['SDIMG_DATA_PART_DIR', 'SDIMG_DATA_PART_SIZE_MB',
                        'SDIMG_BOOT_PART_SIZE_MB', 'SDIMG_PARTITION_ALIGNMENT_MB']

--- a/meta-mender-core/classes/mender-uboot.bbclass
+++ b/meta-mender-core/classes/mender-uboot.bbclass
@@ -8,4 +8,20 @@ PACKAGECONFIG_append_pn-mender = " u-boot"
 def mender_mb2bytes(mb):
     return mb * 1024 * 1024
 
+def mender_get_env_total_aligned_size(bootenv_size, alignment_mb):
+    alignment_bytes = alignment_mb * 1024 * 1024
+    env_aligned_size = int((bootenv_size + alignment_bytes - 1) / alignment_bytes) * alignment_bytes
+
+    # Total size, original and redundant environment.
+    total_env_size = env_aligned_size * 2
+
+    return "%d" % total_env_size
+
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET ?= "${@mender_mb2bytes(${MENDER_PARTITION_ALIGNMENT_MB})}"
+
+# The total occupied length of the environment on disk, after alignment has been
+# taken into account. This is a guesstimate, and will be matched against the
+# real size in the U-Boot recipe later. Must be an *even* multiple of the
+# alignment. Most people should not need to set this, and if so, only because it
+# produces an error if left to the default.
+MENDER_STORAGE_RESERVED_RAW_SPACE ?= "${@mender_get_env_total_aligned_size(${MENDER_PARTITION_ALIGNMENT_MB}, ${MENDER_PARTITION_ALIGNMENT_MB})}"

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -18,6 +18,14 @@ SRC_URI_append = " file://0002-Integration-of-Mender-boot-code-into-U-Boot.patch
 # Generic tasks.
 ################################################################################
 do_provide_mender_defines() {
+    if [ $(expr ${MENDER_STORAGE_RESERVED_RAW_SPACE} % \( ${MENDER_PARTITION_ALIGNMENT_MB} \* 1024 \* 1024 \* 2 \)) -ne 0 ]; then
+        bbfatal "MENDER_STORAGE_RESERVED_RAW_SPACE is not an even multiple of MENDER_PARTITION_ALIGNMENT_MB."
+    fi
+
+    if [ ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} -gt ${MENDER_STORAGE_RESERVED_RAW_SPACE} ]; then
+        bbfatal "BOOTENV_SIZE (${BOOTENV_SIZE}) is too big to fit two copies inside MENDER_STORAGE_RESERVED_RAW_SPACE (${MENDER_STORAGE_RESERVED_RAW_SPACE}) with proper alignment. Please increase MENDER_STORAGE_RESERVED_RAW_SPACE manually and make sure it is an *even* multiple of MENDER_PARTITION_ALIGNMENT_MB (in bytes)."
+    fi
+
     MENDER_BOOT_PART_NUMBER=`get_part_number_from_device ${MENDER_BOOT_PART}`
     MENDER_ROOTFS_PART_A_NUMBER=`get_part_number_from_device ${MENDER_ROOTFS_PART_A}`
     MENDER_ROOTFS_PART_B_NUMBER=`get_part_number_from_device ${MENDER_ROOTFS_PART_B}`
@@ -59,15 +67,10 @@ addtask do_provide_mender_defines after do_patch before do_configure
 # Helpers and internal variables.
 ################################################################################
 
-def mender_get_env_total_aligned_size(bootenv_size, alignment_mb):
-    alignment_bytes = alignment_mb * 1024 * 1024
-    env_aligned_size = int((bootenv_size + alignment_bytes - 1) / alignment_bytes) * alignment_bytes
-
-    # Total size, original and redundant environment.
-    total_env_size = env_aligned_size * 2
-
-    return "%d" % total_env_size
-
+# This should evaluate to the same as MENDER_STORAGE_RESERVED_RAW_SPACE.
+# The only reason it's not evaluated the same way is that we don't have the
+# necessary information (BOOTENV_SIZE) when evaluating
+# MENDER_STORAGE_RESERVED_RAW_SPACE.
 MENDER_BOOTENV_TOTAL_ALIGNED_SIZE = "${@mender_get_env_total_aligned_size(${BOOTENV_SIZE}, ${MENDER_PARTITION_ALIGNMENT_MB})}"
 
 def mender_get_env_offset(start_offset, index, total_aligned_size):

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -144,3 +144,16 @@ class TestMenderArtifact:
         """Test that the mender-artifact tool validates the update successfully."""
 
         subprocess.check_call(["mender-artifact", "validate", latest_mender_image])
+
+
+    def test_artifacts_rootfs_size(self, latest_mender_image, bitbake_path, bitbake_variables):
+        """Test that the rootfs has the expected size. This relies on
+        IMAGE_ROOTFS_SIZE *not* being overridden in the build."""
+
+        output = subprocess.check_output(["mender-artifact", "read", latest_mender_image])
+
+        match = re.search("^ *size: *([0-9]+) *$", output, flags=re.MULTILINE)
+        assert(match is not None)
+        size_from_artifact = int(match.group(1))
+        size_from_build = int(bitbake_variables["MENDER_CALC_ROOTFS_SIZE"]) * 1024
+        assert(size_from_artifact == size_from_build)


### PR DESCRIPTION
This is "payload" of the PR:

```
MEN-934: Always respect storage conf when determining rootfs size.

Previously it was only being respected when building the sdimg. We
want it to be respected also when building mender updates.

For this we auto-set the standard IMAGE_ROOTFS_SIZE Yocto variable,
however it's still possible to override it by the user.
```

The rest of the commits are simply enablers for this to work.