### PR TITLE
MEN-927: Lock mender to Go version 1.7.

### DIFF
--- a/meta-mender-core/classes/mender-install.bbclass
+++ b/meta-mender-core/classes/mender-install.bbclass
@@ -60,7 +60,8 @@ MENDER_STORAGE_RESERVED_RAW_SPACE ??= "0"
 # --------------------------- END OF CONFIGURATION -----------------------------
 
 
-PREFERRED_VERSION_go_cross = "1.6%"
+PREFERRED_VERSION_go-cross-arm ?= "1.7.%"
+PREFERRED_VERSION_go-native ?= "1.7.%"
 
 IMAGE_INSTALL_append = " \
     mender \

--- a/meta-mender-core/conf/layer.conf
+++ b/meta-mender-core/conf/layer.conf
@@ -11,3 +11,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "mender"
 BBFILE_PATTERN_mender = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender = "6"
+
+LAYERDEPENDS_mender = "go"


### PR DESCRIPTION
```
commit a3d1d47aa73d0fd9fe31b5deca5b6d0e3ae8ede8
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Thu Jan 26 12:40:16 2017

    MEN-927: Lock mender to Go version 1.7.
    
    Not locking to the current 1.7.4, because the upstream Go layer does
    not keep old patch versions around, and getting latest patch version
    anyway seems like a good idea.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit c9b4e966920246698e2da04b0f07a6df6c5d4470
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Thu Jan 26 12:27:53 2017

    Add layer dependency to go layer.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```