### PR TITLE
meta-mender-core: Clean spaces out of UBOOT_MACHINE.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -177,10 +177,24 @@ do_mender_uboot_auto_configure() {
     rm -rf ${MENDER_UBOOT_OLD_SRC}
     cp -r "${S}" ${MENDER_UBOOT_OLD_SRC}
 
+    # Strip leading and trailing whitespace, then newline divide.
+    MENDER_UBOOT_MACHINE="$(echo "${UBOOT_MACHINE}" | sed -r 's/(^\s*)|(\s*$)//g; s/\s+/\n/g')"
+
+    if [ -z "$MENDER_UBOOT_MACHINE" ]; then
+        bbfatal "Did not find a machine specified in UBOOT_MACHINE"
+        exit 1
+    fi
+
+    MACHINE_COUNT=$(echo "$MENDER_UBOOT_MACHINE" | wc -l)
+    if [ "$MACHINE_COUNT" -ne 1 ]; then
+        bbwarn "Found more than one machine specified in UBOOT_MACHINE. Only one should be specified. Choosing the last one."
+        MENDER_UBOOT_MACHINE="$(echo "$MENDER_UBOOT_MACHINE" | tail -1)"
+    fi
+
     env \
         BUILDCC="${BUILD_CC}" \
         ./uboot_auto_configure.sh \
-        --config=${UBOOT_MACHINE} \
+        --config=$MENDER_UBOOT_MACHINE \
         --src-dir=${S} \
         --tmp-dir=${MENDER_UBOOT_TMP_SRC} \
         --debug

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -64,7 +64,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "0175f115f83a1fedcd9282a7976c3213",
+                   "md5": "8ce3d9108b58e4a185a5f812536f03a5",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_ARTIFACT_BRANCH'))['md5']}"


### PR DESCRIPTION
Some platforms use "_append" to set the UBOOT_MACHINE resulting
in a leading space in the variable value.  We need to strip this
out so that it is passed in properly as a command line parameter
to uboot_auto_configure.sh.

Changelog: Title

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
(cherry picked from commit b8aa8dcf58c1d1a1ab255b00b44cff1959b35009)