### PR TITLE
rpi-u-boot-scr: Switch to boot.cmd.in style recipe.

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -2,5 +2,5 @@ fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
-bootm ${kernel_addr_r} - ${fdt_addr}
+@@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover


### PR DESCRIPTION
Commit e9bb7f0c6d3f77312970034ca0a63b3df0e3ba8e in meta-raspberrypi changed
the processing of this file so we need to adjust.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>