### PR TITLE
m-artifact: Support automatic version by using Makefile.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.bb
@@ -28,11 +28,11 @@ do_compile() {
     install -d ${GOPATHDIR}
     # we could also try symlinking ${S} into our fake GOPATH, however `go build...`
     # ignores symlinks in GOPATH
-    rsync -av --exclude '.git' --delete ${S}/ ${GOPATHDIR}/
+    rsync -av --delete ${S}/ ${GOPATHDIR}/
 
     GOPATH=${B}:${STAGING_LIBDIR}/${TARGET_SYS}/go go env
     if test -n "${GO_INSTALL}" ; then
-       GOPATH=${B}:${STAGING_LIBDIR}/${TARGET_SYS}/go go install -v ${GO_INSTALL}
+       GOPATH=${B}:${STAGING_LIBDIR}/${TARGET_SYS}/go make -C ${GOPATHDIR} V=1 install
     fi
 }
 


### PR DESCRIPTION
We also need to transfer the .git directory to the build folder
because the Makefile needs it to figure out the version.

Fixes MEN-897.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>