### PR TITLE
fstab: fix support for SD card supported BSPs

### DIFF
--- a/meta-mender-core/recipes-core/base-files/base-files/fstab
+++ b/meta-mender-core/recipes-core/base-files/base-files/fstab
@@ -5,5 +5,5 @@ tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,stri
 tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 # Where the U-Boot environment resides; for devices with SD card support ONLY!
-@MENDER_BOOT_PART@   /uboot               auto       defaults,sync,auto    0  0
-@MENDER_DATA_PART@   /data                auto       defaults,auto         0  0
+@MENDER_BOOT_PART@   /uboot               auto       defaults,sync    0  0
+@MENDER_DATA_PART@   /data                auto       defaults         0  0


### PR DESCRIPTION
defaults settings in fstab already include auto.
Remove redundant auto flag as it will fail auto
mounting during boot.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>