### PR TITLE
QEMU: Limit client setup steps to run on first boot only.

### DIFF
--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -24,8 +24,11 @@ if [ -f /mnt/config/artifact-verify-key.pem ]; then
     CONFIG_ARGS="$CONFIG_ARGS --verify-key=/mnt/config/artifact-verify-key.pem"
 fi
 
-./setup-mender-configuration.py --img="$DISK_IMG" \
-                                --server-url=$SERVER_URL \
-                                --tenant-token=$TENANT_TOKEN $CONFIG_ARGS
+if [ ! -e /mender-setup-complete ]; then
+    ./setup-mender-configuration.py --img="$DISK_IMG" \
+                                    --server-url=$SERVER_URL \
+                                    --tenant-token=$TENANT_TOKEN $CONFIG_ARGS
+    touch /mender-setup-complete
+fi
 
 ./mender-qemu "$@"


### PR DESCRIPTION
Changelog: Fix occasional inode corruption issue when re-launching a
previously launched and saved QEMU image.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 131708bb84e20dfe891a1a7fcd367bcd6888631f)