### PR TITLE
mender: added the ability to inject custom timeouts for state scripts…

### DIFF
--- a/meta-mender-core/recipes-mender/mender/mender.inc
+++ b/meta-mender-core/recipes-mender/mender/mender.inc
@@ -15,6 +15,9 @@ SYSTEMD_AUTO_ENABLE ?= "enable"
 MENDER_UPDATE_POLL_INTERVAL_SECONDS ?= "1800"
 MENDER_INVENTORY_POLL_INTERVAL_SECONDS ?= "1800"
 MENDER_RETRY_POLL_INTERVAL_SECONDS ?= "300"
+MENDER_STATE_SCRIPT_RETRY_INTERVAL_SECONDS ?= "1800"
+MENDER_STATE_SCRIPT_RETRY_TIMEOUT_SECONDS ?= "60"
+MENDER_STATE_SCRIPT_TIMEOUT_SECONDS ?= "300"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
@@ -99,6 +102,9 @@ python do_prepare_mender_conf() {
     if key_in_src_uri or key_in_var:
         conf_maybe_add("ArtifactVerifyKey", "%s/mender/artifact-verify-key.pem" % d.getVar("sysconfdir"), integer=False)
     conf_maybe_add("InventoryPollIntervalSeconds", d.getVar("MENDER_INVENTORY_POLL_INTERVAL_SECONDS"), integer=True)
+    conf_maybe_add("StateScriptRetryIntervalSeconds", d.getVar("MENDER_STATE_SCRIPT_RETRY_INTERVAL_SECONDS"), integer=True)
+    conf_maybe_add("StateScriptRetryTimeoutSeconds", d.getVar("MENDER_STATE_SCRIPT_RETRY_TIMEOUT_SECONDS"), integer=True)
+    conf_maybe_add("StateScriptTimeoutSeconds", d.getVar("MENDER_STATE_SCRIPT_TIMEOUT_SECONDS"), integer=True)
     # Mandatory variables - will always exist
     conf_maybe_add("RetryPollIntervalSeconds", d.getVar("MENDER_RETRY_POLL_INTERVAL_SECONDS"), integer=True)
     conf_maybe_add("RootfsPartA", d.getVar("MENDER_ROOTFS_PART_A"), integer=False)


### PR DESCRIPTION
… into the image.

This commit introduces the following variables:

- MENDER_STATE_SCRIPT_RETRY_INTERVAL_SECONDS (for StateScriptRetryIntervalSeconds)
- MENDER_STATE_SCRIPT_RETRY_TIMEOUT_SECONDS (for StateScriptRetryTimeoutSeconds)
- MENDER_STATE_SCRIPT_TIMEOUT_SECONDS (for StateScriptTimeoutSeconds)

Tested with:

- https://github.com/WaRP7/meta-warp7-distro/tree/master/recipes-mender/state-scripts/files (some custom state scripts)
- https://github.com/texierp/mender-qt-updater (A tiny application to handle D-Bus msgs from state scripts (with Qt 5.9).)

Changelog: Title

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>