### PR TITLE
MENDER_DATA_PART_DIR: copy files with rsync

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -110,7 +110,7 @@ IMAGE_CMD_sdimg() {
     mkdir -p "${WORKDIR}/data"
 
     if [ -n "${MENDER_DATA_PART_DIR}" ]; then
-        find "${MENDER_DATA_PART_DIR}" -not -name . -exec cp -a '{}' "${WORKDIR}/data" \;
+        rsync -a ${MENDER_DATA_PART_DIR}/* "${WORKDIR}/data"
     fi
 
     if [ -f "${DEPLOY_DIR_IMAGE}/data.tar" ]; then


### PR DESCRIPTION
The MENDER_DATA_PART_DIR variable is not documented, but seems intended to enable preloading the data partition with the contents of a directory. The current implementation recursively copies the directory and its contents, resulting in several copies of the files. 

This change uses rsync to copy the contents of the directory so the contents of the directory pointed to by MENDER_DATA_PART_DIR get copied to the data partition once as expected. 