### PR TITLE
Work around DNS not working in upstream poky pyro and master.

### DIFF
--- a/meta-mender-demo/recipes-core/volatile-binds/volatile-binds.bbappend
+++ b/meta-mender-demo/recipes-core/volatile-binds/volatile-binds.bbappend
@@ -1,0 +1,10 @@
+do_install_append() {
+    # Work around problem that /etc/resolv.conf is not created. Introduced by
+    # commit fcd48092d7bca in poky.
+
+    # If this test fails it's probably a sign that this workaround should be
+    # removed.
+    test -h ${D}${sysconfdir}/tmpfiles.d/etc.conf
+
+    rm -f ${D}${sysconfdir}/tmpfiles.d/etc.conf
+}


### PR DESCRIPTION
It was caused by commit fcd48092d7bca, and this just partially
restores the old behavior.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>