### PR TITLE
mender: Allow empty in mender-wait-for-timesync.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-wait-for-timesync/mender-wait-for-timesync_1.0.bb
+++ b/meta-mender-core/recipes-mender/mender-wait-for-timesync/mender-wait-for-timesync_1.0.bb
@@ -10,6 +10,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 inherit mender-state-scripts
 
+ALLOW_EMPTY_${PN} = "1"
+
 do_compile() {
     cp wait-for-timesync ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_10_wait-for-timesync
 }


### PR DESCRIPTION
Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>