### PR TITLE
Reduce demo sdimg size to 400MiB.

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -106,15 +106,7 @@ IMAGE_CMD_sdimg() {
     # exist.
     mkdir -p "${IMAGE_ROOTFS}"
 
-    # Round up to nearest MB.
-    boot_env_size_mb=$(expr \( ${MENDER_STORAGE_RESERVED_RAW_SPACE} + 1048575 \) / 1048576)
-
-    REMAINING_SIZE=$(expr ${MENDER_STORAGE_TOTAL_SIZE_MB} - \
-                          ${MENDER_BOOT_PART_SIZE_MB} - \
-                          ${MENDER_DATA_PART_SIZE_MB} - \
-                          ${MENDER_PARTITIONING_OVERHEAD_MB} - \
-                          $boot_env_size_mb)
-    CALC_ROOTFS_SIZE=$(expr $REMAINING_SIZE / 2)
+    MENDER_CALC_ROOTFS_SIZE_KB=$(expr ${MENDER_CALC_ROOTFS_SIZE} / 1024)
 
     MENDER_PARTITION_ALIGNMENT_KB=$(expr ${MENDER_PARTITION_ALIGNMENT_MB} \* 1024)
 
@@ -163,8 +155,8 @@ EOF
 
     cat >> "$wks" <<EOF
 part /boot   --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --align $MENDER_PARTITION_ALIGNMENT_KB --active --fixed-size ${MENDER_BOOT_PART_SIZE_MB}
-part /       --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label primary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size $CALC_ROOTFS_SIZE
-part         --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label secondary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size $CALC_ROOTFS_SIZE
+part /       --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label primary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size $MENDER_CALC_ROOTFS_SIZE_KB
+part         --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label secondary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size $MENDER_CALC_ROOTFS_SIZE_KB
 part /data   --source fsimage --sourceparams=file="${WORKDIR}/data.$FSTYPE" --ondisk mmcblk0 --fstype=$FSTYPE --label data --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size ${MENDER_DATA_PART_SIZE_MB}
 EOF
 

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -11,3 +11,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "mender-demo"
 BBFILE_PATTERN_mender-demo = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender-demo = "6"
+
+MENDER_STORAGE_TOTAL_SIZE_MB ?= "400"
+IMAGE_OVERHEAD_FACTOR = "1.0"


### PR DESCRIPTION
Generally it's all that's needed, and this will reduce testing times
considerably because there will be much less writing.

At the time of writing, the rootfs fills about 94MiB, so if you double
that for the dual rootfs and add 100MiB+ for the other partitions,
400MiB seems like a sane default.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>