### PR TITLE
Fix parse error in MENDER_CERT_LOCATION when PREFERRED_VERSION is unset.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -6,15 +6,22 @@ require mender-artifact.inc
 # SHA.
 def mender_artifact_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
     if version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
         return "77326b288c70cd713e7ad15d2a084b6ee797e8ff"
 SRCREV ?= '${@mender_artifact_autorev_if_git_version(d)}'
 
-def mender_branch_from_preferred_version(pref_version):
+def mender_branch_from_preferred_version(d):
     import re
-    match = re.match(r"^[0-9]+\.[0-9]+\.", pref_version)
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is None:
+        version = ""
+    match = re.match(r"^[0-9]+\.[0-9]+\.", version)
     if match is not None:
         # If the preferred version is some kind of version, use the branch name
         # for that one (1.0.x style).
@@ -22,7 +29,7 @@ def mender_branch_from_preferred_version(pref_version):
     else:
         # Else return master as branch.
         return "master"
-MENDER_ARTIFACT_BRANCH = "${@mender_branch_from_preferred_version('${PREFERRED_VERSION}')}"
+MENDER_ARTIFACT_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
 def mender_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")

--- a/meta-mender-core/recipes-mender/mender/mender_git.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_git.bb
@@ -6,15 +6,22 @@ require mender.inc
 # SHA.
 def mender_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
     if version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
         return "f6ffa190892202263fdb75975059fbb201adab6a"
 SRCREV ?= '${@mender_autorev_if_git_version(d)}'
 
-def mender_branch_from_preferred_version(pref_version):
+def mender_branch_from_preferred_version(d):
     import re
-    match = re.match(r"^[0-9]+\.[0-9]+\.", pref_version)
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is None:
+        version = ""
+    match = re.match(r"^[0-9]+\.[0-9]+\.", version)
     if match is not None:
         # If the preferred version is some kind of version, use the branch name
         # for that one (1.0.x style).
@@ -22,7 +29,7 @@ def mender_branch_from_preferred_version(pref_version):
     else:
         # Else return master as branch.
         return "master"
-MENDER_BRANCH = "${@mender_branch_from_preferred_version('${PREFERRED_VERSION}')}"
+MENDER_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
 def mender_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -734,6 +734,17 @@ def min_mender_version(request, bitbake_variables):
         pytest.skip("Test for Mender client %s and newer cannot run with Mender client %s"
                     % (test_version, mender_version))
 
+def versions_of_recipe(recipe):
+    """Returns a list of all the versions we have of the given recipe, excluding
+    git recipes."""
+
+    versions = []
+    for entry in os.listdir("../../meta-mender-core/recipes-mender/%s/" % recipe):
+        match = re.match(r"^%s_([1-9][0-9]*\.[0-9]+\.[0-9]+[^.]*)\.bb" % recipe, entry)
+        if match is not None:
+            versions.append(match.group(1))
+    return versions
+
 @pytest.fixture(autouse=True)
 def only_for_machine(request, bitbake_variables):
     """Fixture that enables use of `only_for_machine(machine-name)` mark.

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -671,12 +671,10 @@ def prepared_test_build_base(request, bitbake_variables):
 
     run_verbose("cp %s/conf/* %s/conf" % (os.environ['BUILDDIR'], build_dir))
     local_conf = os.path.join(build_dir, "conf", "local.conf")
-    fd = open(local_conf, "a")
-    fd.write('SSTATE_MIRRORS = " file://.* file://%s/sstate-cache/PATH"\n' % os.environ['BUILDDIR'])
-    # The idea here is to append customizations, and then reset the file by
-    # deleting everything below this line.
-    fd.write('### TEST CUSTOMIZATIONS BELOW HERE ###\n')
-    fd.close()
+    local_conf_orig = local_conf + ".orig"
+    with open(local_conf, "a") as fd:
+        fd.write('SSTATE_MIRRORS = " file://.* file://%s/sstate-cache/PATH"\n' % os.environ['BUILDDIR'])
+    run_verbose("cp %s %s" % (local_conf, local_conf_orig))
 
     os.symlink(os.path.join(os.environ['BUILDDIR'], "downloads"), os.path.join(build_dir, "downloads"))
 
@@ -685,7 +683,8 @@ def prepared_test_build_base(request, bitbake_variables):
     return {'build_dir': build_dir,
             'image_name': image_name,
             'env_setup': env_setup,
-            'local_conf': local_conf
+            'local_conf': local_conf,
+            'local_conf_orig': local_conf_orig,
     }
 
 
@@ -699,21 +698,11 @@ def prepared_test_build(prepared_test_build_base):
     - local_conf
     """
 
-    old_file = prepared_test_build_base['local_conf']
-    new_file = old_file + ".tmp"
+    new_file = prepared_test_build_base['local_conf']
+    old_file = prepared_test_build_base['local_conf_orig']
 
-    old = open(old_file)
-    new = open(new_file, "w")
-
-    # Reset "local.conf" by removing everything below the special line.
-    for line in old:
-        new.write(line)
-        if line == "### TEST CUSTOMIZATIONS BELOW HERE ###\n":
-            break
-
-    old.close()
-    new.close()
-    os.rename(new_file, old_file)
+    # Restore original local.conf
+    run_verbose("cp %s %s" % (old_file, new_file))
 
     return prepared_test_build_base
 


### PR DESCRIPTION
```
commit e2e69ebaf8c7dd5ebeae24a913c0faa1d25d180a
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Oct 12 13:55:01 2017

    Fix parse error in MENDER_CERT_LOCATION when PREFERRED_VERSION is unset.
    
    Also add a long desired test, which tests all common combinations of
    PREFERRED_VERSIONs. This tests that we can build all tagged versions
    of Mender, something that isn't normally checked in Jenkins, because
    it builds using PREFERRED_VERSION and a SHA. It also checks that
    different types of PREFERRED_VERSION, including with and without
    "pn-", and including being missing altogether, builds successfully.
    
    Changelog: Title
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 92aa055d76bca814c7d8ff7e799eea1924576b24
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Oct 12 13:54:04 2017

    tests: Keep a backup of original local.conf instead of grepping for changes.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```