### PR TITLE
mender: get rid of IMAGE_DEPENDS

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -8,7 +8,7 @@ MENDER_ARTIFACT_SIGNING_KEY ?= ""
 
 # --------------------------- END OF CONFIGURATION -----------------------------
 
-IMAGE_DEPENDS_mender = "mender-artifact-native"
+do_image_mender[depends] += "mender-artifact-native:do_populate_sysroot"
 
 ARTIFACTIMG_FSTYPE  ??= "ext4"
 IMAGE_CMD_mender () {

--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -59,7 +59,7 @@ python() {
             d.setVar('IMAGE_TYPEDEP_sdimg_append', " " + fs)
 }
 
-IMAGE_DEPENDS_sdimg += "${IMAGE_DEPENDS_wic} wic-tools dosfstools-native mtools-native rsync-native"
+do_image_sdimg[depends] += "${@d.getVarFlag('do_image_wic', 'depends', False)} wic-tools:do_populate_sysroot dosfstools-native:do_populate_sysroot mtools-native:do_populate_sysroot rsync-native:do_populate_sysroot"
 
 IMAGE_CMD_sdimg() {
     set -ex

--- a/meta-mender-core/classes/mender-ubimg.bbclass
+++ b/meta-mender-core/classes/mender-ubimg.bbclass
@@ -23,7 +23,7 @@ IMAGE_TYPEDEP_ubimg_append = "ubifs"
 inherit image
 inherit image_types
 
-IMAGE_DEPENDS_ubimg += " mtd-utils-native"
+do_image_ubimg[depends] += "mtd-utils-native:do_populate_sysroot"
 
 IMAGE_CMD_ubimg () {
     # For some reason, logging is not working correctly inside IMAGE_CMD bodies,

--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -31,7 +31,7 @@ in addition to `meta-mender` dependencies.
         MENDER_PARTITION_ALIGNMENT_KB = "4096"
         MENDER_BOOT_PART_SIZE_MB = "40"
 
-        IMAGE_DEPENDS_sdimg += " bcm2835-bootfiles"
+        do_image_sdimg[depends] += " bcm2835-bootfiles:do_populate_sysroot"
 
         # raspberrypi files aligned with mender layout requirements
         IMAGE_BOOT_FILES_append = " boot.scr u-boot.bin;${SDIMG_KERNELIMAGE}"


### PR DESCRIPTION
Replaced usage of IMAGE_DEPENDS_<type> with explicitly added
dependencies to do_image_<type> tasks.

This is related to upstream Yocto changes.  For reference:
    https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=f93d58378fb4095a18c1403de03ca0e13ce465cd
    https://bugzilla.yoctoproject.org/show_bug.cgi?id=11302

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>