### PR TITLE
raspberrypi: use bootargs passed on by boot firmware

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi/boot.cmd
@@ -1,8 +1,8 @@
-run mender_setup
 setenv fdtfile bcm2708-rpi-b.dtb
-setenv bootargs earlyprintk console=tty0 console=ttyAMA0,115200 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr_r}
+load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi0/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi0/boot.cmd
@@ -1,8 +1,8 @@
-run mender_setup
 setenv fdtfile bcm2708-rpi-b.dtb
-setenv bootargs earlyprintk console=tty0 console=ttyAMA0,115200 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr_r}
+load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi2/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi2/boot.cmd
@@ -1,8 +1,8 @@
-run mender_setup
 setenv fdtfile bcm2709-rpi-2-b.dtb
-setenv bootargs earlyprintk console=tty0 console=ttyAMA0,115200 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr_r}
+load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi3/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi3/boot.cmd
@@ -1,8 +1,8 @@
-run mender_setup
 setenv fdtfile bcm2710-rpi-3-b.dtb
-setenv bootargs earlyprintk console=tty0 console=ttyAMA0,115200 root=${mender_kernel_root} rootfstype=ext4 rootwait noinitrd
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr_r} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr_r}
+load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
+bootm ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,0 +1,2 @@
+CMDLINE_remove = "root=/dev/mmcblk0p2"
+CMDLINE_append = " root=\${mender_kernel_root}"


### PR DESCRIPTION
Currently we completly ignore what boot firmware feels that we
should use as bootargs and we define our own. By doing so we
lose some functionality. This patch attempts to improve this.

The bootargs looks like this now:

8250.nr_uarts=0 bcm2708_fb.fbwidth=1184 bcm2708_fb.fbheight=624 bcm2708_fb.fbswap=1 vc_mem.mem_base=0x3dc00000 vc_mem.mem_size=0x3f000000 dwc_otg.lpm_enable=0 console=ttyS0,115200 rootfstype=ext4
rootwait root=/dev/mmcblk0p3

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@endian.se>