### PR TITLE
MEN-1431: Make UEFI image generator: uefiimg.

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -10,7 +10,9 @@ MENDER_ARTIFACT_SIGNING_KEY ?= ""
 
 do_image_mender[depends] += "mender-artifact-native:do_populate_sysroot"
 
-ARTIFACTIMG_FSTYPE  ??= "ext4"
+ARTIFACTIMG_FSTYPE ??= "${ARTIFACTIMG_FSTYPE_DEFAULT}"
+ARTIFACTIMG_FSTYPE_DEFAULT = "ext4"
+
 IMAGE_CMD_mender () {
     set -x
 

--- a/meta-mender-core/classes/mender-setup-ubi.inc
+++ b/meta-mender-core/classes/mender-setup-ubi.inc
@@ -1,39 +1,34 @@
-python() {
-    if bb.utils.contains('DISTRO_FEATURES', 'mender-ubi', True, False, d):
-        # Using "_defaultval" is the same as a '??=' assignment.
+ARTIFACTIMG_FSTYPE_DEFAULT_mender-ubi = "ubifs"
 
-        d.setVarFlag("ARTIFACTIMG_FSTYPE", "_defaultval", "ubifs")
+MENDER_STORAGE_DEVICE_DEFAULT_mender-ubi = "ubi0"
 
-        d.setVarFlag("MENDER_STORAGE_DEVICE", "_defaultval", "ubi0")
+# The base name of the devices that hold individual volumes.
+MENDER_STORAGE_DEVICE_BASE_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE}_"
 
-        # The base name of the devices that hold individual volumes.
-        d.setVarFlag("MENDER_STORAGE_DEVICE_BASE", "_defaultval", "${MENDER_STORAGE_DEVICE}_")
+# The numbers of the two rootfs partitions in the A/B partition layout.
+MENDER_ROOTFS_PART_A_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE_BASE}0"
+MENDER_ROOTFS_PART_B_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE_BASE}1"
 
-        # The numbers of the two rootfs partitions in the A/B partition layout.
-        d.setVarFlag("MENDER_ROOTFS_PART_A", "_defaultval", "${MENDER_STORAGE_DEVICE_BASE}0")
-        d.setVarFlag("MENDER_ROOTFS_PART_B", "_defaultval", "${MENDER_STORAGE_DEVICE_BASE}1")
+# The partition number holding the data partition.
+MENDER_DATA_PART_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE_BASE}2"
+MENDER_DATA_PART_FSTYPE_DEFAULT_mender-ubi = "ubifs"
 
-        # The partition number holding the data partition.
-        d.setVarFlag("MENDER_DATA_PART", "_defaultval", "${MENDER_STORAGE_DEVICE_BASE}2")
-        d.setVarFlag("MENDER_DATA_PART_FSTYPE", "_defaultval", "ubifs")
+# u-boot command ubifsmount requires volume name as the only argument
+# and hence we need to keep track of that since we load kernel/dtb from
+# rootfs part
+#
+# It also needs the volume index e.g.
+# ubifsmount ubi0:rootfsa
+MENDER_ROOTFS_PART_A_NAME_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE}:rootfsa"
+MENDER_ROOTFS_PART_B_NAME_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE}:rootfsb"
 
-        # u-boot command ubifsmount requires volume name as the only argument
-        # and hence we need to keep track of that since we load kernel/dtb from
-        # rootfs part
-        #
-        # It also needs the volume index e.g.
-        # ubifsmount ubi0:rootfsa
-        d.setVarFlag("MENDER_ROOTFS_PART_A_NAME", "_defaultval", "${MENDER_STORAGE_DEVICE}:rootfsa")
-        d.setVarFlag("MENDER_ROOTFS_PART_B_NAME", "_defaultval", "${MENDER_STORAGE_DEVICE}:rootfsb")
+# The name of of the MTD part holding your UBI volumes.
+MENDER_MTD_UBI_DEVICE_NAME_DEFAULT_mender-ubi = "ubi"
 
-        # The name of of the MTD part holding your UBI volumes.
-        d.setVarFlag("MENDER_MTD_UBI_DEVICE_NAME", "_defaultval", "ubi")
+# Boot part is not used when building UBI image.
+MENDER_BOOT_PART_DEFAULT_mender-ubi = ""
+MENDER_BOOT_PART_SIZE_MB_DEFAULT_mender-ubi = "0"
 
-        # Boot part is not used when building UBI image.
-        d.setVarFlag("MENDER_BOOT_PART", "_defaultval", "")
-        d.setVarFlag("MENDER_BOOT_PART_SIZE_MB", "_defaultval", "0")
-
-        # These are not applicable when building UBI image.
-        d.setVarFlag("MENDER_UBOOT_STORAGE_DEVICE", "_defaultval", "dummy")
-        d.setVarFlag("MENDER_UBOOT_STORAGE_INTERFACE", "_defaultval", "dummy")
-}
+# These are not applicable when building UBI image.
+MENDER_UBOOT_STORAGE_DEVICE_DEFAULT_mender-ubi = "dummy"
+MENDER_UBOOT_STORAGE_INTERFACE_DEFAULT_mender-ubi = "dummy"

--- a/meta-mender-core/classes/mender-setup-uboot.inc
+++ b/meta-mender-core/classes/mender-setup-uboot.inc
@@ -1,5 +1,6 @@
 EXTRA_IMAGEDEPENDS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', ' u-boot', '', d)}"
 
+
 def mender_get_env_total_aligned_size(bootenv_size, bootenv_range, alignment_kb):
     alignment_bytes = alignment_kb * 1024
 
@@ -35,3 +36,11 @@ MENDER_STORAGE_RESERVED_RAW_SPACE_DEFAULT_mender-uboot = \
     "${@mender_get_env_total_aligned_size(${MENDER_PARTITION_ALIGNMENT_KB}, \
                                           ${MENDER_PARTITION_ALIGNMENT_KB}, \
                                           ${MENDER_PARTITION_ALIGNMENT_KB})}"
+
+# u-boot environment file
+IMAGE_UENV_TXT_FILE ?= ""
+
+IMAGE_BOOT_FILES_append_mender-uboot = " ${IMAGE_UENV_TXT_FILE}"
+
+# make sure to provide a weak default
+UBOOT_SUFFIX ??= "bin"

--- a/meta-mender-core/classes/mender-setup-uboot.inc
+++ b/meta-mender-core/classes/mender-setup-uboot.inc
@@ -24,15 +24,14 @@ def mender_get_env_total_aligned_size(bootenv_size, bootenv_range, alignment_kb)
 
     return "%d" % total_env_size
 
-MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET ?= "${@eval('${MENDER_PARTITION_ALIGNMENT_KB} * 1024')}"
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET ??= "${@eval('${MENDER_PARTITION_ALIGNMENT_KB} * 1024')}"
 
 # The total occupied length of the environment on disk, after alignment has been
 # taken into account. This is a guesstimate, and will be matched against the
 # real size in the U-Boot recipe later. Must be an *even* multiple of the
 # alignment. Most people should not need to set this, and if so, only because it
 # produces an error if left to the default.
-MENDER_STORAGE_RESERVED_RAW_SPACE ??= "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', \
-                                                            mender_get_env_total_aligned_size(${MENDER_PARTITION_ALIGNMENT_KB}, \
-                                                                                              ${MENDER_PARTITION_ALIGNMENT_KB}, \
-                                                                                              ${MENDER_PARTITION_ALIGNMENT_KB}), \
-                                                            '0', d)}"
+MENDER_STORAGE_RESERVED_RAW_SPACE_DEFAULT_mender-uboot = \
+    "${@mender_get_env_total_aligned_size(${MENDER_PARTITION_ALIGNMENT_KB}, \
+                                          ${MENDER_PARTITION_ALIGNMENT_KB}, \
+                                          ${MENDER_PARTITION_ALIGNMENT_KB})}"

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -1,58 +1,75 @@
 # ------------------------------ CONFIGURATION ---------------------------------
 
 # The storage device that holds the device partitions.
-MENDER_STORAGE_DEVICE ??= "/dev/mmcblk0"
+MENDER_STORAGE_DEVICE ??= "${MENDER_STORAGE_DEVICE_DEFAULT}"
+MENDER_STORAGE_DEVICE_DEFAULT = "/dev/mmcblk0"
 
 # The base name of the devices that hold individual partitions.
 # This is often MENDER_STORAGE_DEVICE + "p".
-MENDER_STORAGE_DEVICE_BASE ??= "${MENDER_STORAGE_DEVICE}p"
+MENDER_STORAGE_DEVICE_BASE ??= "${MENDER_STORAGE_DEVICE_BASE_DEFAULT}"
+MENDER_STORAGE_DEVICE_BASE_DEFAULT = "${MENDER_STORAGE_DEVICE}p"
 
 # The partition number holding the boot partition.
-MENDER_BOOT_PART ??= "${MENDER_STORAGE_DEVICE_BASE}1"
+MENDER_BOOT_PART ??= "${MENDER_BOOT_PART_DEFAULT}"
+MENDER_BOOT_PART_DEFAULT = "${MENDER_STORAGE_DEVICE_BASE}1"
 
 # The numbers of the two rootfs partitions in the A/B partition layout.
-MENDER_ROOTFS_PART_A ??= "${MENDER_STORAGE_DEVICE_BASE}2"
-MENDER_ROOTFS_PART_B ??= "${MENDER_STORAGE_DEVICE_BASE}3"
+MENDER_ROOTFS_PART_A ??= "${MENDER_ROOTFS_PART_A_DEFAULT}"
+MENDER_ROOTFS_PART_A_DEFAULT = "${MENDER_STORAGE_DEVICE_BASE}2"
+MENDER_ROOTFS_PART_B ??= "${MENDER_ROOTFS_PART_B_DEFAULT}"
+MENDER_ROOTFS_PART_B_DEFAULT = "${MENDER_STORAGE_DEVICE_BASE}3"
 
 # The names of the two rootfs partitions in the A/B partition layout. By default
 # it is the same name as MENDER_ROOTFS_PART_A and MENDER_ROOTFS_B
-MENDER_ROOTFS_PART_A_NAME ??= "${MENDER_ROOTFS_PART_A}"
-MENDER_ROOTFS_PART_B_NAME ??= "${MENDER_ROOTFS_PART_B}"
+MENDER_ROOTFS_PART_A_NAME ??= "${MENDER_ROOTFS_PART_A_NAME_DEFAULT}"
+MENDER_ROOTFS_PART_A_NAME_DEFAULT = "${MENDER_ROOTFS_PART_A}"
+MENDER_ROOTFS_PART_B_NAME ??= "${MENDER_ROOTFS_PART_B_NAME_DEFAULT}"
+MENDER_ROOTFS_PART_B_NAME_DEFAULT = "${MENDER_ROOTFS_PART_B}"
 
 # The partition number holding the data partition.
-MENDER_DATA_PART ??= "${MENDER_STORAGE_DEVICE_BASE}4"
+MENDER_DATA_PART ??= "${MENDER_DATA_PART_DEFAULT}"
+MENDER_DATA_PART_DEFAULT = "${MENDER_STORAGE_DEVICE_BASE}4"
 
 # The name of of the MTD part holding your UBI volumes.
-MENDER_MTD_UBI_DEVICE_NAME ??= ""
+MENDER_MTD_UBI_DEVICE_NAME ??= "${MENDER_MTD_UBI_DEVICE_NAME_DEFAULT}"
+MENDER_MTD_UBI_DEVICE_NAME_DEFAULT = ""
 
 # Filesystem type of data partition. This configuration is used in fstab. Most
 # filesystems can be auto detected, but some can not and hence we allow the
 # user to override this.
-MENDER_DATA_PART_FSTYPE ??= "auto"
-MENDER_BOOT_PART_FSTYPE ??= "auto"
+MENDER_DATA_PART_FSTYPE ??= "${MENDER_DATA_PART_FSTYPE_DEFAULT}"
+MENDER_DATA_PART_FSTYPE_DEFAULT = "auto"
+MENDER_BOOT_PART_FSTYPE ??= "${MENDER_BOOT_PART_FSTYPE_DEFAULT}"
+MENDER_BOOT_PART_FSTYPE_DEFAULT = "auto"
 
 # Device type of device when making an initial partitioned image.
-MENDER_DEVICE_TYPE ?= "${MACHINE}"
+MENDER_DEVICE_TYPE ??= "${MENDER_DEVICE_TYPE_DEFAULT}"
+MENDER_DEVICE_TYPE_DEFAULT = "${MACHINE}"
 
 # Space separated list of device types compatible with the built update.
-MENDER_DEVICE_TYPES_COMPATIBLE ?= "${MENDER_DEVICE_TYPE}"
+MENDER_DEVICE_TYPES_COMPATIBLE ??= "${MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT}"
+MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT = "${MENDER_DEVICE_TYPE}"
 
 # Total size of the medium that mender sdimg will be written to. The size of
 # rootfs partition will be calculated automatically by subtracting the size of
 # boot and data partitions along with some predefined overhead (see
 # MENDER_PARTITIONING_OVERHEAD_KB).
-MENDER_STORAGE_TOTAL_SIZE_MB ?= "1024"
+MENDER_STORAGE_TOTAL_SIZE_MB ??= "${MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT}"
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "1024"
 
 # Optional location where a directory can be specified with content that should
 # be included on the data partition. Some of Mender's own files will be added to
 # this (e.g. OpenSSL certificates).
-MENDER_DATA_PART_DIR ?= ""
+MENDER_DATA_PART_DIR ??= "${MENDER_DATA_PART_DIR_DEFAULT}"
+MENDER_DATA_PART_DIR_DEFAULT = ""
 
 # Size of the data partition, which is preserved across updates.
-MENDER_DATA_PART_SIZE_MB ?= "128"
+MENDER_DATA_PART_SIZE_MB ??= "${MENDER_DATA_PART_SIZE_MB_DEFAULT}"
+MENDER_DATA_PART_SIZE_MB_DEFAULT = "128"
 
 # Size of the first (FAT) partition, that contains the bootloader
-MENDER_BOOT_PART_SIZE_MB ??= "16"
+MENDER_BOOT_PART_SIZE_MB ??= "${MENDER_BOOT_PART_SIZE_MB_DEFAULT}"
+MENDER_BOOT_PART_SIZE_MB_DEFAULT = "16"
 
 # For performance reasons, we try to align the partitions to the SD
 # card's erase block. It is impossible to know this information with
@@ -62,22 +79,26 @@ MENDER_BOOT_PART_SIZE_MB ??= "16"
 #
 # 8MB alignment is a safe setting that might waste some space if the
 # erase block is smaller.
-MENDER_PARTITION_ALIGNMENT_KB ?= "8192"
+MENDER_PARTITION_ALIGNMENT_KB ??= "${MENDER_PARTITION_ALIGNMENT_KB_DEFAULT}"
+MENDER_PARTITION_ALIGNMENT_KB_DEFAULT = "8192"
 
 # The reserved space between the partition table and the first partition.
 # Most people don't need to set this, and it will be automatically overridden
 # by mender-uboot distro feature.
-#MENDER_STORAGE_RESERVED_RAW_SPACE ??= "0"
+MENDER_STORAGE_RESERVED_RAW_SPACE ??= "${MENDER_STORAGE_RESERVED_RAW_SPACE_DEFAULT}"
+MENDER_STORAGE_RESERVED_RAW_SPACE_DEFAULT = "0"
 
 # The interface to load partitions from. This is normally empty, in which case
 # it is deduced from MENDER_STORAGE_DEVICE. Only use this if the interface
 # cannot be deduced from MENDER_STORAGE_DEVICE.
-MENDER_UBOOT_STORAGE_INTERFACE ??= ""
+MENDER_UBOOT_STORAGE_INTERFACE ??= "${MENDER_UBOOT_STORAGE_INTERFACE_DEFAULT}"
+MENDER_UBOOT_STORAGE_INTERFACE_DEFAULT = ""
 
 # The device number of the interface to load partitions from. This is normally
 # empty, in which case it is deduced from MENDER_STORAGE_DEVICE. Only use this
 # if the indexing of devices is different in U-Boot and in the Linux kernel.
-MENDER_UBOOT_STORAGE_DEVICE ??= ""
+MENDER_UBOOT_STORAGE_DEVICE ??= "${MENDER_UBOOT_STORAGE_DEVICE_DEFAULT}"
+MENDER_UBOOT_STORAGE_DEVICE_DEFAULT = ""
 
 # --------------------------- END OF CONFIGURATION -----------------------------
 

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -100,10 +100,18 @@ MENDER_UBOOT_STORAGE_INTERFACE_DEFAULT = ""
 MENDER_UBOOT_STORAGE_DEVICE ??= "${MENDER_UBOOT_STORAGE_DEVICE_DEFAULT}"
 MENDER_UBOOT_STORAGE_DEVICE_DEFAULT = ""
 
+# This will be embedded into the boot sector, or close to the boot sector, where
+# exactly depends on the offset variable. Since it is a machine specific
+# setting, the default value is an empty string.
+IMAGE_BOOTLOADER_FILE ??= ""
+
+# Offset of bootloader, in sectors (512 bytes).
+IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET ??= "2"
+
 # --------------------------- END OF CONFIGURATION -----------------------------
 
 IMAGE_INSTALL_append = " mender"
-IMAGE_CLASSES += "mender-sdimg mender-ubimg mender-artifactimg"
+IMAGE_CLASSES += "mender-part-images mender-ubimg mender-artifactimg"
 
 # MENDER_FEATURES_ENABLE and MENDER_FEATURES_DISABLE map to
 # DISTRO_FEATURES_BACKFILL and DISTRO_FEATURES_BACKFILL_CONSIDERED,

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -103,6 +103,6 @@ def mender_get_env_offset(start_offset, index, total_aligned_size):
         raise Exception("env index out of range in mender_get_env_offset: Should not happen")
 
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 ?= "${@mender_get_env_offset(${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET}, 1, \
-                                                                     ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE})}"
+                                                                      ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE})}"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 ?= "${@mender_get_env_offset(${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET}, 2, \
-                                                                     ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE})}"
+                                                                      ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE})}"

--- a/meta-mender-qemu/conf/machine/vexpress-qemu.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu.conf
@@ -14,7 +14,7 @@ require conf/machine/include/vexpress.inc
 # Needed to skip particular QA checks that don't apply to U-boot's binary.
 INSANE_SKIP_u-boot += "ldflags textrel"
 
-IMAGE_BOOT_FILES_mender-uboot ?= "u-boot.${UBOOT_SUFFIX}"
+IMAGE_BOOT_FILES ?= "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', 'u-boot.${UBOOT_SUFFIX}', '', d)}"
 
 # Enable systemd by default for vexpress-qemu.
 DISTRO_FEATURES_append = " systemd"


### PR DESCRIPTION
This is the first step in booting via UEFI. This just creates an image
using the GPT partition table format, which UEFI requires. There are
some shortcomings in this implementation, which will be resolved in
upcoming tasks:

* The boot partition source in the wks file should be changed to
  'bootimg-efi'. However, this can't be done until we have a valid
  bootloader available like grub. Hence the EFI partition is not valid
  at the moment.

* Right now you have to set IMAGE_BOOT_FILES to a dummy file in order
  for wic not to complain. This will also go away once we get a real
  EFI bootloader in place.

We also tweak some variable assignments after it was revealed that
removing mender-uboot from DISTRO_FEATURES caused some problems.

Changelog: title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>