### PR TITLE
qemu: Rearrange memory layout to allow lower memory footprint.

### DIFF
--- a/meta-mender-qemu/recipes-bsp/u-boot/patches/0001-Enable-U-Boot-on-QEMU-to-use-Mender-boot-code.patch
+++ b/meta-mender-qemu/recipes-bsp/u-boot/patches/0001-Enable-U-Boot-on-QEMU-to-use-Mender-boot-code.patch
@@ -32,9 +32,9 @@ index a8eba31..1a234eb 100644
 +    "run qemu_boot"
 +
 +#define MENDER_QEMU_ENV_SETTINGS                                        \
-+    "qemu_kernel_addr=0x70000000\0"                                     \
++    "qemu_kernel_addr=0x60100000\0"                                     \
 +                                                                        \
-+    "qemu_dtb_addr=0x6fc00000\0"                                        \
++    "qemu_dtb_addr=0x60000000\0"                                        \
 +                                                                        \
 +    "qemu_boot=load ${mender_uboot_root} ${qemu_kernel_addr} /boot/zImage; " \
 +    "load ${mender_uboot_root} ${qemu_dtb_addr} /boot/vexpress-v2p-ca9.dtb; " \

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -45,7 +45,7 @@ RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
 QEMU_AUDIO_DRV=none \
     $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
-    -m 512M \
+    -m 64M \
     -kernel "$UBOOT_ELF" \
     -drive file="$VEXPRESS_SDIMG",if=sd,format=raw \
     -net nic,macaddr="$RANDOM_MAC" \


### PR DESCRIPTION
The memory apparently starts counting from 0x60000000. By having our
kernel and dtb files load to an address closer to that address, we can
reduce the memory needed to boot. The problem with the previous
address was that it was pointing outside of the address space if the
available memory was reduced.

Consequently, reduce the QEMU memory to 64MiB.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>