### PR TITLE
rpi: Fix DTB handling for Mender-based Raspberry Pi boards.

### DIFF
--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -2,7 +2,7 @@
 
 This Yocto layers contains recipes which enables support of building Mender client for Raspberry Pi boards.
 
-**NOTE!**. To be able to support update of Linux kernel and DTB these are installed to `/boot` on rootfs. This breaks support of user configurations based on `config.txt` because the Raspberry Pi boot firmware requires that the DTB file is in the same partition as the boot firmware files (mmcblk0p1). Boot firmware normally patches the DTB file based on configurations in `config.txt`.
+**NOTE!**. To be able to support update of Linux kernel and DTB, Mender requires these to be installed in the `/boot` directory for each rootfs (normally /dev/mmcblk0p2 and /dev/mmcblk0p3). On the other hand, the Raspberry Pi boot firmware requires that the DTB file is in the same partition as the boot firmware (/dev/mmcbl0p1) and the config.txt file. For now Mender will not use the DTB that is delivered with new artifacts and will continue to boot with the original DTB that was populated using the SDIMG file.
 
 Above should not pose any problems if you do not require any changes in `config.txt` and the default configuration certainly is enough to run Mender client.
 

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd
@@ -1,8 +1,6 @@
-setenv fdtfile bcm2708-rpi-b.dtb
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
 bootm ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi0/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi0/boot.cmd
@@ -1,8 +1,0 @@
-setenv fdtfile bcm2708-rpi-b.dtb
-fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
-run mender_setup
-mmc dev ${mender_uboot_dev}
-load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr}
-run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi2/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi2/boot.cmd
@@ -1,8 +1,0 @@
-setenv fdtfile bcm2709-rpi-2-b.dtb
-fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
-run mender_setup
-mmc dev ${mender_uboot_dev}
-load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr}
-run mender_try_to_recover

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi3/boot.cmd
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/raspberrypi3/boot.cmd
@@ -1,8 +1,0 @@
-setenv fdtfile bcm2710-rpi-3-b.dtb
-fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
-run mender_setup
-mmc dev ${mender_uboot_dev}
-load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-load ${mender_uboot_root} ${fdt_addr} /boot/${fdtfile}
-bootm ${kernel_addr_r} - ${fdt_addr}
-run mender_try_to_recover


### PR DESCRIPTION
On the Raspberry Pi platform, the DTB is generate by the start.elf firmware
and we should defer to that rather than loading the "standard" DTB file.
This is fixed in the meta-raspberrypi layer here:
    https://www.mail-archive.com/yocto@yoctoproject.org/msg32465.html

Additional links with details:
    https://www.raspberrypi.org/forums//viewtopic.php?f=107&t=134018
    http://dius.com.au/2015/08/19/raspberry-pi-uboot/

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>