### PR TITLE
raspberrypi: remove legacy documentation from README

### DIFF
--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -4,8 +4,6 @@ This Yocto layers contains recipes which enables support of building Mender clie
 
 **NOTE!**. To be able to support update of Linux kernel and DTB, Mender requires these to be installed in the `/boot` directory for each rootfs (normally /dev/mmcblk0p2 and /dev/mmcblk0p3). On the other hand, the Raspberry Pi boot firmware requires that the DTB file is in the same partition as the boot firmware (/dev/mmcbl0p1) and the config.txt file. For now Mender will not use the DTB that is delivered with new artifacts and will continue to boot with the original DTB that was populated using the SDIMG file.
 
-Above should not pose any problems if you do not require any changes in `config.txt` and the default configuration certainly is enough to run Mender client.
-
 ## Dependencies
 
 This layer depends on:


### PR DESCRIPTION
Changes done in 264cf2ee4c12e072a1343e0102dfc70a35ee93c5 make this line obsolete.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>