### PR TITLE
qemu raw flash acceptance tests

### DIFF
--- a/meta-mender-core/classes/mender-install.bbclass
+++ b/meta-mender-core/classes/mender-install.bbclass
@@ -54,7 +54,7 @@ MENDER_DATA_PART_DIR ?= ""
 MENDER_DATA_PART_SIZE_MB ?= "128"
 
 # Size of the first (FAT) partition, that contains the bootloader
-MENDER_BOOT_PART_SIZE_MB ?= "16"
+MENDER_BOOT_PART_SIZE_MB ??= "16"
 
 # For performance reasons, we try to align the partitions to the SD
 # card's erase block. It is impossible to know this information with

--- a/meta-mender-core/classes/mender-install.bbclass
+++ b/meta-mender-core/classes/mender-install.bbclass
@@ -120,3 +120,8 @@ MENDER_CALC_ROOTFS_SIZE = "${@mender_calculate_rootfs_size_kb(${MENDER_STORAGE_T
 # But subtract IMAGE_ROOTFS_EXTRA_SPACE, since it will be added automatically
 # in later bitbake calculations.
 IMAGE_ROOTFS_SIZE ?= "${@eval('${MENDER_CALC_ROOTFS_SIZE} - (${IMAGE_ROOTFS_EXTRA_SPACE})')}"
+
+# Set hard limit on maximum rootfs size. Calculated rootfs size is used when
+# partitioning the disk image (be it SD card or UBI image), and defines an upper
+# bound of the space allocated for rootfs partition/volume.
+IMAGE_ROOTFS_MAXSIZE ?= "${MENDER_CALC_ROOTFS_SIZE}"

--- a/meta-mender-qemu/Dockerfile
+++ b/meta-mender-qemu/Dockerfile
@@ -16,12 +16,94 @@
 # -e TENANT_TOKEN=<token>
 #       Use token as tenant token for client.
 
-FROM alpine:3.4
+FROM alpine:3.6
 
-# Install QEMU
+# Install packages
 RUN apk update && apk upgrade && \
-    apk add qemu-system-arm util-linux \
+    apk add util-linux \
             bash e2fsprogs-extra python3 && \
+    rm -rf /var/cache/apk/*
+
+# Install qemu from source
+RUN apk update && apk add --virtual build-dependencies \
+    alsa-lib-dev \
+    bison \
+    curl-dev \
+    flex \
+	  glib-dev \
+	  glib-static \
+	  gnutls-dev \
+	  gtk+3.0-dev \
+	  libaio-dev \
+	  libcap-dev \
+	  libcap-ng-dev \
+	  libjpeg-turbo-dev \
+	  libnfs-dev \
+	  libpng-dev \
+	  libssh2-dev \
+	  libusb-dev \
+	  linux-headers \
+	  lzo-dev \
+	  ncurses-dev \
+	  paxmark \
+	  snappy-dev \
+	  spice-dev \
+	  texinfo \
+	  usbredir-dev \
+	  util-linux-dev \
+	  vde2-dev \
+	  xfsprogs-dev \
+	  zlib-dev \
+    git \
+    alpine-sdk \
+    && \
+    git clone --progress -b qemu-system-reset-race-fix git://github.com/mendersoftware/qemu.git && \
+    cd qemu && \
+    git submodule update --init dtc && \
+    ./configure --target-list=arm-softmmu \
+                --disable-werror \
+                --prefix=/usr \
+                --localstatedir=/var \
+		            --sysconfdir=/etc \
+		            --libexecdir=/usr/lib/qemu \
+		            --disable-glusterfs \
+		            --disable-debug-info \
+		            --disable-bsd-user \
+		            --disable-werror \
+		            --disable-sdl \
+		            --disable-xen \
+                --disable-attr \
+                --disable-gtk \
+                && \
+    make install -j4 V=1 && \
+    cd .. && \
+    rm -rf qemu && \
+    apk del build-dependencies && \
+    apk add so:libaio.so.1 \
+            so:libasound.so.2 \
+            so:libbz2.so.1 \
+            so:libc.musl-x86_64.so.1 \
+            so:libcurl.so.4 \
+            so:libepoxy.so.0 \
+            so:libgbm.so.1 \
+            so:libgcc_s.so.1 \
+            so:libglib-2.0.so.0 \
+            so:libgnutls.so.30 \
+            so:libjpeg.so.8 \
+            so:liblzo2.so.2 \
+            so:libncursesw.so.6 \
+            so:libnettle.so.6 \
+            so:libnfs.so.8 \
+            so:libpixman-1.so.0 \
+            so:libpng16.so.16 \
+            so:libsnappy.so.1 \
+            so:libspice-server.so.1 \
+            so:libssh2.so.1 \
+            so:libstdc++.so.6 \
+            so:libusb-1.0.so.0 \
+            so:libusbredirparser.so.1 \
+            so:libvdeplug.so.3 \
+            so:libz.so.1 \
     rm -rf /var/cache/apk/*
 
 ARG VEXPRESS_IMAGE=scripts/docker/empty-file

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -6,7 +6,9 @@
 require conf/machine/include/qemu.inc
 require conf/machine/include/vexpress.inc
 
-IMAGE_FSTYPES_append = " ubifs ubi vexpress-nor"
+# build only ubifs (used as mender artifact), vexpress-nor (used for qemu and
+# testing), mender-image-ubi will append ubimg to built FSTYPES
+IMAGE_FSTYPES = "ubifs vexpress-nor"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "mtd-utils mtd-utils-ubifs mtd-utils-jffs2"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -36,7 +36,15 @@ MENDER_DATA_PART_SIZE_MB = "16"
 MENDER_PARTITION_ALIGNMENT_KB = "256"
 # there is no partitioning overhead (no MBR and such)
 MENDER_PARTITIONING_OVERHEAD_KB = "0"
-# all of above should give 56832KB (55.5MB) for rootfs
+# Account for UBI overhead, see
+# http://www.linux-mtd.infradead.org/doc/ubi.html#L_overhead for details,
+# NOTE: the variable is supposed to be used differently, but it is also
+# subtracted from MENDER_STORAGE_TOTAL_SIZE_MB, since MTD partitions are fixed
+# (and burned into uboot) we need something that will make room fo UBI metadata,
+# and setting MENDER_STORAGE_TOTAL_SIZE_MB seems like a good choice.
+# The overhead was calculated to be ~1.01MB, round it up to 2MB
+MENDER_STORAGE_RESERVED_RAW_SPACE = "2097152"
+# all of above should give 55296KB (54MB) for rootfs
 
 # MTD partitioning has the following layout:
 # 1m(u-boot)ro,

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -41,5 +41,8 @@ MENDER_PARTITION_ALIGNMENT_KB = "256"
 # our own config instead.
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "0x100000"
 
+# use ubifs volumes for generating mender artifacts
+ARTIFACTIMG_FSTYPE = "ubifs"
+
 # add support for generating NOR Image files
 IMAGE_CLASSES += "vexpress-nor_image"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -23,12 +23,18 @@ UBINIZE_ARGS = "-p 256KiB -m 1 -O 64"
 # Needed to skip particular QA checks that don't apply to U-boot's binary.
 INSANE_SKIP_u-boot += "ldflags textrel"
 
-# 16MB for data partition
-MENDER_DATA_PART_SIZE_MB = "16"
 # combined NOR flash is 128MB
 MENDER_STORAGE_TOTAL_SIZE_MB = "128"
+# reserving 1MB for uboot and additional 1MB for uboot env, pretend it's a
+# single boot partition
+MENDER_BOOT_PART_SIZE_MB = "2"
+# 16MB for data partition
+MENDER_DATA_PART_SIZE_MB = "16"
 # align to PEB size 256k
 MENDER_PARTITION_ALIGNMENT_KB = "256"
+# there is no partitioning overhead (no MBR and such)
+MENDER_PARTITIONING_OVERHEAD_KB = "0"
+# all of above should give 56832KB (55.5MB) for rootfs
 
 # MTD partitioning has the following layout:
 # 1m(u-boot)ro,

--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -46,6 +46,10 @@ MENDER_PARTITIONING_OVERHEAD_KB = "0"
 MENDER_STORAGE_RESERVED_RAW_SPACE = "2097152"
 # all of above should give 55296KB (54MB) for rootfs
 
+# since UBIFS employs compression, we override maximum rootfs size and put the
+# upper limit at 80MB
+IMAGE_ROOTFS_MAXSIZE = "81920"
+
 # MTD partitioning has the following layout:
 # 1m(u-boot)ro,
 # 1m(u-boot-env)ro,

--- a/meta-mender-qemu/recipes-core/systemd/files/01-logs-to-console.conf
+++ b/meta-mender-qemu/recipes-core/systemd/files/01-logs-to-console.conf
@@ -1,0 +1,2 @@
+[Journal]
+ForwardToConsole=true

--- a/meta-mender-qemu/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mender-qemu/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = "\
+               file://01-logs-to-console.conf \
+               "
+do_install_append() {
+    install -d ${D}${sysconfdir}/systemd/journald.conf.d
+    install -m 0644 -t ${D}${sysconfdir}/systemd/journald.conf.d \
+            ${WORKDIR}/01-logs-to-console.conf
+}
+
+CONFFILES_${PN}_append = " ${sysconfdir}/systemd/journald.conf.d/01-logs-to-console.conf"

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -48,7 +48,7 @@ QEMU_DRIVE=${QEMU_DRIVE:-""}
 QEMU_ARGS=""
 case $VEXPRESS_IMG in
     *.sdimg)
-        QEMU_ARGS="$QEMU_ARGS -drive file=$VEXPRESS_IMG,if=sd "
+        QEMU_ARGS="$QEMU_ARGS -drive file=$VEXPRESS_IMG,if=sd,format=raw "
         ;;
     *.vexpress-nor)
         tar -C /tmp -xvf $VEXPRESS_IMG

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -63,6 +63,9 @@ case $VEXPRESS_IMG in
         fi
 esac
 
+echo "--- qemu version"
+$QEMU_SYSTEM_ARM --version
+
 QEMU_AUDIO_DRV=none \
     exec $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -463,6 +463,8 @@ def run_bitbake(prepared_test_build):
 def clean_image(request, prepared_test_build_base):
     add_to_local_conf(prepared_test_build_base,
                       'SYSTEMD_AUTO_ENABLE_pn-mender = "disable"')
+    add_to_local_conf(prepared_test_build_base,
+                      'EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh"')
     run_bitbake(prepared_test_build_base)
     return prepared_test_build_base
 

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -102,7 +102,7 @@ def is_qemu_running():
 
 def reboot(wait = 120):
     with settings(warn_only = True):
-        sudo("reboot")
+        run("reboot")
 
     # Make sure reboot has had time to take effect.
     time.sleep(5)
@@ -212,8 +212,8 @@ def qemu_prep_fresh_host():
 
 
 def manual_uboot_commit():
-    sudo("fw_setenv upgrade_available 0")
-    sudo("fw_setenv bootcount 0")
+    run("fw_setenv upgrade_available 0")
+    run("fw_setenv bootcount 0")
 
 
 def setup_bbb_sdcard():
@@ -221,10 +221,10 @@ def setup_bbb_sdcard():
     put("core-image-base-beaglebone-modified-testing.sdimg",
         local_path=local_sdimg,
         remote_path="/opt/")
-    sudo("chmod +x /root/install-new-image.sh")
+    run("chmod +x /root/install-new-image.sh")
 
     #easier to keep the followinf in a bash script
-    sudo("/root/install-new-image.sh")
+    run("/root/install-new-image.sh")
     reboot()
 
 
@@ -234,9 +234,9 @@ def boot_from_internal():
                   setenv bootargs console=tty0 console=${console} root=/dev/mmcblk1p1; \
                   bootz ${loadaddr} - ${fdtaddr}"""
 
-    if "yocto" in sudo("uname -a"):
+    if "yocto" in run("uname -a"):
         with settings(warn_only=True):
-            sudo("sed '/uenvcmd/d' -i /uboot/uEnv.txt")
+            run("sed '/uenvcmd/d' -i /uboot/uEnv.txt")
         append("/uboot/uEnv.txt", bootline)
         reboot()
 
@@ -269,7 +269,7 @@ def qemu_running(request, clean_image):
         def qemu_finalizer_impl():
             try:
                 manual_uboot_commit()
-                sudo("halt")
+                run("halt")
                 halt_time = time.time()
                 # Wait up to 30 seconds for shutdown.
                 while halt_time + 30 > time.time() and qemu.poll() is None:

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -634,6 +634,27 @@ def add_to_local_conf(prepared_test_build, string):
 
 
 @pytest.fixture(autouse=True)
+def only_for_machine(request, bitbake_variables):
+    """Fixture that enables use of `only_for_machine(machine-name)` mark.
+    Example::
+
+       @pytest.mark.only_for_machine('vexpress-qemu')
+       def test_foo():
+           # executes only if building for vexpress-qemu
+           pass
+
+    """
+    mach_mark = request.node.get_marker('only_for_machine')
+    if mach_mark is not None:
+        machines = mach_mark.args
+        current = bitbake_variables.get('MACHINE', None)
+        if  current not in machines:
+            pytest.skip('incompatible machine {} ' \
+                        '(required {})'.format(current if not None else '(none)',
+                                               ', '.join(machines)))
+
+
+@pytest.fixture(autouse=True)
 def only_with_image(request, bitbake_variables):
     """Fixture that enables use of `only_with_image(img1, img2)` mark.
     Example::

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -328,6 +328,21 @@ def latest_sdimg():
     return latest_build_artifact(os.environ['BUILDDIR'], ".sdimg")
 
 @pytest.fixture(scope="session")
+def latest_ubimg():
+    assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
+
+    # Find latest built ubimg.
+    return latest_build_artifact(os.environ['BUILDDIR'], ".ubimg")
+
+@pytest.fixture(scope="session")
+def latest_ubifs():
+    assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
+
+    # Find latest built ubifs. NOTE: need to include *core-image* otherwise
+    # we'll likely match data partition file - data.ubifs
+    return latest_build_artifact(os.environ['BUILDDIR'], "*core-image*.ubifs")
+
+@pytest.fixture(scope="session")
 def latest_mender_image():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -468,7 +468,7 @@ def clean_image(request, prepared_test_build_base):
 
 
 @pytest.fixture(scope="session")
-def prepared_test_build_base(request, bitbake_variables, latest_sdimg):
+def prepared_test_build_base(request, bitbake_variables):
     """Base fixture for prepared_test_build. Returns the same as that one."""
 
     build_dir = tempfile.mkdtemp(prefix="test-build-", dir=os.environ['BUILDDIR'])
@@ -494,9 +494,7 @@ def prepared_test_build_base(request, bitbake_variables, latest_sdimg):
 
     os.symlink(os.path.join(os.environ['BUILDDIR'], "downloads"), os.path.join(build_dir, "downloads"))
 
-    sdimg_base = os.path.basename(latest_sdimg)
-    # Remove machine, date and suffix.
-    image_name = re.sub("-%s(-[0-9]+)?\.sdimg$" % bitbake_variables['MACHINE'], "", sdimg_base)
+    image_name = pytest.config.getoption("--bitbake-image")
 
     return {'build_dir': build_dir,
             'image_name': image_name,

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -491,7 +491,8 @@ def prepared_test_build_base(request, bitbake_variables):
     build_dir = tempfile.mkdtemp(prefix="test-build-", dir=os.environ['BUILDDIR'])
 
     def cleanup_test_build():
-        run_verbose("rm -rf %s" % build_dir)
+        if not pytest.config.getoption('--keep-build-dir'):
+            run_verbose("rm -rf %s" % build_dir)
 
     cleanup_test_build()
     request.addfinalizer(cleanup_test_build)

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -541,3 +541,24 @@ def add_to_local_conf(prepared_test_build, string):
     fd = open(prepared_test_build['local_conf'], "a")
     fd.write("%s\n" % string)
     fd.close()
+
+
+@pytest.fixture(autouse=True)
+def only_with_image(request, bitbake_variables):
+    """Fixture that enables use of `only_with_image(img1, img2)` mark.
+    Example::
+
+       @pytest.mark.only_with_image('ext4')
+       def test_foo():
+           # executes only if ext4 image is enabled
+           pass
+
+    """
+    mark = request.node.get_marker('only_with_image')
+    if mark is not None:
+        images = mark.args
+        current = bitbake_variables.get('IMAGE_FSTYPES', '').strip().split(' ')
+        if not any([img in current for img in images]):
+            pytest.skip('no supported filesystem in {} ' \
+                        '(supports {})'.format(', '.join(current),
+                                               ', '.join(images)))

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -554,9 +554,9 @@ def add_to_local_conf(prepared_test_build, string):
     """Add given string to local.conf before the build. Newline is added
     automatically."""
 
-    fd = open(prepared_test_build['local_conf'], "a")
-    fd.write("%s\n" % string)
-    fd.close()
+    with open(prepared_test_build['local_conf'], "a") as fd:
+        fd.write('\n## ADDED BY TEST\n')
+        fd.write("%s\n" % string)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -26,6 +26,8 @@ import tempfile
 import errno
 import shutil
 
+from contextlib import contextmanager
+
 import conftest
 
 def if_not_bbb(func):
@@ -578,3 +580,15 @@ def only_with_image(request, bitbake_variables):
             pytest.skip('no supported filesystem in {} ' \
                         '(supports {})'.format(', '.join(current),
                                                ', '.join(images)))
+
+
+@contextmanager
+def make_tempdir(delete=True):
+    """context manager for temporary directories"""
+    tdir = tempfile.mkdtemp(prefix='meta-mender-acceptance.')
+    print('created dir', tdir)
+    try:
+        yield tdir
+    finally:
+        if delete:
+            shutil.rmtree(tdir)

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -424,9 +424,11 @@ def latest_mender_image():
     return latest_build_artifact(os.environ['BUILDDIR'], ".mender")
 
 @pytest.fixture(scope="function")
-def successful_image_update_mender(request, latest_mender_image):
+def successful_image_update_mender(request, clean_image):
     """Provide a 'successful_image_update.mender' file in the current directory that
     contains the latest built update."""
+
+    latest_mender_image = latest_build_artifact(clean_image['build_dir'], ".mender")
 
     if os.path.lexists("successful_image_update.mender"):
         print("Using existing 'successful_image_update.mender' in current directory")

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -240,8 +240,8 @@ def determine_active_passive_part(bitbake_variables):
     elif mount_output.find(b) >= 0:
         return (b, a)
     else:
-        raise Exception("Could not determine active partition. Mount output: %s"
-                        % mount_output)
+        raise Exception("Could not determine active partition. Mount output:\n {}" \
+                        "\nwas looking for {}".format(mount_output, (a, b)))
 
 
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -40,6 +40,8 @@ def pytest_addoption(parser):
     parser.addoption("--bitbake-image", action="store",
                      default='core-image-full-cmdline',
                      help="image to build during the tests")
+    parser.addoption("--keep-build-dir", action="store_true", default=False,
+                     help="do not remove Yocto build directory after each test")
 
 
 def pytest_configure(config):

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -37,6 +37,9 @@ def pytest_addoption(parser):
     parser.addoption("--sdimg-location", action="store",
                      default=os.getcwd(),
                      help="location to the sdimg you want to install on the bbb")
+    parser.addoption("--bitbake-image", action="store",
+                     default='core-image-full-cmdline',
+                     help="image to build during the tests")
 
 
 def pytest_configure(config):

--- a/tests/acceptance/requirements.txt
+++ b/tests/acceptance/requirements.txt
@@ -1,0 +1,3 @@
+Fabric
+python-lzo
+ubi-reader

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -94,7 +94,7 @@ class TestBuild:
         """Test that setting IMAGE_ROOTFS_EXTRA_SPACE to arbitrary values does
         not break the build."""
 
-        add_to_local_conf(prepared_test_build, 'IMAGE_EXTRA_ROOTFS_SPACE_append = " + 640 - 222 + 900"')
+        add_to_local_conf(prepared_test_build, 'IMAGE_ROOTFS_EXTRA_SPACE_append = " + 640 - 222 + 900"')
 
         run_bitbake(prepared_test_build)
 

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -47,6 +47,7 @@ class TestBuild:
                               % output.split()[0], shell=True)
 
 
+    @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
     def test_bootloader_embed(self, prepared_test_build):
         """Test that IMAGE_BOOTLOADER_FILE causes the bootloader to be embedded
         correctly in the resulting sdimg."""
@@ -88,6 +89,7 @@ class TestBuild:
         os.close(embedded)
 
 
+    @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
     def test_image_rootfs_extra_space(self, prepared_test_build, bitbake_variables):
         """Test that setting IMAGE_ROOTFS_EXTRA_SPACE to arbitrary values does
         not break the build."""
@@ -101,6 +103,7 @@ class TestBuild:
         assert(os.stat(built_rootfs).st_size == int(bitbake_variables['MENDER_CALC_ROOTFS_SIZE']) * 1024)
 
 
+    @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
     def test_artifact_signing_keys(self, prepared_test_build, bitbake_variables, bitbake_path):
         """Test that MENDER_ARTIFACT_SIGNING_KEY and MENDER_ARTIFACT_VERIFY_KEY
         works correctly."""
@@ -128,6 +131,7 @@ class TestBuild:
         finally:
             os.remove("artifact-verify-key.pem")
 
+    @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
     def test_state_scripts(self, prepared_test_build, bitbake_variables, bitbake_path, latest_rootfs, latest_mender_image):
         """Test that state scripts that are specified in the build are included
         correctly."""

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -47,7 +47,7 @@ class TestBuild:
                               % output.split()[0], shell=True)
 
 
-    @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
+    @pytest.mark.only_with_image('sdimg')
     def test_bootloader_embed(self, prepared_test_build):
         """Test that IMAGE_BOOTLOADER_FILE causes the bootloader to be embedded
         correctly in the resulting sdimg."""

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -258,9 +258,9 @@ class TestMenderArtifact:
             # not be a part of the image, in which case the image will be smaller
             # or equal to MENDER_CALC_ROOTFS_SIZE
             assert size_from_artifact <= size_from_build
-            # assume that the difference will not be more than 30% of calculated
-            # size
-            assert size_from_artifact >= 0.7 * size_from_build
+            # assume that the compressed image will be not less than 30% of
+            # allocated rootfs size size
+            assert size_from_artifact >= 0.3 * size_from_build
         elif re.match('.*\.ext[234]', gd['image']):
             assert size_from_artifact == size_from_build
         else:

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -54,6 +54,8 @@ def versioned_mender_image(request, prepared_test_build, latest_mender_image):
         LAST_BUILD_VERSION = version
     return (version, latest_build_artifact(prepared_test_build['build_dir'], ".mender"))
 
+
+@pytest.mark.only_with_image('mender')
 class TestMenderArtifact:
     def test_order(self, versioned_mender_image):
         """Test that order of components inside update is correct."""

--- a/tests/acceptance/test_rootfs.py
+++ b/tests/acceptance/test_rootfs.py
@@ -18,31 +18,43 @@ from fabric.api import *
 import pytest
 import subprocess
 import os
-import re
+import tempfile
+import shutil
+import stat
+
+from contextlib import contextmanager
 
 # Make sure common is imported after fabric, because we override some functions.
 from common import *
 
+
 class TestRootfs:
-    def test_artifact_info(self, latest_rootfs, bitbake_variables, bitbake_path):
+
+    @staticmethod
+    def verify_artifact_info_data(data, artifact_name):
+        lines = data.split()
+        assert(len(lines) == 1)
+        line = lines[0]
+        line = line.rstrip('\n\r')
+        var = line.split('=', 2)
+        assert(len(var) == 2)
+
+        var = [entry.strip() for entry in var]
+
+        assert(var[0] == "artifact_name")
+        assert(var[1] == artifact_name)
+
+    @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
+    def test_artifact_info_ext234(self, latest_rootfs, bitbake_variables, bitbake_path):
         """Test that artifact_info file is correctly embedded."""
 
         try:
-            subprocess.check_call(["debugfs", "-R", "dump -p /etc/mender/artifact_info artifact_info", latest_rootfs])
-            fd = open("artifact_info")
-            lines = fd.readlines()
-            assert(len(lines) == 1)
-            line = lines[0]
-            line = line.rstrip('\n\r')
-            var = line.split('=', 2)
-            assert(len(var) == 2)
+            subprocess.check_call(["debugfs", "-R", "dump -p /etc/mender/artifact_info artifact_info",
+                                   latest_rootfs])
+            with open("artifact_info") as fd:
+                data = fd.read()
 
-            var = [entry.strip() for entry in var]
-
-            assert(var[0] == "artifact_name")
-            assert(var[1] == bitbake_variables["MENDER_ARTIFACT_NAME"])
-
-            fd.close()
+            TestRootfs.verify_artifact_info_data(data, bitbake_variables["MENDER_ARTIFACT_NAME"])
 
             assert(os.stat("artifact_info").st_mode & 0777 == 0644)
 
@@ -57,3 +69,29 @@ class TestRootfs:
                 os.remove("artifact_info")
             except:
                 pass
+
+    @pytest.mark.only_with_image('ubifs')
+    def test_artifact_info_ubifs(self, latest_ubifs, bitbake_variables, bitbake_path):
+        """Test that artifact_info file is correctly embedded."""
+
+        with make_tempdir() as tmpdir:
+            # NOTE: ubireader_extract_files can keep permissions only if
+            # running as root, which we won't do
+            subprocess.check_call("ubireader_extract_files -o {outdir} {ubifs}".format(outdir=tmpdir,
+                                                                                       ubifs=latest_ubifs),
+                                  shell=True)
+            path = os.path.join(tmpdir, "etc/mender/artifact_info")
+            with open(path) as fd:
+                data = fd.read()
+
+            TestRootfs.verify_artifact_info_data(data, bitbake_variables["MENDER_ARTIFACT_NAME"])
+
+
+@contextmanager
+def make_tempdir():
+    tdir = tempfile.mkdtemp(prefix='meta-mender-acceptance.')
+    print('created dir', tdir)
+    try:
+        yield tdir
+    finally:
+        shutil.rmtree(tdir)

--- a/tests/acceptance/test_rootfs.py
+++ b/tests/acceptance/test_rootfs.py
@@ -19,10 +19,7 @@ import pytest
 import subprocess
 import os
 import tempfile
-import shutil
 import stat
-
-from contextlib import contextmanager
 
 # Make sure common is imported after fabric, because we override some functions.
 from common import *
@@ -85,13 +82,3 @@ class TestRootfs:
                 data = fd.read()
 
             TestRootfs.verify_artifact_info_data(data, bitbake_variables["MENDER_ARTIFACT_NAME"])
-
-
-@contextmanager
-def make_tempdir():
-    tdir = tempfile.mkdtemp(prefix='meta-mender-acceptance.')
-    print('created dir', tdir)
-    try:
-        yield tdir
-    finally:
-        shutil.rmtree(tdir)

--- a/tests/acceptance/test_sdimg.py
+++ b/tests/acceptance/test_sdimg.py
@@ -45,6 +45,7 @@ def extract_partition(sdimg, number):
                            "skip=%d" % start, "count=%d" % (end - start)])
 
 
+@pytest.mark.only_with_image('sdimg')
 class TestSdimg:
     def test_total_size(self, bitbake_variables, latest_sdimg):
         """Test that the total size of the sdimg is correct."""

--- a/tests/acceptance/test_ubimg.py
+++ b/tests/acceptance/test_ubimg.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+# Copyright 2016 Mender Software AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from fabric.api import *
+
+import pytest
+import subprocess
+import os
+
+# Make sure common is imported after fabric, because we override some functions.
+from common import *
+
+def extract_ubimg(path, outdir):
+    """Extract ubi image to a directory inside `outdir`. Returns path to a the
+    directory, where contents of each volume are in direct sub-directories.
+    Sub-directories are named after volumes.
+    """
+    subprocess.check_call("ubireader_extract_files -o {} {}".format(outdir, path),
+                          shell=True)
+    # extract to the following directories:
+    # /tmp/meta-mender-acceptance.xzkPVM/148052886/data
+    # /tmp/meta-mender-acceptance.xzkPVM/148052886/rootfsa
+    # /tmp/meta-mender-acceptance.xzkPVM/148052886/rootfsb
+    volumes_root = os.path.join(outdir, os.listdir(outdir)[0])
+    return volumes_root
+
+
+def extract_ubimg_info(path):
+
+    output = subprocess.check_output("ubireader_utils_info -r {}".format(path), shell=True)
+
+    # Example output from ubireader_utils_info:
+    #
+    # Volume data
+    #     alignment       -a 1
+    #     default_compr   -x lzo
+    #     fanout          -f 8
+    #     image_seq       -Q 24735236
+    #     key_hash        -k r5
+    #     leb_size        -e 262016
+    #     log_lebs        -l 4
+    #     max_bud_bytes   -j 8388608
+    #     max_leb_cnt     -c 1024
+    #     min_io_size     -m 8
+    #     name            -N data
+    #     orph_lebs       -p 1
+    #     peb_size        -p 262144
+    #     sub_page_size   -s 64
+    #     version         -x 1
+    #     vid_hdr_offset  -O 64
+    #     vol_id          -n 2
+    #
+    #     #ubinize.ini#
+    #     [data]
+    #     vol_name=data
+    #     vol_size=17031040
+    #     vol_flags=0
+    #     vol_type=dynamic
+    #     vol_alignment=1
+    #     vol_id=2
+
+    data = {}
+    volume = None
+    ubinize = None
+
+    for line in output.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+
+        pieces = line.split()
+        # print("pieces", pieces, line)
+
+        if pieces[0] == 'Volume':
+            # reached 'Volume <volname>' banner
+
+            # save old volume information
+            if ubinize and volume:
+                volume['ubinize'] = ubinize
+            if volume:
+                data[volume['name']] = volume
+
+            # start new volume and ubinize
+            volume = {'name': pieces[1]}
+            ubinize = None
+
+        elif volume is not None:
+            # inside volume
+
+            if pieces[0] == '#ubinize.ini#':
+                # reached '#ubinize.ini#' banner
+                ubinize = {}
+
+            elif ubinize is not None:
+                # currently parsing ubninize.ini part
+
+                if pieces[0] == '[{}]'.format(volume['name']):
+                    # hit [<volname>] line
+                    continue
+
+                elif '=' in pieces[0]:
+                    param, val = pieces[0].split('=')
+                    ubinize[param] = val
+
+            else:
+                # currently parsing volume part
+                if len(pieces) == 3:
+                    volume[pieces[0]] = pieces[2]
+
+    # parsing finished
+
+    # save last parsed volume information
+    if ubinize and not 'ubinize' in volume:
+        volume['ubinize'] = ubinize
+    if volume and not volume['name'] in data:
+        data[volume['name']] = volume
+
+    # print('volume data:', data)
+    return data
+
+
+@pytest.mark.only_with_image('ubimg')
+class TestUbimg:
+    def test_total_size(self, bitbake_variables, latest_ubimg):
+        """Test that the size of the ubimg and its volumes are correct."""
+
+        total_size_file = os.stat(latest_ubimg).st_size
+        total_size_max_expected = int(bitbake_variables['MENDER_STORAGE_TOTAL_SIZE_MB']) * 1024 * 1024
+
+        assert total_size_file <= total_size_max_expected
+
+        data_size = int(bitbake_variables['MENDER_DATA_PART_SIZE_MB']) * 1024 * 1024
+        # rootfs size is in kB
+        rootfs_size = int(bitbake_variables['MENDER_CALC_ROOTFS_SIZE']) * 1024
+
+        expected_total = data_size + rootfs_size * 2
+
+        # NOTE: ubifs employs compression so the actual ubi image file size
+        # will be less than what we calculated
+        assert total_size_file < expected_total
+        # but assume the image will not be less than 60% of expected size
+        assert total_size_file > 0.6 * expected_total
+
+    def test_volumes(self, bitbake_variables, latest_ubimg):
+        """Test that ubimg has correnct number of volumes, each with correct size &
+        config"""
+
+        ubinfo = extract_ubimg_info(latest_ubimg)
+
+        # we're expecting 3 volumes, rootfsa, rootfsb and data
+        assert len(ubinfo) == 3
+        assert all([volname in ubinfo for volname in ['rootfsa', 'rootfsb', 'data']])
+
+        data_size = int(bitbake_variables['MENDER_DATA_PART_SIZE_MB']) * 1024 * 1024
+        # rootfs size is in kB
+        rootfs_size = int(bitbake_variables['MENDER_CALC_ROOTFS_SIZE']) * 1024
+
+        # UBI adds overhead, so the actual volume size will be slightly more
+        # than what requested. add 2% for overhead
+        assert int(ubinfo['data']['ubinize']['vol_size']) <= 1.02 * data_size
+        assert int(ubinfo['rootfsa']['ubinize']['vol_size']) <= 1.02 * rootfs_size
+        assert int(ubinfo['rootfsb']['ubinize']['vol_size']) <= 1.02 * rootfs_size
+
+    def test_volume_contents(self, bitbake_variables, latest_ubimg):
+        """Test that data volume has correct contents"""
+
+        with make_tempdir() as tmpdir:
+            rootdir = extract_ubimg(latest_ubimg, tmpdir)
+
+            assert os.path.exists(os.path.join(rootdir, 'rootfsa/usr/bin/mender'))
+            assert os.path.exists(os.path.join(rootdir, 'rootfsb/usr/bin/mender'))
+            # TODO: verify contents of data partition

--- a/tests/acceptance/test_ubimg.py
+++ b/tests/acceptance/test_ubimg.py
@@ -150,8 +150,8 @@ class TestUbimg:
         # NOTE: ubifs employs compression so the actual ubi image file size
         # will be less than what we calculated
         assert total_size_file < expected_total
-        # but assume the image will not be less than 60% of expected size
-        assert total_size_file > 0.6 * expected_total
+        # but assume the image will not be less than 30% of expected size
+        assert total_size_file > 0.3 * expected_total
 
     def test_volumes(self, bitbake_variables, latest_ubimg):
         """Test that ubimg has correnct number of volumes, each with correct size &

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -25,10 +25,6 @@ import tempfile
 # Make sure common is imported after fabric, because we override some functions.
 from common import *
 
-if pytest.config.getoption("--bbb"):
-    image_type = "beaglebone"
-else:
-    image_type = "vexpress-qemu"
 
 class Helpers:
     @staticmethod
@@ -135,6 +131,8 @@ class TestUpdates:
 
         (active_before, passive_before) = determine_active_passive_part(bitbake_variables)
 
+        image_type = bitbake_variables["MACHINE"]
+
         try:
             # Make a dummy/broken update
             subprocess.call("dd if=/dev/zero of=image.dat bs=1M count=0 seek=16", shell=True)
@@ -159,11 +157,13 @@ class TestUpdates:
             os.remove("image.mender")
             os.remove("image.dat")
 
-    def test_too_big_image_update(self):
+    def test_too_big_image_update(self, bitbake_variables):
         if not env.host_string:
             # This means we are not inside execute(). Recurse into it!
-            execute(self.test_too_big_image_update)
+            execute(self.test_too_big_image_update, bitbake_variables)
             return
+
+        image_type = bitbake_variables["MACHINE"]
 
         try:
             # Make a too big update
@@ -412,6 +412,8 @@ class TestUpdates:
         else:
             sig_key = None
 
+        image_type = bitbake_variables["MACHINE"]
+
         subprocess.check_call("mender-artifact write rootfs-image %s -t %s -n test-update -u image.dat -o image.mender"
                               % (artifact_args, image_type), shell=True)
 
@@ -561,6 +563,8 @@ class TestUpdates:
         old_checksums = Helpers.get_env_checksums(bitbake_variables)
 
         orig_env = run("fw_printenv")
+
+        image_type = bitbake_variables["MACHINE"]
 
         try:
             # Make a dummy/broken update

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -513,6 +513,7 @@ class TestUpdates:
                 run("rm -f /etc/mender/%s" % os.path.basename(sig_key.public))
 
 
+    @pytest.mark.only_for_machine('vexpress-qemu')
     def test_redundant_uboot_env(self, successful_image_update_mender, bitbake_variables):
         """This tests a very specific scenario: Consider the following production
         scenario: You are currently running an update on rootfs partition


### PR DESCRIPTION
Currently contains also what's already up for review in #323 will rebase when that one is merged.

Work in progress, I'm testing with both `vexpress-qemu` and `vexpress-qemu-flash`. You will need a modification to mednersoftware/mender-qa scripts in order to build for `vexpress-qemu-flash` as the tests don't set `MACHINE` on their own.

Most of `test_build` tests are skipped, because they rely heavily on ext* images. All of mender-artifact tests are all usable. `test_rootfs` contains a separate tests for `ubimg` and `sdimg`. All of `test_sdimg` are skipped for non-sdimg images. `test_update` was not updated yet.

@kacf @GregorioDiStefano @pasinskim 
