### PR TITLE
Drop creation of `authtentoken` file, which is unneeded now. 

### DIFF
--- a/meta-mender-core/recipes-mender/mender/files/mender.service
+++ b/meta-mender-core/recipes-mender/mender/files/mender.service
@@ -7,7 +7,6 @@ Type=idle
 User=root
 Group=root
 ExecStartPre=/bin/mkdir -p -m 0700 /data/mender
-ExecStartPre=/bin/ln -sf /etc/mender/tenant.conf /var/lib/mender/authtentoken
 ExecStart=/usr/bin/mender -daemon
 Restart=on-abort
 


### PR DESCRIPTION
It was originally meant to hold the tenant token, but we have moved
away from that and it is now in the config file.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>