### PR TITLE
Support building without a server.crt client certificate.

### DIFF
--- a/meta-mender-core/recipes-mender/mender/mender.inc
+++ b/meta-mender-core/recipes-mender/mender/mender.inc
@@ -1,8 +1,14 @@
 DESCRIPTION = "Mender tool for doing OTA software updates."
 HOMEPAGE = "https://mender.io"
 
+def cert_location_if_server_crt_in(src_uri, d):
+    for src in src_uri.split():
+        if src.endswith("/server.crt"):
+            return "%s/mender/server.crt" % d.getVar('sysconfdir')
+    return ""
+
 MENDER_SERVER_URL ?= "https://docker.mender.io"
-MENDER_CERT_LOCATION ?= "${sysconfdir}/mender/server.crt"
+MENDER_CERT_LOCATION ?= "${@cert_location_if_server_crt_in('${SRC_URI}', d)}"
 # Tenant token
 MENDER_TENANT_TOKEN ?= "dummy"
 SYSTEMD_AUTO_ENABLE ?= "enable"
@@ -44,10 +50,6 @@ do_compile() {
     export PATH
 
     DEFAULT_CERT_MD5="1fba17436027eb1f5ceff4af9a63c9c2"
-
-    if [ ! -f ${WORKDIR}/server.crt ]; then
-        bbfatal "You have not provided a public server certificate. Please add the desired server certificate to the SRC_URI list, under the name 'server.crt'."
-    fi
 
     if [ "$(md5sum ${WORKDIR}/server.crt | awk '{ print $1 }')" = $DEFAULT_CERT_MD5 ]; then
         bbwarn "You are building with the default server certificate, which is not intended for production use"
@@ -144,7 +146,9 @@ do_install() {
     install -m 0644 ${B}/mender.conf ${D}/${sysconfdir}/mender
 
     #install server certificate
-    install -m 0444 ${WORKDIR}/server.crt ${D}/${sysconfdir}/mender
+    if [ -f ${WORKDIR}/server.crt ]; then
+        install -m 0444 ${WORKDIR}/server.crt ${D}/${sysconfdir}/mender
+    fi
 
     install -d ${D}/${localstatedir}/lib/mender
 


### PR DESCRIPTION
It's not required by the client if the server certificate is properly
signed.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>