### PR TITLE
qemu raw flash

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
@@ -40,8 +40,8 @@ index 0000000..043f97d
 +
 +#include <config_mender_defines.h>
 +
-+#if !defined(CONFIG_ENV_IS_IN_MMC) && !defined(CONFIG_ENV_IS_IN_NAND)
-+# error CONFIG_ENV_IS_IN_MMC or CONFIG_ENV_IS_IN_NAND is required for Mender to work
++#if !defined(CONFIG_ENV_IS_IN_MMC) && !defined(CONFIG_ENV_IS_IN_NAND) && !defined(CONFIG_ENV_IS_IN_FLASH)
++# error CONFIG_ENV_IS_IN_MMC, CONFIG_ENV_IS_IN_NAND or CONFIG_ENV_IS_IN_FLASH is required for Mender to work
 +#endif
 +
 +#ifndef CONFIG_BOOTCOUNT_LIMIT

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
@@ -11,14 +11,18 @@ do_compile_append() {
                 "MENDER_PARTITION_ALIGNMENT_KB"
     fi
 
-    # fw-utils seem to only be able to handle hex values.
-    HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
+    if [ ! -e ${WORKDIR}/fw_env.config.default ]; then
+        # fw-utils seem to only be able to handle hex values.
+        HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
 
-    # create fw_env.config file
-    cat > ${WORKDIR}/fw_env.config <<EOF
+        # create fw_env.config file
+        cat > ${WORKDIR}/fw_env.config <<EOF
 ${MENDER_STORAGE_DEVICE} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
 ${MENDER_STORAGE_DEVICE} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
 EOF
+    else
+        cp ${WORKDIR}/fw_env.config.default ${WORKDIR}/fw_env.config
+    fi
 }
 
 do_install_append() {

--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -20,7 +20,8 @@ FROM alpine:3.4
 
 # Install QEMU
 RUN apk update && apk upgrade && \
-    apk add qemu-system-arm bash e2fsprogs-extra python3 && \
+    apk add qemu-system-arm util-linux \
+            bash e2fsprogs-extra python3 && \
     rm -rf /var/cache/apk/*
 
 ARG VEXPRESS_IMAGE=scripts/docker/empty-file

--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -1,8 +1,8 @@
 # Usage of Docker image.
 #
 # While building:
-# --build-arg VEXPRESS_IMAGE=<sdimg>
-#       sdimg image to add to the Docker image
+# --build-arg VEXPRESS_IMAGE=<sdimg|vexpress-nor>
+#       image to add to the Docker image
 # --build-arg UBOOT_ELF=<u-boot.elf>
 #       U-Boot ELF image to add to Docker image.
 #
@@ -27,8 +27,8 @@ RUN apk update && apk upgrade && \
 ARG VEXPRESS_IMAGE=scripts/docker/empty-file
 ARG UBOOT_ELF=scripts/docker/empty-file
 
-ADD $UBOOT_ELF ./u-boot.elf
-ADD $VEXPRESS_IMAGE ./core-image-full-cmdline-vexpress-qemu.sdimg
+COPY $UBOOT_ELF ./u-boot.elf
+COPY $VEXPRESS_IMAGE .
 
 ADD scripts/mender-qemu ./
 ADD scripts/docker/entrypoint.sh ./
@@ -37,6 +37,7 @@ ADD scripts/docker/setup-mender-configuration.py ./
 # Delete images if they are empty. This is to save space if the artifacts are
 # mounted on /mnt/build instead.
 RUN if [ `stat -c %s core-image-full-cmdline-vexpress-qemu.sdimg` -eq 0 ]; then rm -f core-image-full-cmdline-vexpress-qemu.sdimg; fi
+RUN if [ `stat -c %s core-image-full-cmdline-vexpress-qemu.vexpress-nor` -eq 0 ]; then rm -f core-image-full-cmdline-vexpress-qemu.vexpress-nor; fi
 RUN if [ `stat -c %s u-boot.elf` -eq 0 ]; then rm -f u-boot.elf; fi
 
 RUN chmod +x entrypoint.sh mender-qemu

--- a/meta-mender-qemu/classes/vexpress-nor_image.bbclass
+++ b/meta-mender-qemu/classes/vexpress-nor_image.bbclass
@@ -1,0 +1,33 @@
+inherit image_types
+
+NORIMG = "${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.vexpress-nor"
+
+# we need ubimg to be present
+IMAGE_TYPEDEP_vexpress-nor = "ubimg"
+
+IMAGE_CMD_vexpress-nor() {
+
+    # MTD partitioning has the following layout:
+    # 1m(u-boot)ro,
+    # 1m(u-boot-env)ro,
+    # -(ubi)
+
+    # create a single NOR file image, fill with 0xff (empty) pattern
+    dd if=/dev/zero bs=1M count=128 | tr '\000' '\377' > ${WORKDIR}/nor-full
+
+    ubimgfile=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ubimg
+
+    # ubi image starts at 2MB offset and must be smaller than 126MB
+    imgsize=$(stat -c '%s' -L ${ubimgfile})
+    if [ "$imgsize" -gt 132120576 ]; then
+        bbfatal "image too large"
+        exit 1
+    fi
+
+    dd if=${ubimgfile} of=${WORKDIR}/nor-full bs=1M seek=2 conv=notrunc
+
+    # split into 2 * 64MB files, output files are named nor0 & nor1
+    split -b 67108864 -a 1 -d ${WORKDIR}/nor-full ${WORKDIR}/nor
+
+    tar -C ${WORKDIR} -c nor0 nor1 > ${NORIMG}
+}

--- a/meta-mender-qemu/conf/machine/include/vexpress.inc
+++ b/meta-mender-qemu/conf/machine/include/vexpress.inc
@@ -1,0 +1,17 @@
+include conf/machine/include/arm/arch-armv5-dsp.inc
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
+PREFERRED_VERSION_linux-yocto ?= "4.1%"
+
+SERIAL_CONSOLE = "115200 ttyAMA0"
+
+KERNEL_IMAGETYPE = "zImage"
+KERNEL_DEVICETREE = "vexpress-v2p-ca9.dtb"
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+
+UBOOT_SUFFIX = "bin"
+UBOOT_MACHINE = "vexpress_ca9x4_config"
+UBOOT_ENTRYPOINT = "0x60800000"
+UBOOT_LOADADDRESS = "0x60800000"
+
+UBOOT_ELF ?= "u-boot"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -1,0 +1,24 @@
+#@TYPE: Machine
+#@NAME: vexpress-qemu
+
+#@DESCRIPTION: Machine configuration for QEMU running vexpress with system on MTD device
+
+require conf/machine/include/qemu.inc
+require conf/machine/include/vexpress.inc
+
+IMAGE_FSTYPES_append = " ubifs ubi"
+
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "mtd-utils mtd-utils-ubifs mtd-utils-jffs2"
+
+MKUBIFS_ARGS = "-m 1 -e 262016 -c 1024"
+UBINIZE_ARGS = "-p 256KiB -m 1 -O 64"
+
+# NOTE: normally we'd pick up overrides for vexpress-qemu, disable them for now
+# to avoid incorrect u-boot patches being applied (on a side note, maybe rework
+# u-boot patches to be applied for any machine?)
+
+#MACHINEOVERRIDES =. "vexpress-qemu-flash:vexpress-qemu:"
+
+# Needed to skip particular QA checks that don't apply to U-boot's binary.
+INSANE_SKIP_u-boot += "ldflags textrel"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -22,3 +22,21 @@ UBINIZE_ARGS = "-p 256KiB -m 1 -O 64"
 
 # Needed to skip particular QA checks that don't apply to U-boot's binary.
 INSANE_SKIP_u-boot += "ldflags textrel"
+
+# 16MB for data partition
+MENDER_DATA_PART_SIZE_MB = "16"
+# combined NOR flash is 128MB
+MENDER_STORAGE_TOTAL_SIZE_MB = "128"
+# align to PEB size 256k
+MENDER_PARTITION_ALIGNMENT_KB = "256"
+
+# MTD partitioning has the following layout:
+# 1m(u-boot)ro,
+# 1m(u-boot-env)ro,
+# -(ubi)
+#
+# NOTE: this affects only u-boot's autoconfigured headers, the same variable is
+# also used for generating fw_env.config but because of assumptions made in
+# meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc we need ship
+# our own config instead.
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "0x100000"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -6,7 +6,7 @@
 require conf/machine/include/qemu.inc
 require conf/machine/include/vexpress.inc
 
-IMAGE_FSTYPES_append = " ubifs ubi"
+IMAGE_FSTYPES_append = " ubifs ubi vexpress-nor"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "mtd-utils mtd-utils-ubifs mtd-utils-jffs2"
@@ -40,3 +40,6 @@ MENDER_PARTITION_ALIGNMENT_KB = "256"
 # meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc we need ship
 # our own config instead.
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "0x100000"
+
+# add support for generating NOR Image files
+IMAGE_CLASSES += "vexpress-nor_image"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu.conf
@@ -1,7 +1,7 @@
 #@TYPE: Machine
 #@NAME: vexpress-qemu
 
-#@DESCRIPTION: Machine configuration for QEMU running vexpress
+#@DESCRIPTION: Machine configuration for QEMU running vexpress with system on MMC device
 
 
 MACHINE_EXTRA_RRECOMMENDS = " kernel-modules kernel-devicetree"
@@ -11,26 +11,9 @@ IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
 EXTRA_IMAGEDEPENDS += "u-boot"
 
 require conf/machine/include/qemu.inc
-include conf/machine/include/arm/arch-armv5-dsp.inc
+require conf/machine/include/vexpress.inc
 
 IMAGE_FSTYPES ?= "tar.gz ext3"
-
-SERIAL_CONSOLE = "115200 ttyAMA0"
-
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
-PREFERRED_VERSION_linux-yocto ?= "4.1%"
-
-
-KERNEL_IMAGETYPE = "zImage"
-KERNEL_DEVICETREE = "vexpress-v2p-ca9.dtb"
-KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
-
-UBOOT_SUFFIX = "bin"
-UBOOT_MACHINE = "vexpress_ca9x4_config"
-UBOOT_ENTRYPOINT = "0x60800000"
-UBOOT_LOADADDRESS = "0x60800000"
-
-UBOOT_ELF ?= "u-boot"
 
 # Needed to skip particular QA checks that don't apply to U-boot's binary.
 INSANE_SKIP_u-boot += "ldflags textrel"

--- a/meta-mender-qemu/recipes-bsp/u-boot/files/vexpress-qemu-flash/fw_env.config.default
+++ b/meta-mender-qemu/recipes-bsp/u-boot/files/vexpress-qemu-flash/fw_env.config.default
@@ -1,0 +1,3 @@
+# MTD device name	   Device offset     Env. size
+/dev/mtd1            0x00000000       0x40000
+/dev/mtd1            0x00040000       0x40000

--- a/meta-mender-qemu/recipes-bsp/u-boot/patches/0001-vexpress_ca9x4-enable-booting-from-ubifs.patch
+++ b/meta-mender-qemu/recipes-bsp/u-boot/patches/0001-vexpress_ca9x4-enable-booting-from-ubifs.patch
@@ -1,0 +1,108 @@
+From a2bc4d72fe6c8e888534fb4049374af4fef394e5 Mon Sep 17 00:00:00 2001
+Message-Id: <a2bc4d72fe6c8e888534fb4049374af4fef394e5.1497444332.git.maciej.borzecki@rndity.com>
+In-Reply-To: <cover.1497444332.git.maciej.borzecki@rndity.com>
+References: <cover.1497444332.git.maciej.borzecki@rndity.com>
+From: Maciej Borzecki <maciej.borzecki@rndity.com>
+Date: Mon, 12 Jun 2017 23:14:40 +0200
+Subject: [PATCH 1/5] vexpress_ca9x4: enable booting from ubifs
+
+Enable options that add support for UBI images on CFI and UBIFS.
+
+Enable MTD concatenation, thus 2*64MB NOR flash appears as single 128MB device.
+
+Define the follwing flash partitions:
+ - 1MB - uboot
+ - 1MB - uboot environment (previously stored at the top of the flash)
+ - remaining - UBI
+
+When defining mtdparts use device name that matches kernel's MTD name (otherwise
+partitioning will not be applied).
+
+Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
+---
+ configs/vexpress_ca9x4_defconfig |  5 ++++
+ include/configs/vexpress_ca9x4.h | 57 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 62 insertions(+)
+
+diff --git a/configs/vexpress_ca9x4_defconfig b/configs/vexpress_ca9x4_defconfig
+index 7b845c6c79843f99b04bc64d80d2e13d6a53b494..554e07b4c25ad4ec7b469c9e8f830da4404eca6a 100644
+--- a/configs/vexpress_ca9x4_defconfig
++++ b/configs/vexpress_ca9x4_defconfig
+@@ -20,3 +20,8 @@ CONFIG_CMD_MMC=y
+ CONFIG_MTD_NOR_FLASH=y
+ CONFIG_BAUDRATE=38400
+ CONFIG_OF_LIBFDT=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBIFS=y
++CONFIG_MTD_DEVICE=y
++CONFIG_MTD_PARTITIONS=y
++CONFIG_CMD_MTDPARTS=y
+diff --git a/include/configs/vexpress_ca9x4.h b/include/configs/vexpress_ca9x4.h
+index 993398ccc696c70d7f4c23c13f00fda6c0f536fe..4138a0e0ff18ff138bfe4918cd75a3494366d94b 100644
+--- a/include/configs/vexpress_ca9x4.h
++++ b/include/configs/vexpress_ca9x4.h
+@@ -14,4 +14,61 @@
+ #define CONFIG_VEXPRESS_ORIGINAL_MEMORY_MAP
+ #include "vexpress_common.h"
+ 
++#define CONFIG_RBTREE
++#define CONFIG_CMD_MTDPARTS
++#define CONFIG_MTD_DEVICE
++#define CONFIG_MTD_PARTITIONS
++#define CONFIG_MTD_CONCAT
++#define CONFIG_FLASH_CFI_MTD
++#define CONFIG_LZO
++
++#ifdef CONFIG_SYS_MALLOC_LEN
++#undef CONFIG_SYS_MALLOC_LEN
++#define CONFIG_SYS_MALLOC_LEN (8 * 1024 * 1024)
++#endif
++
++/* CONFIG_MTD_CONCAT is set, hence nor0 and nor1 will become a single device
++   named nor2
++
++   NOTE: NOR flash appears as a single MTD device with name 40000000.flash */
++#define MTDIDS_DEFAULT		"nor2=40000000.flash"
++#define MTDPARTS_DEFAULT  "mtdparts=40000000.flash:"  \
++  "1m(u-boot)ro," \
++  "1m(u-boot-env)ro," \
++  "-(ubi)"
++
++#ifdef CONFIG_EXTRA_ENV_SETTINGS
++#undef CONFIG_EXTRA_ENV_SETTINGS
++#endif
++
++#define UBI_BOOTCMD \
++ 	"ubiboot=" \
++	"echo Booting from NOR...; "                                          \
++	"ubi part ubi && "                                                    \
++	"ubifsmount ubi0:rootfs && "                                          \
++	"ubifsload ${kernel_addr_r} /boot/zImage && "                         \
++	"ubifsload ${fdt_addr_r} /boot/${fdtfile} && "                        \
++  "setenv bootargs ${mtdparts} ${ubiargs} ${defargs} && "               \
++	"bootz ${kernel_addr_r} - ${fdt_addr_r}\0"
++
++#define CONFIG_EXTRA_ENV_SETTINGS                                       \
++  UBI_BOOTCMD \
++  "kernel_addr_r=0x60100000\0"                                          \
++  "fdt_addr_r=0x60000000\0"                                             \
++  "fdtfile=vexpress-v2p-ca9.dtb\0"                                      \
++  "mtdparts=" MTDPARTS_DEFAULT "\0"                                     \
++  "ubiargs=ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs ubi.fm_autoconvert=1\0" \
++  "defargs=console=ttyAMA0,115200n8 panic=3\0"
++
++#undef CONFIG_BOOTCOMMAND
++#define CONFIG_BOOTCOMMAND "run ubiboot; reset; "
++
++/* environment starts at 1MB offset in the flash */
++#undef CONFIG_ENV_OFFSET
++#define CONFIG_ENV_OFFSET 0x100000
++/* was fixed in vexpress_common, but will be derived in environment.h */
++#undef CONFIG_ENV_ADDR
++/* required for automatic calculation of CONFIG_ENV_ADDR */
++#define CONFIG_SYS_FLASH_BASE CONFIG_SYS_FLASH_BASE0
++
+ #endif /* VEXPRESS_CA9X4_H */
+-- 
+2.9.3
+

--- a/meta-mender-qemu/recipes-bsp/u-boot/patches/0005-vexpress_ca9x4-Mender-with-UBIFS-integration.patch
+++ b/meta-mender-qemu/recipes-bsp/u-boot/patches/0005-vexpress_ca9x4-Mender-with-UBIFS-integration.patch
@@ -1,0 +1,68 @@
+From dec6c9da2dfd7aa8856431b3305c20970e8c2eac Mon Sep 17 00:00:00 2001
+Message-Id: <dec6c9da2dfd7aa8856431b3305c20970e8c2eac.1497444332.git.maciej.borzecki@rndity.com>
+In-Reply-To: <cover.1497444332.git.maciej.borzecki@rndity.com>
+References: <cover.1497444332.git.maciej.borzecki@rndity.com>
+From: Maciej Borzecki <maciej.borzecki@rndity.com>
+Date: Wed, 14 Jun 2017 11:09:17 +0200
+Subject: [PATCH 5/5] vexpress_ca9x4: Mender with UBIFS integration
+
+Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
+---
+ include/configs/vexpress_ca9x4.h | 19 ++++++++++++++-----
+ 1 file changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/include/configs/vexpress_ca9x4.h b/include/configs/vexpress_ca9x4.h
+index 4138a0e0ff18ff138bfe4918cd75a3494366d94b..4ec386fd85e8abcec90e66ff6e4a90bb23f354de 100644
+--- a/include/configs/vexpress_ca9x4.h
++++ b/include/configs/vexpress_ca9x4.h
+@@ -34,7 +34,7 @@
+ #define MTDIDS_DEFAULT		"nor2=40000000.flash"
+ #define MTDPARTS_DEFAULT  "mtdparts=40000000.flash:"  \
+   "1m(u-boot)ro," \
+-  "1m(u-boot-env)ro," \
++  "1m(u-boot-env)," \
+   "-(ubi)"
+ 
+ #ifdef CONFIG_EXTRA_ENV_SETTINGS
+@@ -44,8 +44,10 @@
+ #define UBI_BOOTCMD \
+  	"ubiboot=" \
+ 	"echo Booting from NOR...; "                                          \
+-	"ubi part ubi && "                                                    \
+-	"ubifsmount ubi0:rootfs && "                                          \
++	"run mender_setup; "                                                  \
++	"run set_ubiargs; "                                                   \
++	"ubi part ${mender_mtd_ubi_dev_name} && "                             \
++	"ubifsmount ${mender_uboot_root_name} && "                            \
+ 	"ubifsload ${kernel_addr_r} /boot/zImage && "                         \
+ 	"ubifsload ${fdt_addr_r} /boot/${fdtfile} && "                        \
+   "setenv bootargs ${mtdparts} ${ubiargs} ${defargs} && "               \
+@@ -57,11 +59,12 @@
+   "fdt_addr_r=0x60000000\0"                                             \
+   "fdtfile=vexpress-v2p-ca9.dtb\0"                                      \
+   "mtdparts=" MTDPARTS_DEFAULT "\0"                                     \
+-  "ubiargs=ubi.mtd=2 root=ubi0:rootfs rootfstype=ubifs ubi.fm_autoconvert=1\0" \
++  "set_ubiargs=setenv ubiargs ubi.mtd=${mender_mtd_ubi_dev_name} "      \
++              "root=${mender_kernel_root} rootfstype=ubifs ubi.fm_autoconvert=1\0"  \
+   "defargs=console=ttyAMA0,115200n8 panic=3\0"
+ 
+ #undef CONFIG_BOOTCOMMAND
+-#define CONFIG_BOOTCOMMAND "run ubiboot; reset; "
++#define CONFIG_BOOTCOMMAND "run ubiboot; run mender_try_to_recover; "
+ 
+ /* environment starts at 1MB offset in the flash */
+ #undef CONFIG_ENV_OFFSET
+@@ -71,4 +74,10 @@
+ /* required for automatic calculation of CONFIG_ENV_ADDR */
+ #define CONFIG_SYS_FLASH_BASE CONFIG_SYS_FLASH_BASE0
+ 
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
++
++/* Mender integration will set this */
++#undef CONFIG_ENV_OFFSET
++
+ #endif /* VEXPRESS_CA9X4_H */
+-- 
+2.9.3
+

--- a/meta-mender-qemu/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/meta-mender-qemu/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,1 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append_vexpress-qemu-flash = " file://fw_env.config.default "
+
 require u-boot-vexpress-qemu.inc

--- a/meta-mender-qemu/recipes-bsp/u-boot/u-boot-vexpress-qemu.inc
+++ b/meta-mender-qemu/recipes-bsp/u-boot/u-boot-vexpress-qemu.inc
@@ -1,6 +1,10 @@
-FILESEXTRAPATHS_prepend_vexpress-qemu := "${THISDIR}/patches:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 
 SRC_URI_append_vexpress-qemu = " file://0001-Enable-U-Boot-on-QEMU-to-use-Mender-boot-code.patch \
                                  file://0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch"
 
+SRC_URI_append_vexpress-qemu-flash = " \
+                                 file://0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch"
+
 BOOTENV_SIZE_vexpress-qemu ?= "0x40000"
+BOOTENV_SIZE_vexpress-qemu-flash ?= "0x40000"

--- a/meta-mender-qemu/recipes-bsp/u-boot/u-boot-vexpress-qemu.inc
+++ b/meta-mender-qemu/recipes-bsp/u-boot/u-boot-vexpress-qemu.inc
@@ -4,7 +4,10 @@ SRC_URI_append_vexpress-qemu = " file://0001-Enable-U-Boot-on-QEMU-to-use-Mender
                                  file://0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch"
 
 SRC_URI_append_vexpress-qemu-flash = " \
-                                 file://0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch"
+                                   file://0001-vexpress_ca9x4-enable-booting-from-ubifs.patch \
+                                   file://0003-Add-kernel-panic-option-to-vexpress-boot-arguments.patch \
+                                   file://0005-vexpress_ca9x4-Mender-with-UBIFS-integration.patch \
+                                   "
 
 BOOTENV_SIZE_vexpress-qemu ?= "0x40000"
 BOOTENV_SIZE_vexpress-qemu-flash ?= "0x40000"

--- a/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -3,5 +3,11 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append_vexpress-qemu = " file://defconfig \
                                 file://vexpress-qemu-standard.scc \
                                " 
-
 COMPATIBLE_MACHINE_vexpress-qemu = "vexpress-qemu"
+
+# same config for vexpress-qemu-flash
+SRC_URI_append_vexpress-qemu-flash = " file://defconfig \
+                                       file://vexpress-qemu-standard.scc \
+                                       "
+
+COMPATIBLE_MACHINE_vexpress-qemu-flash = "vexpress-qemu-flash"

--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -2,11 +2,31 @@
 
 set -x -e
 
-if [ -e /mnt/build/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.sdimg ]; then
-    cp /mnt/build/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.sdimg .
-fi
-if [ -e /mnt/build/tmp/deploy/images/vexpress-qemu/u-boot.elf ]; then
-    cp /mnt/build/tmp/deploy/images/vexpress-qemu/u-boot.elf .
+MACHINE=${MACHINE:-"vexpress-qemu"}
+IMAGE=${IMAGE:-"core-image-full-cmdline"}
+
+case "$MACHINE" in
+    vexpress-qemu)
+        if [ -e /mnt/build/tmp/deploy/images/${MACHINE}/${IMAGE}-${MACHINE}.sdimg ]; then
+            cp /mnt/build/tmp/deploy/images/${MACHINE}/${IMAGE}-${MACHINE}.sdimg .
+        fi
+        VEXPRESS_IMG="${IMAGE}-${MACHINE}.sdimg"
+        ;;
+    vexpress-qemu-flash)
+        if [ -e /mnt/build/tmp/deploy/images/${MACHINE}/${IMAGE}-${MACHINE}.vexpress-nor ]; then
+            cp /mnt/build/tmp/deploy/images/${MACHINE}/${IMAGE}-${MACHINE}.vexpress-nor .
+        fi
+        VEXPRESS_IMG="${IMAGE}-${MACHINE}.vexpress-nor"
+        ;;
+    *)
+        echo "unsupported machine $MACHINE"
+        exit 1
+        ;;
+esac
+
+# NOTE: vexpress-qemu-flash has a differently configured u-boot
+if [ -e /mnt/build/tmp/deploy/images/${MACHINE}/u-boot.elf ]; then
+    cp /mnt/build/tmp/deploy/images/${MACHINE}/u-boot.elf .
 fi
 
 CONFIG_ARGS=
@@ -19,6 +39,15 @@ if [ -f /mnt/config/artifact-verify-key.pem ]; then
     CONFIG_ARGS="$CONFIG_ARGS --verify-key=/mnt/config/artifact-verify-key.pem"
 fi
 
-./setup-mender-configuration.py --sdimg=core-image-full-cmdline-vexpress-qemu.sdimg --server-url=$SERVER_URL --tenant-token=$TENANT_TOKEN $CONFIG_ARGS
+if [ "$MACHINE" = "vexpress-qemu "]; then
+    ./setup-mender-configuration.py --sdimg=core-image-full-cmdline-vexpress-qemu.sdimg \
+                                    --server-url=$SERVER_URL \
+                                    --tenant-token=$TENANT_TOKEN $CONFIG_ARGS
+else
+    if [ -n "$TENANT_TOKEN" -o -n "$CONFIG_ARGS" -o -n "$SERVER_URL" ]; then
+       echo "reconfiguration of flash images is not supported"
+       exit 1
+    fi
+fi
 
-QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_SDIMG="core-image-full-cmdline-vexpress-qemu.sdimg" UBOOT_ELF="u-boot.elf" ./mender-qemu $*
+QEMU_SYSTEM_ARM="qemu-system-arm" VEXPRESS_IMG="${VEXPRESS_IMG}" UBOOT_ELF="u-boot.elf" ./mender-qemu $*

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -51,4 +51,4 @@ QEMU_AUDIO_DRV=none \
     -net nic,macaddr="$RANDOM_MAC" \
     -net user,hostfwd=tcp::8822-:22 \
     -display vnc=:23 \
-    -nographic
+    -nographic "$@"

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -37,18 +37,34 @@ else
     BUILDTMP=${BUILDDIR}/tmp-glibc
 fi
 
-UBOOT_ELF=${UBOOT_ELF:-"${BUILDTMP}/deploy/images/vexpress-qemu/u-boot.elf"}
-VEXPRESS_SDIMG=${VEXPRESS_SDIMG:-"${BUILDTMP}/deploy/images/vexpress-qemu/${IMAGE_NAME}-vexpress-qemu.sdimg"}
+MACHINE=${MACHINE:-"vexpress-qemu"}
+UBOOT_ELF=${UBOOT_ELF:-"${BUILDTMP}/deploy/images/${MACHINE}/u-boot.elf"}
+VEXPRESS_IMG=${VEXPRESS_IMG:-"${BUILDTMP}/deploy/images/${MACHINE}/${IMAGE_NAME}-${MACHINE}.sdimg"}
 QEMU_SYSTEM_ARM=${QEMU_SYSTEM_ARM:-"qemu-system-arm"}
 RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
+
+QEMU_ARGS=""
+case $VEXPRESS_IMG in
+    *.sdimg)
+        QEMU_ARGS="$QEMU_ARGS -drive file=$VEXPRESS_IMG,if=sd "
+        ;;
+    *.vexpress-nor)
+        tar -C /tmp -xvf $VEXPRESS_IMG
+        QEMU_ARGS="$QEMU_ARGS -drive file=/tmp/nor0,if=pflash,format=raw -drive file=/tmp/nor1,if=pflash,format=raw "
+        ;;
+    *)
+        echo "unsupported image $VEXPRESS_IMG"
+        exit 1
+esac
 
 QEMU_AUDIO_DRV=none \
     $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
     -m 128M \
     -kernel "$UBOOT_ELF" \
-    -drive file="$VEXPRESS_SDIMG",if=sd \
     -net nic,macaddr="$RANDOM_MAC" \
     -net user,hostfwd=tcp::8822-:22 \
     -display vnc=:23 \
-    -nographic "$@"
+    -nographic \
+    $QEMU_ARGS \
+    "$@"


### PR DESCRIPTION
This PR adds support for raw flash to qemu. You need to use qemu master (or 2.9) to be able to use generated image.

Short summary:

There's a separate machine config `vexpress-qemu-flash`, as its setup is significantly different. The machine config already defines some MENDER variables (see vexpress-qemu-flash.conf) as we know the size of the storage upfront.

There's a number of u-boot patches that are queued up right here for now: https://github.com/bboozzoo/u-boot/commits/bboozzoo/vexpress-a9-ubi-mender (they will be added once I verify that things are working). The 
`vexpress_ca9x4: enable booting from ubifs` does some significant changes to uboot config and flash layout, these are:
* enable UBI, UBIFS, MTD on CFI, MTD concatenation (so our sepate 64MB banks (`nor0`, `nor1`) will appear as single 128MB `nor2` device)
* defines the following MTD partitions: `mtdparts=40000000.flash:1m(u-boot)ro,1m(u-boot-env),-(ubi)`
* uboot environment starts at the 1MB offset from the bottom of the flash (before it was at the top of the flash - 2 * env size)
* environment has been trimmed to just the necessary minimum

Patch `meta-mender-core/install-ubi: [DO NOT MERGE] comment out warnings...` will be dumped before this is merged.

There's some warnings from `configcheck` task when building linux-yocto. I don't know why, but configcheck may be picking incorrect config for verification. Needs investigation.

I had to add some workarounds for u-boot-fw-utils and generating `fw_env.config`. The code generating `fw_env.config` would end up using incorrect device (defaulting to `MENDER_STORAGE_DEVICE`) and generated incorrect config. @mirzak did not have this problem as he was using `u-boot-toradex-fsl-fw-utils`, where he could selectively include `meta-mender-core` files and ended up shipping a premade `fw_env.confg`. I also don't want to introduce more `MENDER_*` varaibles, and I cannot selectively include files, hence the workaround to provide a default `fw_env/.config.default`. (BTW adding `do_compile_append_vexpress-qemu-flash` ended up being added before `do_compile_append` code)

Also, there's a problem with data partition, for now I get:
```
[    4.930933] UBIFS error (ubi0:2 pid 718): validate_sb: bad superblock, error 4
[    4.932212]  magic          0x6101831
[    4.932403]  crc            0x293fadba
[    4.932599]  node_type      6 (superblock node)
[    4.932813]  group_type     0 (no node group)
[    4.933005]  sqnum          1
[    4.933149]  len            4096
[    4.933350]  key_hash       0 (R5)
[    4.933530]  key_fmt        0 (simple)
[    4.933716]  flags          0x0
[    4.933880]  big_lpt        0
[    4.934031]  space_fixup    0
[    4.934178]  min_io_size    8
[    4.934329]  leb_size       262016
[    4.934490]  leb_cnt        17
[    4.934624]  max_leb_cnt    1024
[    4.934762]  max_bud_bytes  8388608
[    4.934910]  log_lebs       4
[    4.935043]  lpt_lebs       2
[    4.935168]  orph_lebs      1
[    4.935301]  jhead_cnt      1
[    4.935435]  fanout         8
[    4.935583]  lsave_cnt      256
[    4.935728]  default_compr  1
[    4.935878]  rp_size        0
[    4.936006]  rp_uid         0
[    4.936139]  rp_gid         0
[    4.936296]  fmt_version    4
[    4.936542]  time_gran      1000000000
[    4.936925]  UUID           BD9A5147-7BB4-4BA1-9DE9-C88045D28D5F
```
@kacf @pasinskim 

