### PR TITLE
[pyro] Rewrite git recipes to be smarter when selecting versions.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -1,16 +1,5 @@
 require mender-artifact.inc
 
-def mender_branch_from_preferred_version(pref_version):
-    if not pref_version:
-        return "master"
-    else:
-        # Return part before "-git", which should be branch name.
-        return pref_version[0:pref_version.index("-git")]
-
-MENDER_ARTIFACT_BRANCH = "${@mender_branch_from_preferred_version(d.getVar('PREFERRED_VERSION'))}"
-
-SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=${MENDER_ARTIFACT_BRANCH}"
-
 # The revision listed below is not really important, it's just a way to avoid
 # network probing during parsing if we are not gonna build the git version
 # anyway. If git version is enabled, the AUTOREV will be chosen instead of the
@@ -23,7 +12,34 @@ def mender_artifact_autorev_if_git_version(d):
         return "77326b288c70cd713e7ad15d2a084b6ee797e8ff"
 SRCREV ?= '${@mender_artifact_autorev_if_git_version(d)}'
 
-PV = "${MENDER_ARTIFACT_BRANCH}-git${SRCPV}"
+def mender_branch_from_preferred_version(pref_version):
+    import re
+    match = re.match(r"^[0-9]+\.[0-9]+\.", pref_version)
+    if match is not None:
+        # If the preferred version is some kind of version, use the branch name
+        # for that one (1.0.x style).
+        return match.group(0) + "x"
+    else:
+        # Else return master as branch.
+        return "master"
+MENDER_ARTIFACT_BRANCH = "${@mender_branch_from_preferred_version('${PREFERRED_VERSION}')}"
+
+def mender_version_from_preferred_version(pref_version, srcpv):
+    if pref_version.find("-git") >= 0:
+        # If "-git" is in the version, remove it along with any suffix it has,
+        # and then readd it with commit SHA.
+        return "%s-git%s" % (pref_version[0:pref_version.index("-git")], srcpv)
+    elif pref_version.find("-build") >= 0:
+        # If "-build" is in the version, use the version as is. This means that
+        # we can build tags with "-build" in them from this recipe, but not
+        # final tags, which will need their own recipe.
+        return pref_version
+    else:
+        # Else return the default "master-git".
+        return "master-git%s" % srcpv
+PV = "${@mender_version_from_preferred_version('${PREFERRED_VERSION}', '${SRCPV}')}"
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=${MENDER_ARTIFACT_BRANCH}"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.


### PR DESCRIPTION
It should behave like this:

* If PREFERRED_VERSION is unset or a bare version tag, set version to
  "master-git<SHA>" to prevent the recipe from being selected.

* If PREFERRED_VERSION has a tag with "-build" in it, set version to
  that version, in order to be able to use the Git recipe for building
  temporary tags without needing to create a recipe for each one.

* If PREFFERED_VERSION contains "-git", set the version to that
  string, minus any "%" suffix and plus <SHA>. This will build a
  binary with a temporary version string.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 2d7ffec95a59a3168345fb5305632afe620c4e9d)