### PR TITLE
tests: Revert upstream U-Boot patch that breaks Raspberry Pi USB stor…

### DIFF
--- a/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/patches/0001-Revert-usb-Only-get-64-bytes-device-descriptor-for-f.patch
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/patches/0001-Revert-usb-Only-get-64-bytes-device-descriptor-for-f.patch
@@ -1,0 +1,65 @@
+From 85806912549d218b471dc320a6c1591b9783253c Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@northern.tech>
+Date: Tue, 30 Jan 2018 08:31:21 +0100
+Subject: [PATCH] Revert "usb: Only get 64 bytes device descriptor for full
+ speed devices"
+
+This reverts commit c008faa77358bb5b313696dd1d5bb8afa03a6ca2.
+---
+ common/usb.c | 29 ++++++++++++++---------------
+ 1 file changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/common/usb.c b/common/usb.c
+index 8d27bc7..745ea5f 100644
+--- a/common/usb.c
++++ b/common/usb.c
+@@ -970,24 +970,23 @@ static int usb_setup_descriptor(struct usb_device *dev, bool do_read)
+ 	dev->epmaxpacketin[0] = dev->descriptor.bMaxPacketSize0;
+ 	dev->epmaxpacketout[0] = dev->descriptor.bMaxPacketSize0;
+ 
+-	if (do_read && dev->speed == USB_SPEED_FULL) {
++	if (do_read) {
+ 		int err;
+ 
+ 		/*
+-		 * Validate we've received only at least 8 bytes, not that
+-		 * we've received the entire descriptor. The reasoning is:
+-		 * - The code only uses fields in the first 8 bytes, so
+-		 *   that's all we need to have fetched at this stage.
+-		 * - The smallest maxpacket size is 8 bytes. Before we know
+-		 *   the actual maxpacket the device uses, the USB controller
+-		 *   may only accept a single packet. Consequently we are only
+-		 *   guaranteed to receive 1 packet (at least 8 bytes) even in
+-		 *   a non-error case.
++		 * Validate we've received only at least 8 bytes, not that we've
++		 * received the entire descriptor. The reasoning is:
++		 * - The code only uses fields in the first 8 bytes, so that's all we
++		 *   need to have fetched at this stage.
++		 * - The smallest maxpacket size is 8 bytes. Before we know the actual
++		 *   maxpacket the device uses, the USB controller may only accept a
++		 *   single packet. Consequently we are only guaranteed to receive 1
++		 *   packet (at least 8 bytes) even in a non-error case.
+ 		 *
+-		 * At least the DWC2 controller needs to be programmed with
+-		 * the number of packets in addition to the number of bytes.
+-		 * A request for 64 bytes of data with the maxpacket guessed
+-		 * as 64 (above) yields a request for 1 packet.
++		 * At least the DWC2 controller needs to be programmed with the number
++		 * of packets in addition to the number of bytes. A request for 64
++		 * bytes of data with the maxpacket guessed as 64 (above) yields a
++		 * request for 1 packet.
+ 		 */
+ 		err = get_descriptor_len(dev, 64, 8);
+ 		if (err)
+@@ -1010,7 +1009,7 @@ static int usb_setup_descriptor(struct usb_device *dev, bool do_read)
+ 		dev->maxpacketsize = PACKET_SIZE_64;
+ 		break;
+ 	default:
+-		printf("%s: invalid max packet size\n", __func__);
++		printf("usb_new_device: invalid max packet size\n");
+ 		return -EIO;
+ 	}
+ 
+-- 
+2.7.4
+

--- a/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+# Revert patch which breaks USB storage on Raspberry Pi.
+SRC_URI_append = " file://0001-Revert-usb-Only-get-64-bytes-device-descriptor-for-f.patch"


### PR DESCRIPTION
…age.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>