### PR TITLE
Change compatible device types to follow device type of build.

### DIFF
--- a/meta-mender-core/classes/mender-install.bbclass
+++ b/meta-mender-core/classes/mender-install.bbclass
@@ -37,7 +37,7 @@ MENDER_BOOT_PART_FSTYPE ??= "auto"
 MENDER_DEVICE_TYPE ?= "${MACHINE}"
 
 # Space separated list of device types compatible with the built update.
-MENDER_DEVICE_TYPES_COMPATIBLE ?= "${MACHINE}"
+MENDER_DEVICE_TYPES_COMPATIBLE ?= "${MENDER_DEVICE_TYPE}"
 
 # Total size of the medium that mender sdimg will be written to. The size of
 # rootfs partition will be calculated automatically by subtracting the size of


### PR DESCRIPTION
Changelog: Change MENDER_DEVICE_TYPES_COMPATIBLE to follow value of
MENDER_DEVICE_TYPE by default. This triggers the correct behavior when
MENDER_DEVICE_TYPE has been redefined.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>