### PR TITLE
Fix test race condition

### DIFF
--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -75,9 +75,9 @@ def setup_rpi3(request):
 
 @pytest.fixture(scope="module")
 def qemu_running(request, clean_image):
-    latest_sdimg = latest_build_artifact(clean_image['build_dir'], ".sdimg")
-    latest_uefiimg = latest_build_artifact(clean_image['build_dir'], ".uefiimg")
-    latest_vexpress_nor = latest_build_artifact(clean_image['build_dir'], ".vexpress-nor")
+    latest_sdimg = latest_build_artifact(clean_image['build_dir'], "core-image*.sdimg")
+    latest_uefiimg = latest_build_artifact(clean_image['build_dir'], "core-image*.uefiimg")
+    latest_vexpress_nor = latest_build_artifact(clean_image['build_dir'], "core-image*.vexpress-nor")
 
     if latest_sdimg:
         qemu, img_path = start_qemu_block_storage(latest_sdimg, suffix=".sdimg")
@@ -138,21 +138,21 @@ def latest_rootfs():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 
     # Find latest built rootfs.
-    return latest_build_artifact(os.environ['BUILDDIR'], ".ext[234]")
+    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.ext[234]")
 
 @pytest.fixture(scope="session")
 def latest_sdimg():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 
     # Find latest built rootfs.
-    return latest_build_artifact(os.environ['BUILDDIR'], ".sdimg")
+    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.sdimg")
 
 @pytest.fixture(scope="session")
 def latest_ubimg():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 
     # Find latest built ubimg.
-    return latest_build_artifact(os.environ['BUILDDIR'], ".ubimg")
+    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.ubimg")
 
 @pytest.fixture(scope="session")
 def latest_ubifs():
@@ -160,7 +160,7 @@ def latest_ubifs():
 
     # Find latest built ubifs. NOTE: need to include *core-image* otherwise
     # we'll likely match data partition file - data.ubifs
-    return latest_build_artifact(os.environ['BUILDDIR'], "*core-image*.ubifs")
+    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.ubifs")
 
 @pytest.fixture(scope="session")
 def latest_vexpress_nor():
@@ -168,32 +168,32 @@ def latest_vexpress_nor():
 
     # Find latest built ubifs. NOTE: need to include *core-image* otherwise
     # we'll likely match data partition file - data.ubifs
-    return latest_build_artifact(os.environ['BUILDDIR'], ".vexpress-nor")
+    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.vexpress-nor")
 
 @pytest.fixture(scope="session")
 def latest_mender_image():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 
     # Find latest built rootfs.
-    return latest_build_artifact(os.environ['BUILDDIR'], ".mender")
+    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.mender")
 
 @pytest.fixture(scope="session")
 def latest_part_image():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 
     # Find latest built rootfs.
-    latest_sdimg = latest_build_artifact(os.environ['BUILDDIR'], ".sdimg")
+    latest_sdimg = latest_build_artifact(os.environ['BUILDDIR'], "core-image*.sdimg")
     if latest_sdimg:
         return latest_sdimg
     else:
-        return latest_build_artifact(os.environ['BUILDDIR'], ".uefiimg")
+        return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.uefiimg")
 
 @pytest.fixture(scope="function")
 def successful_image_update_mender(request, clean_image):
     """Provide a 'successful_image_update.mender' file in the current directory that
     contains the latest built update."""
 
-    latest_mender_image = latest_build_artifact(clean_image['build_dir'], ".mender")
+    latest_mender_image = latest_build_artifact(clean_image['build_dir'], "core-image*.mender")
 
     if os.path.lexists("successful_image_update.mender"):
         print("Using existing 'successful_image_update.mender' in current directory")

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -70,7 +70,7 @@ class TestBuild:
 
         run_bitbake(prepared_test_build)
 
-        built_sdimg = latest_build_artifact(prepared_test_build['build_dir'], ".sdimg")
+        built_sdimg = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.sdimg")
 
         original = os.open(loader_path, os.O_RDONLY)
         embedded = os.open(built_sdimg, os.O_RDONLY)
@@ -102,7 +102,7 @@ class TestBuild:
 
         run_bitbake(prepared_test_build)
 
-        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], ".ext4")
+        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.ext4")
 
         assert(os.stat(built_rootfs).st_size == int(bitbake_variables['MENDER_CALC_ROOTFS_SIZE']) * 1024)
 
@@ -117,7 +117,7 @@ class TestBuild:
 
         run_bitbake(prepared_test_build)
 
-        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], ".ext[234]")
+        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.ext[234]")
 
         subprocess.check_call(["debugfs", "-R",
                                    "dump -p /etc/mender/mender.conf mender.conf", built_rootfs])
@@ -145,14 +145,14 @@ class TestBuild:
 
         run_bitbake(prepared_test_build)
 
-        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], ".ext[234]")
+        built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.ext[234]")
         # Copy out the key we just added from the image and use that to
         # verify instead of the original, just to be sure.
         subprocess.check_call(["debugfs", "-R",
                                "dump -p /etc/mender/artifact-verify-key.pem artifact-verify-key.pem",
                                built_rootfs])
         try:
-            built_artifact = latest_build_artifact(prepared_test_build['build_dir'], ".mender")
+            built_artifact = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.mender")
             output = subprocess.check_output(["mender-artifact", "read", "-k",
                                               os.path.join(os.getcwd(), "artifact-verify-key.pem"),
                                               built_artifact])
@@ -215,7 +215,7 @@ class TestBuild:
             }
 
             # Check new rootfs.
-            built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], ".ext[234]")
+            built_rootfs = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.ext[234]")
             output = subprocess.check_output(["debugfs", "-R", "ls -p /etc/mender/scripts", built_rootfs])
             for line in output.split('\n'):
                 if len(line) == 0:
@@ -233,7 +233,7 @@ class TestBuild:
                 assert found_rootfs_scripts[script], "%s not found in rootfs script list" % script
 
             # Check new artifact.
-            built_mender_image = latest_build_artifact(prepared_test_build['build_dir'], ".mender")
+            built_mender_image = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.mender")
             output = subprocess.check_output("tar xOf %s header.tar.gz| tar tz scripts"
                                              % built_mender_image, shell=True)
             for line in output.strip().split('\n'):
@@ -293,7 +293,7 @@ class TestBuild:
         add_to_local_conf(prepared_test_build, 'MENDER_DEVICE_TYPES_COMPATIBLE = "machine1 machine2"')
         run_bitbake(prepared_test_build)
 
-        image = latest_build_artifact(prepared_test_build['build_dir'], '.mender')
+        image = latest_build_artifact(prepared_test_build['build_dir'], 'core-image*.mender')
 
         output = run_verbose("mender-artifact read %s" % image, capture=True)
         assert "Compatible devices: '[machine1 machine2]'" in output

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -52,7 +52,7 @@ def versioned_mender_image(request, prepared_test_build, latest_mender_image):
         add_to_local_conf(prepared_test_build, 'MENDER_ARTIFACT_EXTRA_ARGS = "-v %d"' % version)
         run_bitbake(prepared_test_build)
         LAST_BUILD_VERSION = version
-    return (version, latest_build_artifact(prepared_test_build['build_dir'], ".mender"))
+    return (version, latest_build_artifact(prepared_test_build['build_dir'], "core-image*.mender"))
 
 
 @pytest.mark.only_with_image('mender')

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -170,7 +170,7 @@ change."""
         add_to_local_conf(prepared_test_build, 'PREFERRED_PROVIDER_u-boot = "u-boot-testing"')
         run_bitbake(prepared_test_build)
 
-        new_rootfs = latest_build_artifact(prepared_test_build['build_dir'], ".ext[234]")
+        new_rootfs = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.ext[234]")
         subprocess.check_call(["debugfs", "-R", "dump /sbin/fw_setenv fw_setenv.tmp", new_rootfs])
 
         try:

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -168,6 +168,7 @@ change."""
             os.unlink("fw_setenv.tmp")
 
         add_to_local_conf(prepared_test_build, 'PREFERRED_PROVIDER_u-boot = "u-boot-testing"')
+        add_to_local_conf(prepared_test_build, 'PREFERRED_RPROVIDER_u-boot = "u-boot-testing"')
         run_bitbake(prepared_test_build)
 
         new_rootfs = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.ext[234]")


### PR DESCRIPTION
```
commit c1ff21772c3e8db095c94c6fadb17bbd7d5f5273
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Apr 26 09:43:53 2018

    tests: Be pedantically correct in local.conf file.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 0df5e1b4d22750e3fbc2d74559580c99b0a5f22d
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Apr 26 09:41:34 2018

    tests: Avoid race condition in locating files by being more specific.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```