### PR TITLE
Improve resiliency of RPi3 image flashing by booting Raspbian kernel.

### DIFF
--- a/tests/meta-mender-raspberrypi3-ci/conf/layer.conf
+++ b/tests/meta-mender-raspberrypi3-ci/conf/layer.conf
@@ -8,3 +8,5 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "meta-mender-raspberrypi3-ci"
 BBFILE_PATTERN_meta-mender-raspberrypi3-ci = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-mender-raspberrypi3-ci = "99"
+
+IMAGE_BOOT_FILES_append = " boot-for-flashing.scr"

--- a/tests/meta-mender-raspberrypi3-ci/recipes-bsp/rpi-u-boot-scr/files/boot-for-flashing.cmd
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-bsp/rpi-u-boot-scr/files/boot-for-flashing.cmd
@@ -1,0 +1,3 @@
+fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
+load usb 0 ${kernel_addr_r} /kernel7.img
+bootz ${kernel_addr_r} - ${fdt_addr}

--- a/tests/meta-mender-raspberrypi3-ci/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
@@ -1,0 +1,13 @@
+# Provide boot file specifically for booting from USB to Flash a Mender image.
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " file://boot-for-flashing.cmd"
+
+do_compile_append() {
+    mkimage -A arm -T script -C none -n "Boot script for flashing Mender image" -d "${WORKDIR}/boot-for-flashing.cmd" boot-for-flashing.scr
+}
+
+do_deploy_append() {
+    install -m 644 boot-for-flashing.scr ${DEPLOYDIR}
+}

--- a/tests/meta-mender-raspberrypi3-ci/recipes-mender/mender-qa/files/rpi/activate-test-image
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-mender/mender-qa/files/rpi/activate-test-image
@@ -1,23 +1,26 @@
 #!/bin/bash
 set -e -x
 MOUNT_DEV=${MOUNT_DEV:-/dev/mmcblk0p1}
-UENV_MOUNTD=/mnt
+if [ -d /uboot ]; then
+    MOUNTPOINT=/uboot
+else
+    MOUNTPOINT=/mnt
+fi
 
 case "$1" in
     status)
-        if [ -e $UENV_FILE ]; then
-            val=$(grep -e "uenvcmd=" $UENV_FILE 2>/dev/null)
+        if grep "mender" $MOUNTPOINT/boot.scr > /dev/null; then
+            echo "test image is enabled"
+        else
             echo "test image is disabled"
-            disabled=1
-        fi
-        if [ -z "$disabled" ]; then
-            echo "tests image is enabled"
         fi
         ;;
     off)
-        if grep 'mmcblk' /proc/mounts; then
+        if grep "mender" $MOUNTPOINT/boot.scr > /dev/null; then
             echo "deactivating test image"
-            echo "dwc_otg.lpm_enable=0 console=serial0,115200 rootfstype=ext4 rootwait root=/dev/sda2" > /uboot/cmdline.txt && \
+            cp $MOUNTPOINT/boot.scr $MOUNTPOINT/boot-mender.scr
+            cp $MOUNTPOINT/boot-for-flashing.scr $MOUNTPOINT/boot.scr
+            sed -ie 's,root=${mender_kernel_root},root=/dev/sda2,' $MOUNTPOINT/cmdline.txt
             reboot
         else
             echo "test-image not running"
@@ -26,9 +29,12 @@ case "$1" in
         ;;
     on|'')
         echo "activating test image"
-        mount $MOUNT_DEV $UENV_MOUNTD && \
-            echo 'dwc_otg.lpm_enable=0 console=serial0,115200 rootfstype=ext4 rootwait root=${mender_kernel_root}' > /mnt/cmdline.txt && \
-            umount $MOUNT_DEV && \
-            reboot
+        mount $MOUNT_DEV $MOUNTPOINT
+        if [ -f $MOUNTPOINT/boot-mender.scr ]; then
+            cp $MOUNTPOINT/boot-mender.scr $MOUNTPOINT/boot.scr
+        fi
+        sed -ie 's,root=/dev/sda2,root=${mender_kernel_root},' $MOUNTPOINT/cmdline.txt
+        umount $MOUNT_DEV
+        reboot
         ;;
 esac


### PR DESCRIPTION
Previously we were booting the Mender kernel, even when we were
heading for the Raspbian OS to do a Mender sdimg flash. With this
commit we create a separate boot.scr file that can be used to boot the
kernel directly from Raspbian, avoiding any problems that might occur
because some Mender test has corrupted the Mender kernel.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>