### PR TITLE
mender-setup: add possibility to override Mender fstab entries

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -21,12 +21,12 @@ mender_update_fstab_file() {
     echo "# Where the U-Boot environment resides; for devices with SD card support ONLY!" >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
 
     if [ -n "${MENDER_BOOT_PART}" ]; then
-        echo "${MENDER_BOOT_PART}   /uboot               ${MENDER_BOOT_PART_FSTYPE}       defaults,sync    0  0" >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
+        echo "${MENDER_BOOT_PART_FSTAB_ENTRY}" >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
     else
         bbdebug 2 "MENDER_BOOT_PART not set. Not adding to fstab..."
     fi
 
-    echo "${MENDER_DATA_PART}   /data                ${MENDER_DATA_PART_FSTYPE}       defaults         0  0" >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
+    echo "${MENDER_DATA_PART_FSTAB_ENTRY}" >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
 }
 
 # Setup state script version file.

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -37,10 +37,10 @@ MENDER_MTD_UBI_DEVICE_NAME_DEFAULT = ""
 # Filesystem type of data partition. This configuration is used in fstab. Most
 # filesystems can be auto detected, but some can not and hence we allow the
 # user to override this.
-MENDER_DATA_PART_FSTYPE ??= "${MENDER_DATA_PART_FSTYPE_DEFAULT}"
-MENDER_DATA_PART_FSTYPE_DEFAULT = "auto"
-MENDER_BOOT_PART_FSTYPE ??= "${MENDER_BOOT_PART_FSTYPE_DEFAULT}"
-MENDER_BOOT_PART_FSTYPE_DEFAULT = "auto"
+MENDER_DATA_PART_FSTAB_ENTRY ??= "${MENDER_DATA_PART_FSTAB_ENTRY_DEFAULT}"
+MENDER_DATA_PART_FSTAB_ENTRY_DEFAULT = "${MENDER_DATA_PART}    /data    auto    defaults    0 0"
+MENDER_BOOT_PART_FSTAB_ENTRY ??= "${MENDER_BOOT_PART_FSTAB_ENTRY_DEFAULT}"
+MENDER_BOOT_PART_FSTAB_ENTRY_DEFAULT = "${MENDER_BOOT_PART}    /uboot     auto    defaults,sync    0 0"
 
 # Device type of device when making an initial partitioned image.
 MENDER_DEVICE_TYPE ??= "${MENDER_DEVICE_TYPE_DEFAULT}"

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -173,7 +173,16 @@ python() {
 
 python() {
     if d.getVar('MENDER_PARTITION_ALIGNMENT_MB', True):
-        bb.fatal("MENDER_PARTITION_ALIGNMENT_MB is deprecated. Please define MENDER_PARTITION_ALIGNMENT_KB instead.")
+        bb.fatal("MENDER_PARTITION_ALIGNMENT_MB is deprecated. \
+            Please define MENDER_PARTITION_ALIGNMENT_KB instead.")
+
+    if d.getVar('MENDER_DATA_PART_FSTYPE', True):
+        bb.fatal("MENDER_DATA_PART_FSTYPE is deprecated. \
+            Please define MENDER_DATA_PART_FSTAB_ENTRY instead if you want to override the default behaviour.")
+
+    if d.getVar('MENDER_BOOT_PART_FSTYPE', True):
+        bb.fatal("MENDER_BOOT_PART_FSTYPE is deprecated. \
+            Please define MENDER_BOOT_PART_FSTAB_ENTRY instead if you want to override the default behaviour.")
 }
 
 # Including these does not mean that all these features will be enabled, just


### PR DESCRIPTION
Please see commit message for additional information.

This is probably not yet "mergable" as I have not taken in to account that I might break stuff with this. Wanted some feedback before I continue.

I initially tried to work around this with ROOTFS_POSTPROCESS_COMMAND_remove, but could not successfully remove the mender_update_fstab_file entry.

I could also work around this with a custom post process command with some "sed" magic, but I wanted to see if there is a interest to moving this "upstream" or/and at least make you aware of the "problem"