### PR TITLE
tests: Make sure kernel is loaded from correct partition. 

### DIFF
--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -221,6 +221,11 @@ class TestUpdates:
         output = run("fw_printenv mender_boot_part")
         assert(output == "mender_boot_part=" + passive_before[-1:])
 
+        # Delete kernel and associated files from currently running partition,
+        # so that the boot will fail if U-Boot for any reason tries to grab the
+        # kernel from the wrong place.
+        run("rm -rf /boot/*")
+
         reboot()
 
         run_after_connect("true")


### PR DESCRIPTION
This originally came out of the discussion at:
https://github.com/mendersoftware/meta-mender/pull/403#issuecomment-339889998

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>