### PR TITLE
integration fixes

### DIFF
--- a/meta-mender-qemu/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-mender-qemu/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,5 @@
+
+do_install_append () {
+	install -d ${D}${systemd_unitdir}/system/network.target.wants
+  ln -s ../sshdgenkeys.service ${D}${systemd_unitdir}/system/network.target.wants/
+}

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -42,6 +42,8 @@ UBOOT_ELF=${UBOOT_ELF:-"${BUILDTMP}/deploy/images/${MACHINE}/u-boot.elf"}
 VEXPRESS_IMG=${VEXPRESS_IMG:-"${BUILDTMP}/deploy/images/${MACHINE}/${IMAGE_NAME}-${MACHINE}.sdimg"}
 QEMU_SYSTEM_ARM=${QEMU_SYSTEM_ARM:-"qemu-system-arm"}
 RANDOM_MAC="52:54:00$(od -txC -An -N3 /dev/urandom|tr \  :)"
+# use to pass -drive .. parameters directly
+QEMU_DRIVE=${QEMU_DRIVE:-""}
 
 QEMU_ARGS=""
 case $VEXPRESS_IMG in
@@ -53,8 +55,12 @@ case $VEXPRESS_IMG in
         QEMU_ARGS="$QEMU_ARGS -drive file=/tmp/nor0,if=pflash,format=raw -drive file=/tmp/nor1,if=pflash,format=raw "
         ;;
     *)
-        echo "unsupported image $VEXPRESS_IMG"
-        exit 1
+        if [ -n "$QEMU_DRIVE" ]; then
+            QEMU_ARGS="$QEMU_ARGS $QEMU_DRIVE "
+        else
+            echo "unsupported image $VEXPRESS_IMG"
+            exit 1
+        fi
 esac
 
 QEMU_AUDIO_DRV=none \

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -64,7 +64,7 @@ case $VEXPRESS_IMG in
 esac
 
 QEMU_AUDIO_DRV=none \
-    $QEMU_SYSTEM_ARM \
+    exec $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
     -m 128M \
     -kernel "$UBOOT_ELF" \

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -120,11 +120,11 @@ def reboot(wait = 120):
     qemu_prep_after_boot()
 
 
-def run_after_connect(cmd, wait = 120):
+def run_after_connect(cmd, wait=360):
     output = ""
     start_time = time.time()
     # Use shorter timeout to get a faster cycle.
-    with settings(timeout = 5, abort_exception = Exception):
+    with settings(timeout=5, abort_exception=Exception):
         while True:
             attempt_time = time.time()
             try:

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -22,6 +22,8 @@ import os
 import re
 import subprocess
 import time
+import tempfile
+
 import conftest
 
 def if_not_bbb(func):
@@ -425,7 +427,7 @@ def run_bitbake(prepared_test_build):
 def prepared_test_build_base(request, bitbake_variables, latest_sdimg):
     """Base fixture for prepared_test_build. Returns the same as that one."""
 
-    build_dir = os.path.join(os.environ['BUILDDIR'], "test-build-tmp")
+    build_dir = tempfile.mkdtemp(prefix="test-build-", dir=os.environ['BUILDDIR'])
 
     def cleanup_test_build():
         run_verbose("rm -rf %s" % build_dir)

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -117,8 +117,8 @@ def reboot(wait = 120):
 def run_after_connect(cmd, wait=360):
     output = ""
     start_time = time.time()
-    # Use shorter timeout to get a faster cycle.
-    with settings(timeout=5, abort_exception=Exception):
+
+    with settings(timeout=30, abort_exception=Exception):
         while True:
             attempt_time = time.time()
             try:
@@ -130,7 +130,7 @@ def run_after_connect(cmd, wait=360):
                     raise Exception("Could not reconnect to QEMU")
                 now = time.time()
                 if now - attempt_time < 5:
-                    time.sleep(5 - (now - attempt_time))
+                    time.sleep(60)
                 continue
     return output
 

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -260,9 +260,11 @@ def setup_bbb(request):
         request.addfinalizer(bbb_finalizer)
 
 @pytest.fixture(scope="module")
-def qemu_running(request, latest_sdimg):
+def qemu_running(request, clean_image):
     if pytest.config.getoption("--bbb"):
         return
+
+    latest_sdimg = latest_build_artifact(clean_image['build_dir'], ".sdimg")
 
     qemu, img_path = start_qemu(latest_sdimg)
     print("qemu started with pid {}, image {}".format(qemu.pid, img_path))
@@ -461,6 +463,13 @@ def run_verbose(cmd):
 def run_bitbake(prepared_test_build):
     run_verbose("%s && bitbake %s" % (prepared_test_build['env_setup'],
                                       prepared_test_build['image_name']))
+
+
+@pytest.fixture(scope="module")
+def clean_image(request, prepared_test_build_base):
+    run_bitbake(prepared_test_build_base)
+    return prepared_test_build_base
+
 
 @pytest.fixture(scope="session")
 def prepared_test_build_base(request, bitbake_variables, latest_sdimg):

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -461,6 +461,8 @@ def run_bitbake(prepared_test_build):
 
 @pytest.fixture(scope="module")
 def clean_image(request, prepared_test_build_base):
+    add_to_local_conf(prepared_test_build_base,
+                      'SYSTEMD_AUTO_ENABLE_pn-mender = "disable"')
     run_bitbake(prepared_test_build_base)
     return prepared_test_build_base
 

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -40,6 +40,10 @@ def start_qemu(latest_sdimg):
     if pytest.config.getoption("bbb"):
         return
 
+    fh, img_path = tempfile.mkstemp(suffix=".qcow2", prefix="test-image")
+    # don't need an open fd to temp file
+    os.close(fh)
+
     # Make a disposable image.
     try:
         qemu_img = os.environ["QEMU_SYSTEM_ARM"]
@@ -48,14 +52,17 @@ def start_qemu(latest_sdimg):
     qemu_img = re.sub("-system-arm$", "-img", qemu_img)
     subprocess.check_call([qemu_img, "create", "-f", "qcow2", "-o",
                            "backing_file=%s" % latest_sdimg,
-                           "test-image.qcow2"])
+                           img_path])
 
-    os.environ["VEXPRESS_SDIMG"] = "test-image.qcow2"
-    proc = subprocess.Popen("../../meta-mender-qemu/scripts/mender-qemu")
+    env = dict(os.environ)
+    # pass QEMU drive directly
+    env["QEMU_DRIVE"] = "-drive file={},if=sd,format=qcow2".format(img_path)
+    env["VEXPRESS_IMG"] = img_path
+    proc = subprocess.Popen("../../meta-mender-qemu/scripts/mender-qemu", env=env)
     # Make sure we are connected.
     execute(run_after_connect, "true", hosts = conftest.current_hosts())
     execute(qemu_prep_after_boot, hosts = conftest.current_hosts())
-    return proc
+    return proc, img_path
 
 @if_not_bbb
 def kill_qemu():
@@ -238,7 +245,8 @@ def qemu_running(request, latest_sdimg):
     if pytest.config.getoption("--bbb"):
         return
 
-    kill_qemu()
+    qemu, img_path = start_qemu(latest_sdimg)
+    print("qemu stated with pid %s, image %s".format(qemu.pid, img_path))
 
     # Make sure we revert to the first root partition on next reboot, makes test
     # cases more predictable.
@@ -249,17 +257,21 @@ def qemu_running(request, latest_sdimg):
                 sudo("halt")
                 halt_time = time.time()
                 # Wait up to 30 seconds for shutdown.
-                while halt_time + 30 > time.time() and is_qemu_running():
+                while halt_time + 30 > time.time() and qemu.poll() is None:
                     time.sleep(1)
             except:
                 # Nothing we can do about that.
                 pass
-            kill_qemu()
+
+            # kill qemu
+            qemu.kill()
+            qemu.wait()
+            os.remove(img_path)
+
         execute(qemu_finalizer_impl, hosts=conftest.current_hosts())
 
     request.addfinalizer(qemu_finalizer)
 
-    start_qemu(latest_sdimg)
     execute(qemu_prep_fresh_host, hosts=conftest.current_hosts())
 
 


### PR DESCRIPTION
```
commit e6952b8ae150052b1d4ae960de2f2999c55b565d
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Thu Jun 29 08:17:52 2017 +0200

    tests: support QEMU_DRIVE, refactor qemu handling
    
    Add support for setting up QEMU_DRIVE. Use a temporary file to store the image.
    Cleanning this up required refactoring to the actual handling of qemu
    startup/teardown.
    
    Also fixes a problem when the tests went on a rampage and killed all instances
    of qemu-system-arm.
    
    Changelog: none
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 207a7b506a71401b9e4a2d635cf50b0242770302
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Thu Jun 29 08:04:37 2017 +0200

    meta-mender-qemu/mender-qemu: exec qemu
    
    This should allow a reasonable cleanup when killing the helper script. Also,
    qemu was already being started as the last no-return command anyway.
    
    Changelog: none
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 40df3b6d5885a912065cfe69b70ad2a31991378e
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Thu Jun 29 08:03:11 2017 +0200

    meta-mender-qemu/mender-qemu: add QEMU_DRIVE env variable for passing -drive parameter directly to qemu
    
    Add QEMU_DRIVE environment varialbe that will be used as fallback when image
    format is not supproted. This way, one can pass a `-drive ...` parameter
    directly to qemu.
    
    Changelog: title
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

commit 69a8641a158756f5dab038eae3caae5f8e8ddf1c
Author: Maciej Borzecki <maciej.borzecki@rndity.com>
Date:   Tue Jun 27 16:49:47 2017 +0200

    tests: use proper tempdir BUILDDIR/test-build-XXXX for building OE
    
    Changelog: title
    
    Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
```

@GregorioDiStefano @kacf commits that fix integration testing

Note, once the build completes, you'll need to push the resulting container image to docker hub.