### PR TITLE
Remove go layer depends, since Yocto ships with Go support now.

### DIFF
--- a/meta-mender-core/classes/mender-install.bbclass
+++ b/meta-mender-core/classes/mender-install.bbclass
@@ -78,9 +78,6 @@ python() {
         bb.fatal("MENDER_PARTITION_ALIGNMENT_MB is deprecated. Please define MENDER_PARTITION_ALIGNMENT_KB instead.")
 }
 
-PREFERRED_VERSION_go-cross-arm ?= "1.7.%"
-PREFERRED_VERSION_go-native ?= "1.7.%"
-
 PREFERRED_VERSION_mender ?= "1.0.%"
 PREFERRED_VERSION_mender-artifact ?= "1.0.%"
 PREFERRED_VERSION_mender-artifact-native ?= "1.0.%"

--- a/meta-mender-core/conf/layer.conf
+++ b/meta-mender-core/conf/layer.conf
@@ -11,5 +11,3 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "mender"
 BBFILE_PATTERN_mender = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender = "6"
-
-LAYERDEPENDS_mender = "go"

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -372,7 +372,7 @@ def bitbake_path_string():
 
     bb_testing_variables = get_bitbake_variables("mender-test-dependencies")
 
-    return bb_testing_variables['PATH']
+    return bb_testing_variables['PATH'] + ":" + os.environ['PATH']
 
 @pytest.fixture(scope="function")
 def bitbake_path(request, bitbake_path_string):


### PR DESCRIPTION
Also remove dependence on specific version, we now follow the latest
one in Yocto instead.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>