### PR TITLE
meta-mender-core: Allow dtbos in KERNEL_DEVICETREE

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -81,9 +81,19 @@ do_provide_mender_defines() {
             ;;
     esac
 
-    MENDER_DTB_NAME=$(echo "${KERNEL_DEVICETREE}" | grep -o '[^ ]*$')
-    if [ "$MENDER_DTB_NAME" != "${KERNEL_DEVICETREE}" ]; then
-        bbwarn "More than one dtb file specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
+    # Strip leading and trailing whitespace, then newline divide, and remove dtbo's.
+    MENDER_DTB_NAME="$(echo "${KERNEL_DEVICETREE}" | sed -r 's/(^\s*)|(\s*$)//g; s/\s+/\n/g' | sed -ne '/\.dtbo$/b; p')"
+
+    if [ -z "$MENDER_DTB_NAME" ]; then
+        bbfatal "Did not find a dtb specified in KERNEL_DEVICETREE"
+        exit 1
+    fi
+
+    DTB_COUNT=$(echo "$MENDER_DTB_NAME" | wc -l)
+
+    if [ "$DTB_COUNT" -ne 1 ]; then
+        bbwarn "Found more than one dtb specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
+        MENDER_DTB_NAME="$(echo "$MENDER_DTB_NAME" | tail -1)"
     fi
 
     cat > ${S}/include/config_mender_defines.h <<EOF


### PR DESCRIPTION
Raspberry Pi kernel recipes use the KERNEL_DEVICETREE
variable to specify the dtbo overlays to build, not just
the board dtbs.

Ignore these dtbo overlays when assigning MENDER_DTB_NAME.

The existing behavior of choosing the last dtb in the list
if more then one is found is maintained.

Not sure this is a particularly good idea. It might be better
to abort if multiple dtbs are found since using the wrong
dtb for uboot will probably not work.

Signed-off-by: Scott Ellis <scott@jumpnowtek.com>

Modified-by: Kristian Amlie <kristian.amlie@northern.tech>
* Add quotes around variable assignment
* Switch to sed extended regexes and '\s+'
* Remove now unneeded "grep -o"
* Remove redundant 'sed' expressions
* Add changelog

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>