### PR TITLE
Work around bug in libpseudo regarding file owners on data partition.

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -39,7 +39,7 @@ mender_part_image() {
     mkdir -p "${WORKDIR}/data"
 
     if [ -n "${MENDER_DATA_PART_DIR}" ]; then
-        rsync -a ${MENDER_DATA_PART_DIR}/* "${WORKDIR}/data"
+        rsync -a --no-owner --no-group ${MENDER_DATA_PART_DIR}/* "${WORKDIR}/data"
         chown -R root:root "${WORKDIR}/data"
     fi
 


### PR DESCRIPTION
For some reason if we let rsync set the owner and group information
first, it becomes impossible to set them to something else later on.
The exact cause is unknown, but it may be that rsync uses fchown(),
while we use chown(), and that this triggers the bug. In any case,
avoiding setting the owner and group with rsync seems to fix the
problem.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>