### PR TITLE
demo: netbase: add option to specify address of Mender server

### DIFF
--- a/meta-mender-demo/recipes-core/netbase/netbase_%.bbappend
+++ b/meta-mender-demo/recipes-core/netbase/netbase_%.bbappend
@@ -1,0 +1,7 @@
+MENDER_DEMO_HOST_IP_ADDRESS ?= ""
+
+do_install_append() {
+    if [ -n "${MENDER_DEMO_HOST_IP_ADDRESS}" ]; then
+        echo "${MENDER_DEMO_HOST_IP_ADDRESS} docker.mender.io s3.docker.mender.io" >> ${D}${sysconfdir}/hosts
+    fi
+}


### PR DESCRIPTION
This will add an option so that the user can specify the Mender server
address during build time.

e.g. in local.conf:

	MENDER_DEMO_SERVER_ADDRESS = "192.168.0.100"

This is usually a manual step that the user has to perform each time a
new image is built.

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>