### PR TITLE
QEMU: Add ability to configure certain client values before launching

### DIFF
--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -1,14 +1,28 @@
+# Usage of Docker image.
+#
+# While building:
+# --build-arg VEXPRESS_IMAGE=<sdimg>
+#       sdimg image to add to the Docker image
+# --build-arg UBOOT_ELF=<u-boot.elf>
+#       U-Boot ELF image to add to Docker image.
+#
+# While launching:
+# -v $BUILDDIR:/mnt/build:ro
+#       Use BUILDDIR from a poky build as image input.
+# -v <config-dir>:/mnt/config:ro
+#       Use server.crt from config-dir, if it exists.
+# -e SERVER_URL=https://whatever.mender.io
+#       Use SERVER_URL as server address for client.
+# -e TENANT_TOKEN=<token>
+#       Use token as tenant token for client.
+
 FROM alpine:3.4
 
 # Install QEMU
 RUN apk update && apk upgrade && \
-    apk add qemu-system-arm bash && \
+    apk add qemu-system-arm bash e2fsprogs-extra python3 && \
     rm -rf /var/cache/apk/*
 
-# Use: --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg
-# --build-arg UBOOT_ELF=u-boot.elf when building
-# Or use "docker run -v $BUILDDIR:/mnt/build" to get build artifacts from local
-# hard drive.
 ARG VEXPRESS_IMAGE=scripts/docker/empty-file
 ARG UBOOT_ELF=scripts/docker/empty-file
 
@@ -17,6 +31,7 @@ ADD $VEXPRESS_IMAGE ./core-image-full-cmdline-vexpress-qemu.sdimg
 
 ADD scripts/mender-qemu ./
 ADD scripts/docker/entrypoint.sh ./
+ADD scripts/docker/setup-mender-configuration.py ./
 
 # Delete images if they are empty. This is to save space if the artifacts are
 # mounted on /mnt/build instead.

--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -9,4 +9,12 @@ if [ -e /mnt/build/tmp/deploy/images/vexpress-qemu/u-boot.elf ]; then
     cp /mnt/build/tmp/deploy/images/vexpress-qemu/u-boot.elf .
 fi
 
+CONFIG_ARGS=
+
+if [ -f /mnt/config/server.crt ]; then
+    CONFIG_ARGS="$CONFIG_ARGS --server-crt=/mnt/config/server.crt"
+fi
+
+./setup-mender-configuration.py --sdimg=core-image-full-cmdline-vexpress-qemu.sdimg --server-url=$SERVER_URL --tenant-token=$TENANT_TOKEN $CONFIG_ARGS
+
 QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_SDIMG="core-image-full-cmdline-vexpress-qemu.sdimg" UBOOT_ELF="u-boot.elf" ./mender-qemu $*

--- a/meta-mender-qemu/scripts/docker/setup-mender-configuration.py
+++ b/meta-mender-qemu/scripts/docker/setup-mender-configuration.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+
+def get(remote_path, local_path, rootfs):
+    subprocess.check_call(["debugfs", "-R", "dump -p %s %s" % (remote_path, local_path), rootfs],
+                          stderr=subprocess.STDOUT)
+
+def put(local_path, remote_path, rootfs):
+    proc = subprocess.Popen(["debugfs", "-w", rootfs], stdin=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+    proc.stdin.write(("cd %s\n" % os.path.dirname(remote_path)).encode())
+    proc.stdin.write(("rm %s\n" % os.path.basename(remote_path)).encode())
+    proc.stdin.write(("write %s %s\n" % (local_path, os.path.basename(remote_path))).encode())
+    proc.stdin.close()
+    ret = proc.wait()
+    assert ret == 0
+
+def extract_ext4(sdimg, rootfs):
+    return manipulate_ext4(sdimg=sdimg, rootfs=rootfs, write=False)
+
+def insert_ext4(sdimg, rootfs):
+    return manipulate_ext4(sdimg=sdimg, rootfs=rootfs, write=True)
+
+def manipulate_ext4(sdimg, rootfs, write):
+    output = subprocess.check_output(["fdisk", "-ul", sdimg])
+    for line in output.decode().split('\n'):
+        columns = line.split()
+        if len(columns) < 3:
+            continue
+        # This blindly assumes that rootfs is on partition 2.
+        if columns[0] == ("%s2" % sdimg):
+            if write:
+                subprocess.check_call(["dd", "if=%s" % rootfs, "of=%s" % sdimg,
+                                       "seek=%s" % columns[1],
+                                       "count=%d" % (int(columns[2]) - int(columns[1]) + 1),
+                                       "conv=notrunc"],
+                                      stderr=subprocess.STDOUT)
+            else:
+                subprocess.check_call(["dd", "if=%s" % sdimg, "of=%s" % rootfs,
+                                       "skip=%s" % columns[1],
+                                       "count=%d" % (int(columns[2]) - int(columns[1]) + 1)],
+                                      stderr=subprocess.STDOUT)
+            break
+    else:
+        raise Exception("%s not found in fdisk output: %s" % (sdimg, output))
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sdimg", help="Sdimg to modify")
+    parser.add_argument("--tenant-token", help="tenant token to use by client")
+    parser.add_argument("--server-crt", help="server.crt file to put in image")
+    parser.add_argument("--server-url", help="Server address to put in configuration")
+    args = parser.parse_args()
+
+    if not (args.tenant_token or args.server_crt or args.server_url):
+        return
+
+    # Extract ext4 image from sdimg.
+    assert args.sdimg, "--sdimg needs to be supplied"
+    rootfs = "%s.ext4" % args.sdimg
+    extract_ext4(sdimg=args.sdimg, rootfs=rootfs)
+
+    if args.tenant_token:
+        with open("tenant.conf", "w") as fd:
+            fd.write("%s\n" % args.tenant_token)
+        put(local_path="tenant.conf",
+            remote_path="/etc/mender/tenant.conf",
+            rootfs=rootfs)
+        os.unlink("tenant.conf")
+
+    if args.server_crt:
+        put(local_path=args.server_crt,
+            remote_path="/etc/mender/server.crt",
+            rootfs=rootfs)
+
+    if args.server_url:
+        get(local_path="mender.conf",
+            remote_path="/etc/mender/mender.conf",
+            rootfs=rootfs)
+        with open("mender.conf") as fd:
+            conf = json.load(fd)
+        conf['ServerURL'] = args.server_url
+        with open("mender.conf", "w") as fd:
+            json.dump(conf, fd, indent=4, sort_keys=True)
+        put(local_path="mender.conf",
+            remote_path="/etc/mender/mender.conf",
+            rootfs=rootfs)
+        os.unlink("mender.conf")
+
+    # Put back ext4 image into sdimg.
+    insert_ext4(sdimg=args.sdimg, rootfs=rootfs)
+    os.unlink(rootfs)
+
+main()

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -39,7 +39,7 @@ fi
 
 UBOOT_ELF=${UBOOT_ELF:-"${BUILDTMP}/deploy/images/vexpress-qemu/u-boot.elf"}
 VEXPRESS_SDIMG=${VEXPRESS_SDIMG:-"${BUILDTMP}/deploy/images/vexpress-qemu/${IMAGE_NAME}-vexpress-qemu.sdimg"}
-QEMU_SYSTEM_ARM=${QEMU_SYSTEM_ARM:-"${BUILDTMP}/sysroots/x86_64-linux/usr/bin/qemu-system-arm"}
+QEMU_SYSTEM_ARM=${QEMU_SYSTEM_ARM:-"qemu-system-arm"}
 RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
 
 QEMU_AUDIO_DRV=none \


### PR DESCRIPTION
* SERVER_URL environment variable can be passed in while launching
* tenant.conf and server.crt can be passed in by mounting a volume
  containing those files on /mnt/config.

More info in the Dockerfile for QEMU.

MEN-1207

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>