### PR TITLE
Clean up rootfs size usage in mender-sdimg.bbclass.

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -106,8 +106,6 @@ IMAGE_CMD_sdimg() {
     # exist.
     mkdir -p "${IMAGE_ROOTFS}"
 
-    MENDER_CALC_ROOTFS_SIZE_KB=$(expr ${MENDER_CALC_ROOTFS_SIZE} / 1024)
-
     MENDER_PARTITION_ALIGNMENT_KB=$(expr ${MENDER_PARTITION_ALIGNMENT_MB} \* 1024)
 
     rm -rf "${WORKDIR}/data" || true
@@ -155,8 +153,8 @@ EOF
 
     cat >> "$wks" <<EOF
 part /boot   --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --align $MENDER_PARTITION_ALIGNMENT_KB --active --fixed-size ${MENDER_BOOT_PART_SIZE_MB}
-part /       --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label primary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size $MENDER_CALC_ROOTFS_SIZE_KB
-part         --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label secondary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size $MENDER_CALC_ROOTFS_SIZE_KB
+part /       --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label primary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k
+part         --source rootfs --ondisk mmcblk0 --fstype=$FSTYPE --label secondary --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k
 part /data   --source fsimage --sourceparams=file="${WORKDIR}/data.$FSTYPE" --ondisk mmcblk0 --fstype=$FSTYPE --label data --align $MENDER_PARTITION_ALIGNMENT_KB --fixed-size ${MENDER_DATA_PART_SIZE_MB}
 EOF
 


### PR DESCRIPTION
Use kilobytes directly, since it is the unit of
MENDER_CALC_ROOTFS_SIZE.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>