### PR TITLE
Make sure filesystem label is set for data partition. 

### DIFF
--- a/meta-mender-core/classes/mender-sdimg.bbclass
+++ b/meta-mender-core/classes/mender-sdimg.bbclass
@@ -112,7 +112,7 @@ IMAGE_CMD_sdimg() {
     chmod 0444 "${WORKDIR}/data/mender/device_type"
 
     dd if=/dev/zero of="${WORKDIR}/data.$FSTYPE" count=0 bs=1M seek=${MENDER_DATA_PART_SIZE_MB}
-    mkfs.$FSTYPE -F "${WORKDIR}/data.$FSTYPE" -d "${WORKDIR}/data"
+    mkfs.$FSTYPE -F "${WORKDIR}/data.$FSTYPE" -d "${WORKDIR}/data" -L data
 
     wks="${WORKDIR}/mender-sdimg.wks"
     rm -f "$wks"


### PR DESCRIPTION
Since we are using rawcopy/fsimage in the wks entry for the data
partition, wic makes no attempt to set it, so we need to set it when
creating the filesystem.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>