### PR TITLE
experimental suse

### DIFF
--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -16,21 +16,12 @@
 # -e TENANT_TOKEN=<token>
 #       Use token as tenant token for client.
 
-FROM alpine:3.6
+FROM opensuse:tumbleweed
 
 # Install packages
-RUN apk update && apk upgrade && \
-    apk add util-linux \
-            bash e2fsprogs-extra python3 && \
-    rm -rf /var/cache/apk/*
-
-# Install qemu from edge repo as we need some fixes that made it into 2.9
-# (currently avaialble in edge).
-# NOTE: this will need fixing in the future
-RUN sed -i -e 's#v3.6#edge#' /etc/apk/repositories && \
-    apk update && apk add qemu-system-arm && \
-    sed -i -e 's#edge#v3.6#' /etc/apk/repositories && \
-    rm -rf /var/cache/apk/*
+RUN zypper up -y && \
+    zypper install -y e2fsprogs qemu-arm python3 && \
+    zypper clean -a
 
 ARG VEXPRESS_IMAGE=scripts/docker/empty-file
 ARG UBOOT_ELF=scripts/docker/empty-file

--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -16,12 +16,20 @@
 # -e TENANT_TOKEN=<token>
 #       Use token as tenant token for client.
 
-FROM alpine:3.4
+FROM alpine:3.6
 
-# Install QEMU
+# Install packages
 RUN apk update && apk upgrade && \
-    apk add qemu-system-arm util-linux \
+    apk add util-linux \
             bash e2fsprogs-extra python3 && \
+    rm -rf /var/cache/apk/*
+
+# Install qemu from edge repo as we need some fixes that made it into 2.9
+# (currently avaialble in edge).
+# NOTE: this will need fixing in the future
+RUN sed -i -e 's#v3.6#edge#' /etc/apk/repositories && \
+    apk update && apk add qemu-system-arm && \
+    sed -i -e 's#edge#v3.6#' /etc/apk/repositories && \
     rm -rf /var/cache/apk/*
 
 ARG VEXPRESS_IMAGE=scripts/docker/empty-file

--- a/meta-mender-qemu/recipes-core/systemd/files/01-logs-to-console.conf
+++ b/meta-mender-qemu/recipes-core/systemd/files/01-logs-to-console.conf
@@ -1,0 +1,2 @@
+[Journal]
+ForwardToConsole=true

--- a/meta-mender-qemu/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mender-qemu/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+               file://01-logs-to-console.conf \
+               "
+do_install_append() {
+    install -d ${D}${sysconfdir}/systemd/journald.conf.d
+    install -m 0644 -t ${D}${sysconfdir}/systemd/journald.conf.d \
+            ${WORKDIR}/01-logs-to-console.conf
+}
+
+CONFFILES_${PN}_append = " ${sysconfdir}/systemd/journald.conf.d/01-logs-to-console.conf"

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -46,7 +46,7 @@ RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
 QEMU_ARGS=""
 case $VEXPRESS_IMG in
     *.sdimg)
-        QEMU_ARGS="$QEMU_ARGS -drive file=$VEXPRESS_IMG,if=sd "
+        QEMU_ARGS="$QEMU_ARGS -drive file=$VEXPRESS_IMG,if=sd,format=raw "
         ;;
     *.vexpress-nor)
         tar -C /tmp -xvf $VEXPRESS_IMG


### PR DESCRIPTION
We already know that qemu 2.9 causes pain for integration tests when running under high I/O load. This PR is basically the same as https://github.com/mendersoftware/meta-mender/pull/320 but this time using `opensuse:tumbleweed` as base image. Trying to rule out some dependency on how qemu is built and linked.

@GregorioDiStefano @kacf 