### PR TITLE
Fix custom set IMAGE_ROOTFS_SIZE not being respected.

### DIFF
--- a/meta-mender-core/classes/mender-setup-install.inc
+++ b/meta-mender-core/classes/mender-setup-install.inc
@@ -31,17 +31,12 @@ MENDER_CALC_ROOTFS_SIZE = "${@mender_calculate_rootfs_size_kb(${MENDER_STORAGE_T
                                                               ${MENDER_PARTITIONING_OVERHEAD_KB}, \
                                                               ${MENDER_STORAGE_RESERVED_RAW_SPACE})}"
 
-python() {
-    if bb.utils.contains('DISTRO_FEATURES', 'mender-install', True, False, d):
-        # Gently apply this as the default image size.  But subtract
-        # IMAGE_ROOTFS_EXTRA_SPACE, since it will be added automatically in
-        # later bitbake calculations.
-        d.setVar('IMAGE_ROOTFS_SIZE', str(eval("(%s) - (%s)" % (d.getVar('MENDER_CALC_ROOTFS_SIZE'),
-                                                                d.getVar('IMAGE_ROOTFS_EXTRA_SPACE')))))
+# Gently apply this as the default image size.
+# But subtract IMAGE_ROOTFS_EXTRA_SPACE, since it will be added automatically
+# in later bitbake calculations.
+IMAGE_ROOTFS_SIZE ?= "${@eval('${MENDER_CALC_ROOTFS_SIZE} - (${IMAGE_ROOTFS_EXTRA_SPACE})')}"
 
-        # Set hard limit on maximum rootfs size. Calculated rootfs size is used
-        # when partitioning the disk image (be it SD card or UBI image), and
-        # defines an upper bound of the space allocated for rootfs
-        # partition/volume.
-        d.setVar('IMAGE_ROOTFS_MAXSIZE', d.getVar('MENDER_CALC_ROOTFS_SIZE'))
-}
+# Set hard limit on maximum rootfs size. Calculated rootfs size is used when
+# partitioning the disk image (be it SD card or UBI image), and defines an upper
+# bound of the space allocated for rootfs partition/volume.
+IMAGE_ROOTFS_MAXSIZE ?= "${MENDER_CALC_ROOTFS_SIZE}"


### PR DESCRIPTION
This partially reverts variable assignment depending on distro
features.

What we want is for the assignment to happen if, and only if:
* mender-install feature is enabled
* there is no previous assignment

However it seems impossible to do this correctly, because:
* If we use an override, then even a weak default assignment overrides
  any other hard assignment.
* If we use inline Python to detect the distro feature, then the code
  executes at the end instead of where it occurs, which means our
  assignment is overridden by earlier defaults.
* It is not possible in the Python code to tell whether the currently
  set value is a default or not.
* Using a Python function in the assignment itself, we can execute at
  the right moment, but we get an infinite recursion if we try to
  access the already set value of the variable, which we'd need in
  order to set a new one conditionally.

Therefore we have to set the default always, regardless of distro
feature. Most likely this isn't a big issue since it is only a
default, which can be overridden by using the '=' operator.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>