### PR TITLE
meta-mender-core: Allow dtbos in KERNEL_DEVICETREE

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -91,8 +91,8 @@ do_provide_mender_defines() {
     DTB_COUNT=$(echo $MENDER_DTB_NAME | sed 's/\s/\n/g' | wc -l)
 
     if [ "$DTB_COUNT" -ne 1 ]; then
-        bbwarn "Found more then one dtb specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
-        MENDER_DTB_NAME=$(echo $MENDER_DTB_NAME | sed 's/\s/\n/g' | tail -1)
+        bbfatal "Found more then one dtb specified in KERNEL_DEVICETREE. Only one should be specified."
+        exit 1
     fi
 
     cat > ${S}/include/config_mender_defines.h <<EOF

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -81,9 +81,18 @@ do_provide_mender_defines() {
             ;;
     esac
 
-    MENDER_DTB_NAME=$(echo "${KERNEL_DEVICETREE}" | grep -o '[^ ]*$')
-    if [ "$MENDER_DTB_NAME" != "${KERNEL_DEVICETREE}" ]; then
-        bbwarn "More than one dtb file specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
+    MENDER_DTB_NAME=$(echo "${KERNEL_DEVICETREE}" | sed 's/\s/\n/g' | grep -v '.dtbo' | grep -o '[^ ]*$')
+
+    if [ -z "${MENDER_DTB_NAME}" ]; then
+        bbfatal "Did not find a dtb specified in KERNEL_DEVICETREE"
+        exit 1
+    fi
+
+    DTB_COUNT=$(echo ${MENDER_DTB_NAME} | sed 's/\s/\n/g' | wc -l)
+
+    if [ "${DTB_COUNT}" -ne 1 ]; then
+        bbwarn "Found more then one dtb specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
+        MENDER_DTB_NAME=$(echo $MENDER_DTB_NAME | sed 's/\s/\n/g' | tail -1)
     fi
 
     cat > ${S}/include/config_mender_defines.h <<EOF

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -83,14 +83,14 @@ do_provide_mender_defines() {
 
     MENDER_DTB_NAME=$(echo "${KERNEL_DEVICETREE}" | sed 's/\s/\n/g' | grep -v '.dtbo' | grep -o '[^ ]*$')
 
-    if [ -z "${MENDER_DTB_NAME}" ]; then
+    if [ -z "$MENDER_DTB_NAME" ]; then
         bbfatal "Did not find a dtb specified in KERNEL_DEVICETREE"
         exit 1
     fi
 
-    DTB_COUNT=$(echo ${MENDER_DTB_NAME} | sed 's/\s/\n/g' | wc -l)
+    DTB_COUNT=$(echo $MENDER_DTB_NAME | sed 's/\s/\n/g' | wc -l)
 
-    if [ "${DTB_COUNT}" -ne 1 ]; then
+    if [ "$DTB_COUNT" -ne 1 ]; then
         bbwarn "Found more then one dtb specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
         MENDER_DTB_NAME=$(echo $MENDER_DTB_NAME | sed 's/\s/\n/g' | tail -1)
     fi


### PR DESCRIPTION
Raspberry Pi kernel recipes use the KERNEL_DEVICETREE
variable to specify the dtbo overlays to build, not just
the board dtbs.

Ignore these dtbo overlays when assigning MENDER_DTB_NAME.

The existing behavior of choosing the last dtb in the list
if more then one is found is maintained.

Not sure this is a particularly good idea. It might be better
to abort if multiple dtbs are found since using the wrong
dtb for uboot will probably not work.

Signed-off-by: Scott Ellis <scott@jumpnowtek.com>