### PR TITLE
meta-mender-qemu: use alpine:3.4 as base for dockerized client VM

### DIFF
--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -1,10 +1,9 @@
-FROM ubuntu:trusty
+FROM alpine:3.4
 
-# Install QEMU/KVM
-RUN apt-get -y update && \
-    apt-get -y upgrade && \
-    apt-get -y install qemu-kvm qemu-system-arm && \
-    rm -rf /var/lib/apt/lists/*
+# Install QEMU
+RUN apk update && apk upgrade && \
+    apk add qemu-system-arm bash && \
+    rm -rf /var/cache/apk/*
 
 # Use: --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg
 # --build-arg UBOOT_ELF=u-boot.elf when building


### PR DESCRIPTION
This shaves off ~200MB from the image size:

```
sh-4.3$ docker images |grep mender- 
mender-alpine-bash       latest              44aec2f4dab6        3 minutes ago       438.7 MB
mender-ubuntu-arm-bash   latest              1a0ae211dbc9        6 minutes ago       656.2 MB
```

@kacf @GregorioDiStefano 