### PR TITLE
Fix up u-boot for Orange Pi

### DIFF
--- a/meta-mender-orangepi/README.md
+++ b/meta-mender-orangepi/README.md
@@ -31,6 +31,8 @@ in addition to `meta-mender` dependencies.
 	# enable for all orangepi machines
 	MACHINEOVERRIDES =. "orangepi:"
 
+- Integrate Mender into the Orange Pi u-boot fork (u-boot-opi) using [the Mender documentation on Integrating with U-Boot](https://docs.mender.io/1.5/devices/integrating-with-u-boot#forks-of-u-boot).
+
 - Run `bitbake <image name>` where options are
      - opipc-minimal (minimal image for orange pi pc)
      - opipcplus-minimal (minimal image for orange pi pc plus)

--- a/meta-mender-orangepi/README.md
+++ b/meta-mender-orangepi/README.md
@@ -31,7 +31,7 @@ in addition to `meta-mender` dependencies.
 	# enable for all orangepi machines
 	MACHINEOVERRIDES =. "orangepi:"
 
-- Integrate Mender into the Orange Pi u-boot fork (u-boot-opi) using [the Mender documentation on Integrating with U-Boot](https://docs.mender.io/1.5/devices/integrating-with-u-boot#forks-of-u-boot).
+- Integrate Mender into the Orange Pi u-boot fork (u-boot-opi) using [the Mender documentation on Integrating with U-Boot](https://docs.mender.io/devices/integrating-with-u-boot#forks-of-u-boot).
 
 - Run `bitbake <image name>` where options are
      - opipc-minimal (minimal image for orange pi pc)

--- a/meta-mender-orangepi/recipes-bsp/u-boot/u-boot-opi_%.bbappend
+++ b/meta-mender-orangepi/recipes-bsp/u-boot/u-boot-opi_%.bbappend
@@ -1,0 +1,1 @@
+require u-boot-orangepi.inc

--- a/meta-mender-orangepi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-orangepi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,3 @@
+# This file is to properly patch u-boot before the Orange Pi distro u-boot was converted into u-boot-opi.
+# In newer versions, u-boot-opi_%.bbappend is used.
 require u-boot-orangepi.inc


### PR DESCRIPTION
This fixes up u-boot mender integration in the latest version of the Orange Pi distro.
See discussion in:
https://github.com/mendersoftware/meta-mender/pull/465

Without this, the u-boot fw utils will build with the wrong toolchain, as it would only patch u-boot, in later versions of Orange Pi distro, it is called u-boot-opi.

I also added some documentation on how to integrate Mender in the u-boot fork since it is now required.