### PR TITLE
mender: Cleanup IMAGE_FSTYPES.

### DIFF
--- a/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
+++ b/meta-mender-qemu/conf/machine/vexpress-qemu-flash.conf
@@ -6,9 +6,9 @@
 require conf/machine/include/qemu.inc
 require conf/machine/include/vexpress.inc
 
-# build only ubifs (used as mender artifact), vexpress-nor (used for qemu and
-# testing), mender-image-ubi will append ubimg to built FSTYPES
-IMAGE_FSTYPES = "ubifs vexpress-nor"
+# build only vexpress-nor (used for qemu and testing)
+# mender-image-ubi will append ubimg to built FSTYPES
+IMAGE_FSTYPES = "vexpress-nor"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "mtd-utils mtd-utils-ubifs mtd-utils-jffs2"
@@ -60,9 +60,6 @@ IMAGE_ROOTFS_MAXSIZE ?= "81920"
 # meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc we need ship
 # our own config instead.
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "0x100000"
-
-# use ubifs volumes for generating mender artifacts
-ARTIFACTIMG_FSTYPE = "ubifs"
 
 # add support for generating NOR Image files
 IMAGE_CLASSES += "vexpress-nor_image"

--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -43,7 +43,7 @@ in addition to `meta-mender` dependencies.
         # of the `rpi-sdimg`.
         IMAGE_FSTYPES_remove += " rpi-sdimg"
 
-        # Use the same type here as specified in IMAGE_FSTYPES to avoid
+        # Use the same type here as specified in ARTIFACTIMG_FSTYPE to avoid
         # building an unneeded image file.
         SDIMG_ROOTFS_TYPE = "ext4"
 

--- a/tests/build-conf/beaglebone-yocto/local.conf
+++ b/tests/build-conf/beaglebone-yocto/local.conf
@@ -253,6 +253,3 @@ DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
-
-# Make sure we build ext4 and sdimg files
-IMAGE_FSTYPES = "ext4 sdimg"

--- a/tests/build-conf/raspberrypi3/local.conf
+++ b/tests/build-conf/raspberrypi3/local.conf
@@ -42,6 +42,5 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
 
-IMAGE_FSTYPES = "ext4"
 ENABLE_UART = "1"
 

--- a/tests/build-conf/vexpress-qemu-flash/local.conf
+++ b/tests/build-conf/vexpress-qemu-flash/local.conf
@@ -32,5 +32,3 @@ DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
-
-IMAGE_FSTYPES = "ubimg ubifs"


### PR DESCRIPTION
Since we now explicitly use ARTIFACTIMG_FSTYPE instead of scanning
IMAGE_FSTYPES (and have sensible defaults) it should no longer be
necessary to explicitly set these.

Changelog: Title
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>