### PR TITLE
mender: Make mender wait till network configuration is done

### DIFF
--- a/meta-mender-core/recipes-mender/mender/files/mender.service
+++ b/meta-mender-core/recipes-mender/mender/files/mender.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mender OTA update service
 After=systemd-resolved.service
+Wants=network-online.target
 
 [Service]
 Type=idle


### PR DESCRIPTION
Add Wants=network-online.target to the service file to make
mender wait for the network to be up, otherwise it might fail.

Changelog: Title

Signed-off-by: Moritz Fischer <moritz.fischer@ettus.com>