### PR TITLE
MEN-1657: Fix incorrect memory size in vexpress-qemu devicetree file.

### DIFF
--- a/meta-mender-qemu/recipes-kernel/linux/linux-yocto/reduce-memory-to-256m.patch
+++ b/meta-mender-qemu/recipes-kernel/linux/linux-yocto/reduce-memory-to-256m.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm/boot/dts/vexpress-v2p-ca9.dts
++++ b/arch/arm/boot/dts/vexpress-v2p-ca9.dts
+@@ -20,7 +20,7 @@
+ 
+ 	memory@60000000 {
+ 		device_type = "memory";
+-		reg = <0x60000000 0x40000000>;
++		reg = <0x60000000 0x10000000>;
+ 	};
+ 
+ 	clcd@10020000 {

--- a/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,13 +1,16 @@
-# Use custom defconfig in order to enable use of the vexpress model.
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# Use custom defconfig in order to enable use of the vexpress model.
 SRC_URI_append_vexpress-qemu = " file://defconfig \
                                 file://vexpress-qemu-standard.scc \
+                                file://reduce-memory-to-256m.patch \
                                " 
 COMPATIBLE_MACHINE_vexpress-qemu = "vexpress-qemu"
 
 # same config for vexpress-qemu-flash
 SRC_URI_append_vexpress-qemu-flash = " file://defconfig \
                                        file://vexpress-qemu-standard.scc \
+                                       file://reduce-memory-to-256m.patch \
                                        "
 
 COMPATIBLE_MACHINE_vexpress-qemu-flash = "vexpress-qemu-flash"


### PR DESCRIPTION
Our emulator script uses 256M, so the device tree file should mirror
that.

Changelog: Fix Linux kernel hanging when loaded via U-Boot/UEFI/GRUB
on vexpress-qemu*.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>