### PR TITLE
meta-mender-raspberrypi: increase layer priority to 10

### DIFF
--- a/meta-mender-raspberrypi/conf/layer.conf
+++ b/meta-mender-raspberrypi/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "mender-raspberrypi"
 BBFILE_PATTERN_mender-raspberrypi = "^${LAYERDIR}/"
-BBFILE_PRIORITY_mender-raspberrypi = "6"
+BBFILE_PRIORITY_mender-raspberrypi = "10"


### PR DESCRIPTION
Currently meta-raspberrypi has BBFILE_PRIORITY set to 9, which means that our layer will be processed before the layer we append. 

This is not intended and we should have higher priority as there might be changes in meta-raspberrypi that need to be applied before we can apply ours. 

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@gmail.com>