### PR TITLE
systemd: Set default epoch to 0 to avoid fsck at first boot.

### DIFF
--- a/meta-mender-demo/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mender-demo/recipes-core/systemd/systemd_%.bbappend
@@ -15,3 +15,10 @@ do_install_append() {
   fi
 }
 
+# Avoid issues with time being out of sync on first boot.  By default,
+# systemd uses its build time as the epoch. When systemd is launched
+# on a system without a real time clock, this time will be detected as
+# in the future and an fsck will be done.  Setting this to 0 results
+# in an epoch of January 1, 1970 which is detected as an invalid time
+# and the fsck will be skipped.
+EXTRA_OECONF += "--with-time-epoch=0"


### PR DESCRIPTION
Changelog: Title

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>