### PR TITLE
Fix sdimg being generated outside of sstate mechanism.

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -171,7 +171,7 @@ EOF
     echo "### End of contents of wks file ###"
 
     # Call WIC
-    outimgname="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.sdimg"
+    outimgname="${IMGDEPLOYDIR}/${IMAGE_NAME}.sdimg"
     wicout="${IMGDEPLOYDIR}/${IMAGE_NAME}-sdimg"
     BUILDDIR="${TOPDIR}" wic create "$wks" --vars "${STAGING_DIR_TARGET}/imgdata/" -e "${IMAGE_BASENAME}" -o "$wicout/" ${WIC_CREATE_EXTRA_ARGS}
     mv "$wicout/build/$(basename "${wks%.wks}")"*.direct "$outimgname"


### PR DESCRIPTION
Changelog: Fix a bug which caused sdimg generation to bypass the
sstate mechanism. This could lead to broken builds in some corner
cases, and it also means that sdimg images would never be cleaned up.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
(cherry picked from commit 17ec891446942303c7ae37a31b224dae7dc41669, master pull request #309)