### PR TITLE
Add: Build time check for u-boot environment size

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
@@ -66,6 +66,10 @@ index 0000000..043f97d
 +# error CONFIG_ENV_OFFSET_REDUND should not be defined explicitly (will be auto-configured).
 +#endif
 +
++#if CONFIG_ENV_SIZE_REDUND != CONFIG_ENV_SIZE
++# error CONFIG_ENV_SIZE_REDUND must be explicitly set and must be equal to CONFIG_ENV_SIZE.
++#endif
++
 +#if MENDER_BOOTENV_SIZE != CONFIG_ENV_SIZE
 +# error 'CONFIG_ENV_SIZE' define must be equal to bitbake variable 'BOOTENV_SIZE' set in U-Boot build recipe.
 +#endif


### PR DESCRIPTION
In the [u-boot git repo](http://git.denx.de/?p=u-boot.git;a=blob;f=README;h=3174b18d9a894737bccd47c0aaa1943ed4c974bb;hb=8537ddd769f460d7fb7a62a3dcc9669049702e51#l4133) (u-boot v2017.03 prepare) in the `CONFIG_ENV_IS_IN_MMC` section (and the `CONFIG_ENV_IS_IN_FLASH` section) it is stated that  `CONFIG_ENV_SIZE_REDUND` needs to be explicitly set to the same value as `CONFIG_ENV_SIZE` in addition to `CONFIG_ENV_OFFSET_REDUND`.

Relevant for backward compatibility to the oldest u-boot version v2014.07 supported by Mender: The need for an explicitly setting of CONFIG_ENV_SIZE_REDUND is mentioned in its [README](http://git.denx.de/?p=u-boot.git;a=blob;f=README;h=4ac73996983add08d11a15875fa203a5f8fd3393;hb=524123a70761110c5cf3ccc5f52f6d4da071b959#l4292) as well.