### PR TITLE
fix support of CONVERSIONTYPES for sdimg

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -22,6 +22,20 @@ python() {
 inherit image
 inherit image_types
 
+# This normally defaults to .rootfs which is misleading as this is not a simple
+# rootfs image and causes problems if one wants to use something like this:
+#
+#    IMAGE_FSTYPES += "sdimg.gz"
+#
+# Above assumes that the image name is:
+#
+#    ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}
+#
+# Which results in a empty "gz" archive when using the default value, in our
+# case IMAGE_NAME_SUFFIX should be empty as we do not use it when naming
+# our image.
+IMAGE_NAME_SUFFIX_sdimg = ""
+
 mender_part_image() {
     suffix="$1"
     part_type="$2"


### PR DESCRIPTION
The image_types.bbclass defines a set of conversion types that can be
applied to images (gz, xz, bz2 and more).

With the current state it is not possible to apply an conversion type
on the sdimg using:

	IMAGE_FSTYPES += "sdimg.gz"

Because the conversion types assume that that the image is named in the
following format:

	${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${type}

IMAGE_NAME_SUFFIX defaults to ".rootfs" which breaks things for us. By
setting IMAGE_NAME_SUFFIX to an empty string the expected image name
format is correct and the sdimg type can support all the conversiontypes
that are present in image_types.bbclass.

Above is really helpfull to compress the "sdimg" file as it mostly consist
of zero's and by compressing it is much easier to handle, transfer between
devices or between servers.

Note that this change does not generate a compressed sdimg by default, but
only adds support for it.

Changelog: None

Signed-off-by: Mirza Krak <mirza.krak@endian.se>