### PR TITLE
tests: Add mandatory minimum Mender version mark to all tests.

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -71,10 +71,6 @@ def pytest_configure(config):
     env.combine_stderr = False
 
 
-def pytest_unconfigure(config):
-    pass
-
-
 def current_hosts():
     # Workaround for being inside/outside execute().
     if env.host_string:

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -37,6 +37,7 @@ class EmbeddedBootloader:
 
 
 class TestBuild:
+    @pytest.mark.min_mender_version("1.0.0")
     def test_default_server_certificate(self):
         """Test that the md5sum we have on record matches the server certificate.
         This makes sure the warning about this certificate is correct."""
@@ -49,6 +50,7 @@ class TestBuild:
 
 
     @pytest.mark.only_with_image('sdimg')
+    @pytest.mark.min_mender_version("1.0.0")
     def test_bootloader_embed(self, prepared_test_build):
         """Test that IMAGE_BOOTLOADER_FILE causes the bootloader to be embedded
         correctly in the resulting sdimg."""
@@ -91,6 +93,7 @@ class TestBuild:
 
 
     @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
+    @pytest.mark.min_mender_version("1.0.0")
     def test_image_rootfs_extra_space(self, prepared_test_build, bitbake_variables):
         """Test that setting IMAGE_ROOTFS_EXTRA_SPACE to arbitrary values does
         not break the build."""
@@ -105,6 +108,7 @@ class TestBuild:
 
 
     @pytest.mark.only_for_image('sdimg')
+    @pytest.mark.min_mender_version("1.0.0")
     def test_tenant_token(self, prepared_test_build):
         """Test setting a custom tenant-token"""
 
@@ -129,6 +133,7 @@ class TestBuild:
 
 
     @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
+    @pytest.mark.min_mender_version("1.1.0")
     def test_artifact_signing_keys(self, prepared_test_build, bitbake_variables, bitbake_path):
         """Test that MENDER_ARTIFACT_SIGNING_KEY and MENDER_ARTIFACT_VERIFY_KEY
         works correctly."""
@@ -157,6 +162,7 @@ class TestBuild:
             os.remove("artifact-verify-key.pem")
 
     @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
+    @pytest.mark.min_mender_version("1.2.0")
     def test_state_scripts(self, prepared_test_build, bitbake_variables, bitbake_path, latest_rootfs, latest_mender_image):
         """Test that state scripts that are specified in the build are included
         correctly."""

--- a/tests/acceptance/test_commits.py
+++ b/tests/acceptance/test_commits.py
@@ -17,6 +17,7 @@ import pytest
 import re
 import subprocess
 
+@pytest.mark.min_mender_version("1.0.0")
 class TestCommits:
     def test_commits(self):
         # First find which range to check. Include HEAD and exclude all known

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -57,6 +57,7 @@ def versioned_mender_image(request, prepared_test_build, latest_mender_image):
 
 @pytest.mark.only_with_image('mender')
 class TestMenderArtifact:
+    @pytest.mark.min_mender_version("1.0.0")
     def test_order(self, versioned_mender_image):
         """Test that order of components inside update is correct."""
 
@@ -131,6 +132,7 @@ class TestMenderArtifact:
         assert(meta_data_found)
 
 
+    @pytest.mark.min_mender_version("1.0.0")
     def test_files_list_integrity(self, versioned_mender_image):
         """Test that the list of files in the manifest is the same as the actual
         file list."""
@@ -168,6 +170,7 @@ class TestMenderArtifact:
         assert(sorted(manifest_list) == sorted(tar_list))
 
 
+    @pytest.mark.min_mender_version("1.0.0")
     def test_files_checksum_integrity(self, versioned_mender_image):
         """Test that the checksum of each file is correct."""
 
@@ -227,6 +230,7 @@ class TestMenderArtifact:
             assert hasher.hexdigest() == recorded_hash, "%s doesn't match" % file
 
 
+    @pytest.mark.min_mender_version("1.0.0")
     def test_artifacts_validation(self, versioned_mender_image, bitbake_path):
         """Test that the mender-artifact tool validates the update successfully."""
 
@@ -234,6 +238,7 @@ class TestMenderArtifact:
 
         subprocess.check_call(["mender-artifact", "validate", mender_image])
 
+    @pytest.mark.min_mender_version("1.0.0")
     def test_artifacts_rootfs_size(self, versioned_mender_image, bitbake_path, bitbake_variables):
         """Test that the rootfs has the expected size. This relies on
         IMAGE_ROOTFS_SIZE *not* being overridden in the build."""

--- a/tests/acceptance/test_rootfs.py
+++ b/tests/acceptance/test_rootfs.py
@@ -56,6 +56,7 @@ class TestRootfs:
             occurred[cols[1]] = True
 
     @pytest.mark.only_with_image('ext4', 'ext3', 'ext2')
+    @pytest.mark.min_mender_version("1.0.0")
     def test_expected_files_ext234(self, latest_rootfs, bitbake_variables, bitbake_path):
         """Test that artifact_info file is correctly embedded."""
 
@@ -81,6 +82,7 @@ class TestRootfs:
                 raise
 
     @pytest.mark.only_with_image('ubifs')
+    @pytest.mark.min_mender_version("1.2.0")
     def test_expected_files_ubifs(self, latest_ubifs, bitbake_variables, bitbake_path):
         """Test that artifact_info file is correctly embedded."""
 

--- a/tests/acceptance/test_sdimg.py
+++ b/tests/acceptance/test_sdimg.py
@@ -47,6 +47,7 @@ def extract_partition(sdimg, number):
 
 
 @pytest.mark.only_with_image('sdimg')
+@pytest.mark.min_mender_version("1.0.0")
 class TestSdimg:
 
     @staticmethod

--- a/tests/acceptance/test_ubimg.py
+++ b/tests/acceptance/test_ubimg.py
@@ -132,6 +132,7 @@ def extract_ubimg_info(path):
 
 
 @pytest.mark.only_with_image('ubimg')
+@pytest.mark.min_mender_version('1.2.0')
 class TestUbimg:
     def test_total_size(self, bitbake_variables, latest_ubimg):
         """Test that the size of the ubimg and its volumes are correct."""

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -122,6 +122,7 @@ class SignatureCase:
 @pytest.mark.usefixtures("qemu_running", "no_image_file", "setup_bbb", "bitbake_path")
 class TestUpdates:
 
+    @pytest.mark.min_mender_version('1.0.0')
     def test_broken_image_update(self, bitbake_variables):
 
         if not env.host_string:
@@ -157,6 +158,7 @@ class TestUpdates:
             os.remove("image.mender")
             os.remove("image.dat")
 
+    @pytest.mark.min_mender_version('1.0.0')
     def test_too_big_image_update(self, bitbake_variables):
         if not env.host_string:
             # This means we are not inside execute(). Recurse into it!
@@ -180,6 +182,7 @@ class TestUpdates:
             os.remove("image-too-big.mender")
             os.remove("image.dat")
 
+    @pytest.mark.min_mender_version('1.0.0')
     def test_network_based_image_update(self, successful_image_update_mender, bitbake_variables):
         http_server_location = pytest.config.getoption("--http-server")
         bbb = pytest.config.getoption("--bbb")
@@ -379,6 +382,7 @@ class TestUpdates:
                                             artifact_version=None,
                                             success=False),
                              ])
+    @pytest.mark.min_mender_version('1.1.0')
     def test_signed_updates(self, sig_case, bitbake_path, bitbake_variables):
         """Test various combinations of signed and unsigned, present and non-
         present verification keys."""
@@ -525,6 +529,7 @@ class TestUpdates:
 
 
     @pytest.mark.only_for_machine('vexpress-qemu')
+    @pytest.mark.min_mender_version('1.0.0')
     def test_redundant_uboot_env(self, successful_image_update_mender, bitbake_variables):
         """This tests a very specific scenario: Consider the following production
         scenario: You are currently running an update on rootfs partition


### PR DESCRIPTION
This is in order to support multiple versions of Mender with the
acceptance tests, since they live in a repository which is versioned
after poky, not Mender.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>