### PR TITLE
tests: Prevent printing of entire 8MB update.

### DIFF
--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -488,9 +488,6 @@ class TestUpdates:
                             # Corrupt checksum by changing file slightly.
                             with open("image.dat", "r+") as fd:
                                 Helpers.corrupt_middle_byte(fd)
-                                # Need to update the expected content in this case.
-                                fd.seek(0)
-                                new_content = fd.read()
                             # Pack it up again in same order.
                             os.remove("0000.tar.gz")
                             subprocess.check_call(["tar", "czf", "0000.tar.gz"] + data_list)


### PR DESCRIPTION
After 6a420b51ef80ef, the update became much bigger, so the flipped
byte will always be outside the range of the content string we test
for, since it is in the middle of the file. So we no longer need to
update the content, and in fact doing so would print the entire thing
in the log.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>