### PR TITLE
mender-qemu: increase qemu memory size to 256MiB.

### DIFF
--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -80,7 +80,7 @@ echo "--- starting qemu"
 QEMU_AUDIO_DRV=none \
     $QEMU_SYSTEM_ARM \
     -M vexpress-a9 \
-    -m 128M \
+    -m 256M \
     -kernel "$UBOOT_ELF" \
     -net nic,macaddr="$RANDOM_MAC" \
     -net user,hostfwd=tcp::8822-:22 \


### PR DESCRIPTION
qemu does not have enough memory to allocate for upgrade process.

Logs when trying to upgrade qemu image rootfs:
root@vexpress-qemu:~# mender --rootfs https://d1b0l86ne08fsf.cloudfront.net/1.3.0/vexpress-qemu/vexpress_release_2_1.3.0.mender
--- snip ---
ERRO[0158] Could not execute fw_setenv:  fork/exec /sbin/fw_setenv: cannot allocate memory  module=bootenv
ERRO[0158] Enabling updated partition failed: fork/exec /sbin/fw_setenv: cannot allocate memory  module=rootfs
ERRO[0158] fork/exec /sbin/fw_setenv: cannot allocate memory  module=main
--- snip ---

Changelog: Title

Signed-off-by: Chang Rebecca Swee Fun <rebecca.swee.fun.chang@intel.com>
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>