### PR TITLE
Improve failure message when changelog or signoff is missing. 

### DIFF
--- a/tests/acceptance/test_commits.py
+++ b/tests/acceptance/test_commits.py
@@ -40,4 +40,10 @@ class TestCommits:
             # Exclude if no matches above.
             commit_range.append(branch)
 
-        subprocess.check_call(["3rdparty/mendertesting/check_commits.sh"] + commit_range)
+        try:
+            output = subprocess.check_output(["3rdparty/mendertesting/check_commits.sh"] + commit_range,
+                                             stderr=subprocess.STDOUT)
+            # Print output, useful to make sure correct commit range is checked.
+            print(output)
+        except subprocess.CalledProcessError as e:
+            pytest.fail(e.output)


### PR DESCRIPTION
By putting the error in the pytest.fail() call, it shows up in the
test result itself, instead of just buried in a log.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>