### PR TITLE
MEN-1014: Add mender-state-scripts class and example.

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -37,18 +37,22 @@ IMAGE_CMD_mender () {
         bberror "MENDER_DEVICE_TYPES_COMPATIBLE variable cannot be empty."
     fi
 
+    extra_args=
+
     if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then
-        signing_args="-k ${MENDER_ARTIFACT_SIGNING_KEY}"
-    else
-        signing_args=
+        extra_args="$extra_args -k ${MENDER_ARTIFACT_SIGNING_KEY}"
+    fi
+
+    if [ -d "${DEPLOY_DIR_IMAGE}/mender-state-scripts" ]; then
+        extra_args="$extra_args -s ${DEPLOY_DIR_IMAGE}/mender-state-scripts"
     fi
 
     mender-artifact write rootfs-image \
         -n ${MENDER_ARTIFACT_NAME} -t "$devs_compatible" \
-        $signing_args \
+        $extra_args \
         -u ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${ARTIFACTIMG_FSTYPE} \
         ${MENDER_ARTIFACT_EXTRA_ARGS} \
-        -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender \
+        -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender
 }
 
 IMAGE_CMD_mender[vardepsexclude] += "IMAGE_ID"

--- a/meta-mender-core/classes/mender-state-scripts.bbclass
+++ b/meta-mender-core/classes/mender-state-scripts.bbclass
@@ -1,0 +1,85 @@
+inherit deploy
+
+MENDER_STATE_SCRIPTS_DIR = "${B}/mender-state-scripts"
+
+# Default is to look in these two directories for scripts.
+MENDER_STATE_SCRIPTS ?= "${S}/mender-state-scripts ${MENDER_STATE_SCRIPTS_DIR}"
+
+do_create_default_script_dirs() {
+    # Doing this automatically has two advantages: The user can install directly
+    # into the directories with no preparation. And, we can complain if any of
+    # the targets in MENDER_STATE_SCRIPTS doesn't exist, because a directory
+    # that exists, but is empty, is different from not existing at all.
+
+    mkdir -p ${S}/mender-state-scripts ${B}/mender-state-scripts
+}
+addtask do_create_default_script_dirs after do_patch before do_configure
+
+# Takes one argument, which is "install" or "deploy".
+install_or_deploy_scripts() {
+    case "$1" in
+        install|deploy)
+            ;;
+        *)
+            bbfatal "Internal error: Argument is not install or deploy"
+            ;;
+    esac
+    action=$1
+
+    for entry in ${MENDER_STATE_SCRIPTS}; do
+        if [ ! -e "$entry" ]; then
+            bbfatal "$entry from MENDER_STATE_SCRIPTS does not exist"
+        fi
+    done
+
+    # Use "sort -u" below to get rid of duplicates which can often happen if
+    # ${B} and ${S} are the same.
+    for script in $(find ${MENDER_STATE_SCRIPTS} -type f | sort -u); do
+        case "$(basename "$script")" in
+            Artifact*)
+                if [ $action = install ]; then
+                    # Ignore Artifact scripts for install action, since they
+                    # don't go to the rootfs.
+                    continue
+                fi
+
+                # Artifact scripts should be in the .mender file and go
+                # to the deploy section.
+                install -d -m 755 ${DEPLOYDIR}/mender-state-scripts/
+                install -m 755 "$script" ${DEPLOYDIR}/mender-state-scripts/
+                ;;
+            *)
+                if [ $action = deploy ]; then
+                    # Non Artifact scripts go to rootfs, so ignore for
+                    # deploy action.
+                    continue
+                fi
+
+                # Non-Artifact scripts should be installed in rootfs.
+                case "$(basename "$script")" in
+                    Idle*|Sync*|Download*)
+                        ;;
+                    *)
+                        bbfatal "$script script doesn't have a valid name."
+                        ;;
+                esac
+                install -d -m 755 ${D}${sysconfdir}/mender/scripts/
+                install -m 755 "$script" ${D}${sysconfdir}/mender/scripts/
+                ;;
+        esac
+    done
+}
+
+do_install_append() {
+    install_or_deploy_scripts install
+}
+
+# Provide default, empty do_deploy.
+do_deploy() {
+}
+addtask do_deploy after do_compile
+
+# Add our own deploy steps.
+do_deploy_append() {
+    install_or_deploy_scripts deploy
+}

--- a/meta-mender-demo/recipes-mender/example-state-scripts/example-state-scripts_1.0.bb
+++ b/meta-mender-demo/recipes-mender/example-state-scripts/example-state-scripts_1.0.bb
@@ -1,0 +1,20 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI = "file://example-script;subdir=${PN}-${PV} \
+          file://LICENSE;subdir=${PN}-${PV} \
+          "
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
+
+inherit mender-state-scripts
+
+do_compile() {
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/Idle_Enter_00
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/Sync_Enter_10
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/Sync_Leave_90
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Enter_00
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_99
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactReboot_Leave_50
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_50
+}

--- a/meta-mender-demo/recipes-mender/example-state-scripts/files/LICENSE
+++ b/meta-mender-demo/recipes-mender/example-state-scripts/files/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/meta-mender-demo/recipes-mender/example-state-scripts/files/example-script
+++ b/meta-mender-demo/recipes-mender/example-state-scripts/files/example-script
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$(basename "$0") was called!"

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -127,3 +127,82 @@ class TestBuild:
 
         finally:
             os.remove("artifact-verify-key.pem")
+
+    def test_state_scripts(self, prepared_test_build, bitbake_variables, bitbake_path, latest_rootfs, latest_mender_image):
+        """Test that state scripts that are specified in the build are included
+        correctly."""
+
+        # First verify that the base build does *not* contain any state scripts.
+        # Check rootfs.
+        output = subprocess.check_output(["debugfs", "-R", "ls -p /etc/mender", latest_rootfs])
+        for line in output.split('\n'):
+            if len(line) == 0:
+                continue
+
+            entry = line.split('/')
+            if entry[5] == "scripts":
+                # The scripts directory exists. That is fine in itself, but it
+                # should be empty.
+                output = subprocess.check_output(["debugfs", "-R", "ls -p /etc/mender/scripts", latest_rootfs])
+                for line in output.split('\n'):
+                    if len(line) == 0:
+                        continue
+
+                    entry = line.split('/')
+                    assert entry[5] == "." or entry[5] == "..", "There should be no file in /etc/mender/scripts"
+                break
+
+        # Check artifact.
+        output = subprocess.check_output("tar xOf %s header.tar.gz| tar tz"
+                                         % latest_mender_image, shell=True)
+        for line in output.strip().split('\n'):
+            if line == "scripts":
+                output = subprocess.check_output("tar xOf %s header.tar.gz| tar tz scripts"
+                                                 % latest_mender_image, shell=True)
+                assert len(output.strip()) == 0, "Unexpected scripts in base image: %s" % output
+
+        # Alright, now build a new image containing scripts.
+        add_to_local_conf(prepared_test_build, 'IMAGE_INSTALL_append = " example-state-scripts"')
+        run_bitbake(prepared_test_build)
+
+        found_rootfs_scripts = {
+            "Idle_Enter_00": False,
+            "Sync_Enter_10": False,
+            "Sync_Leave_90": False,
+        }
+        found_artifact_scripts = {
+            "ArtifactInstall_Enter_00": False,
+            "ArtifactInstall_Leave_99": False,
+            "ArtifactReboot_Leave_50": False,
+            "ArtifactCommit_Enter_50": False,
+        }
+
+        # Check new rootfs.
+        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], ".ext[234]")
+        output = subprocess.check_output(["debugfs", "-R", "ls -p /etc/mender/scripts", built_rootfs])
+        for line in output.split('\n'):
+            if len(line) == 0:
+                continue
+
+            entry = line.split('/')
+
+            if entry[5] == "." or entry[5] == "..":
+                continue
+
+            assert found_rootfs_scripts.get(entry[5]) is not None, "Unexpected script in rootfs %s" % entry[5]
+            found_rootfs_scripts[entry[5]] = True
+
+        for script in found_rootfs_scripts:
+            assert found_rootfs_scripts[script], "%s not found in rootfs script list" % script
+
+        # Check new artifact.
+        built_mender_image = latest_build_artifact(prepared_test_build['build_dir'], ".mender")
+        output = subprocess.check_output("tar xOf %s header.tar.gz| tar tz scripts"
+                                         % built_mender_image, shell=True)
+        for line in output.strip().split('\n'):
+            script = os.path.basename(line)
+            assert found_artifact_scripts.get(script) is not None, "Unexpected script in image: %s" % script
+            found_artifact_scripts[script] = True
+
+        for script in found_artifact_scripts:
+            assert found_artifact_scripts[script], "%s not found in artifact script list" % script


### PR DESCRIPTION
The new mender-state-scripts class can be used in a recipe to turn
that recipe into a state script recipe. Any script or binary that the
recipe provides using the class will become part of the Mender update
as a state script.

There are several ways to include them:

* Put the script/binary in ${MENDER_STATE_SCRIPTS_DIR} during the
  do_compile stage.

* Put an archive in SRC_URI that extracts to
  ${PN}-${PV}/mender-state-scripts, where ${PN}-${PV} are the recipe
  name and version.

* Set the variable MENDER_STATE_SCRIPTS manually to a directory that
  contains the scripts.

Note that the three methods should not be mixed.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>