### PR TITLE
add missing expand argument to getVar

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -8,7 +8,7 @@ SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;br
 # network probing during parsing if we are not gonna build the git version
 # anyway. If git version is enabled, the AUTOREV will be chosen instead of the
 # SHA.
-SRCREV ?= '${@oe.utils.ifelse("git" in d.getVar("PREFERRED_VERSION_${PN}"), "${AUTOREV}", "77326b288c70cd713e7ad15d2a084b6ee797e8ff")}'
+SRCREV ?= '${@oe.utils.ifelse("git" in d.getVar("PREFERRED_VERSION_${PN}",True), "${AUTOREV}", "77326b288c70cd713e7ad15d2a084b6ee797e8ff")}'
 PV = "${MENDER_ARTIFACT_BRANCH}-git${SRCPV}"
 
 LICENSE = "Apache-2.0"

--- a/meta-mender-core/recipes-mender/mender/mender_git.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_git.bb
@@ -8,7 +8,7 @@ SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=${MENDER
 # network probing during parsing if we are not gonna build the git version
 # anyway. If git version is enabled, the AUTOREV will be chosen instead of the
 # SHA.
-SRCREV ?= '${@oe.utils.ifelse("git" in d.getVar("PREFERRED_VERSION_mender"), "${AUTOREV}", "f6ffa190892202263fdb75975059fbb201adab6a")}'
+SRCREV ?= '${@oe.utils.ifelse("git" in d.getVar("PREFERRED_VERSION_mender",True), "${AUTOREV}", "f6ffa190892202263fdb75975059fbb201adab6a")}'
 PV = "${MENDER_BRANCH}-git${SRCPV}"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including


### PR DESCRIPTION
This fixes an expansion error during parsing of mender_git and
mender-artifact_git recipes.

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>