### PR TITLE
Overo

### DIFF
--- a/meta-mender-overo/conf/layer.conf
+++ b/meta-mender-overo/conf/layer.conf
@@ -1,0 +1,13 @@
+# Board specific layer configuration for meta-mender
+# Copyright 2018 Northern.tech AS
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-overo"
+BBFILE_PATTERN_mender-overo = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-overo = "9"

--- a/meta-mender-overo/recipes-bsp/u-boot/files/fw_env.config.default
+++ b/meta-mender-overo/recipes-bsp/u-boot/files/fw_env.config.default
@@ -1,0 +1,8 @@
+# Configuration file for fw_(printenv/saveenv) utility.
+# Up to two entries are valid, in this case the redundant
+# environment sector is assumed present.
+# Notice, that the "Number of sectors" is ignored on NOR.
+
+# MTD device name       Device offset   Env. size       Flash sector size       Number of sectors
+/dev/mtd2               0x00000          0x20000         0x20000                 1
+/dev/mtd2               0x20000          0x20000         0x20000                 1

--- a/meta-mender-overo/recipes-bsp/u-boot/patches/0002-u-boot-Mender-integration-for-Overo-board.patch
+++ b/meta-mender-overo/recipes-bsp/u-boot/patches/0002-u-boot-Mender-integration-for-Overo-board.patch
@@ -1,0 +1,112 @@
+From 5152008081454cefbacc1d57e082f56f47459df2 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Tue, 13 Feb 2018 14:43:19 -0500
+Subject: [PATCH 2/2] u-boot: Mender integration for Overo board.
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/omap3_overo.h | 49 ++++++++++++++++++-------------------------
+ 1 file changed, 20 insertions(+), 29 deletions(-)
+
+diff --git a/include/configs/omap3_overo.h b/include/configs/omap3_overo.h
+index f66a7b00b8..0f07ed2666 100644
+--- a/include/configs/omap3_overo.h
++++ b/include/configs/omap3_overo.h
+@@ -34,7 +34,8 @@
+ /* Shift 128 << 15 provides 4 MiB heap to support UBI commands.
+  * Shift 128 << 10 provides 128 KiB heap for limited-memory devices. */
+ #define CONFIG_SYS_MALLOC_LEN	(CONFIG_ENV_SIZE + (128 << 15))
+-
++/* Added for Mender integration */
++#define CONFIG_ENV_RANGE        CONFIG_ENV_SIZE
+ /* I2C Support */
+ #define CONFIG_SYS_I2C_OMAP34XX
+ 
+@@ -66,7 +67,9 @@
+ #define CONFIG_RBTREE		/* required by CONFIG_CMD_UBI */
+ #define CONFIG_LZO		/* required by CONFIG_CMD_UBIFS */
+ 
++#define CONFIG_MTD_DEVICE       /* needed for mtdparts commands */
+ #define CONFIG_MTD_PARTITIONS	/* required for UBI partition support */
++#define CONFIG_CMD_MTDPARTS
+ 
+ /* NAND block size is 128 KiB.  Synchronize these values with
+  * overo_nand_partitions in mach-omap2/board-overo.c in Linux:
+@@ -105,7 +108,7 @@
+ 	"mmcdev=0\0" \
+ 	"mmcroot=/dev/mmcblk0p2 rw\0" \
+ 	"mmcrootfstype=ext4 rootwait\0" \
+-	"nandroot=ubi0:rootfs ubi.mtd=4\0" \
++	"nandroot=${mender_kernel_root} ubi.mtd=${mender_mtd_ubi_dev_name}\0" \
+ 	"nandrootfstype=ubifs\0" \
+ 	"mtdparts=" MTDPARTS_DEFAULT "\0" \
+ 	"mmcargs=setenv bootargs console=${console} " \
+@@ -155,35 +158,17 @@
+ 		"bootz ${loadaddr} - ${fdtaddr}\0" \
+ 
+ #define CONFIG_BOOTCOMMAND \
+-	"mmc dev ${mmcdev}; if mmc rescan; then " \
+-		"if run loadbootscript; then " \
+-			"run bootscript; " \
+-		"fi;" \
+-		"if run loadbootenv; then " \
+-			"echo Loaded environment from ${bootenv};" \
+-			"run importbootenv;" \
+-		"fi;" \
+-		"if test -n $uenvcmd; then " \
+-			"echo Running uenvcmd ...;" \
+-			"run uenvcmd;" \
+-		"fi;" \
+-		"if run loaduimage; then " \
+-			"run mmcboot;" \
+-		"fi;" \
+-		"if run loadzimage; then " \
+-			"if test -z \"${fdtfile}\"; then " \
+-				"setenv fdtfile omap3-${boardname}-${expansionname}.dtb;" \
+-			"fi;" \
+-			"if run loadfdt; then " \
+-				"run mmcbootfdt;" \
+-			"fi;" \
+-		"fi;" \
+-	"fi;" \
+-	"run nandboot; " \
+ 	"if test -z \"${fdtfile}\"; then "\
+ 		"setenv fdtfile omap3-${boardname}-${expansionname}.dtb;" \
+ 	"fi;" \
+-	"run nanddtsboot; " \
++	"run nandargs; "                                       \
++	"run mender_setup; "                                   \
++	"ubi part ${mender_mtd_ubi_dev_name} && "              \
++	"ubifsmount ${mender_uboot_root_name} && "             \
++	"run loadubifdt && "                                   \
++	"run loadubizimage && "                                \
++	"bootz ${loadaddr} - ${fdtaddr}; "                     \
++        "run mender_try_to_recover; "                          \
+ 
+ /* memtest works on */
+ #define CONFIG_SYS_MEMTEST_START	(OMAP34XX_SDRC_CS0)
+@@ -204,9 +189,12 @@
+ #define SMNAND_ENV_OFFSET		0x240000 /* environment starts here */
+ 
+ #define CONFIG_SYS_ENV_SECT_SIZE	(128 << 10)	/* 128 KiB */
++#if 0
++/* Removed for Mender Integration */
+ #define CONFIG_ENV_OFFSET		SMNAND_ENV_OFFSET
+ #define CONFIG_ENV_ADDR			SMNAND_ENV_OFFSET
+-
++#endif
++  
+ /* Configure SMSC9211 ethernet */
+ #if defined(CONFIG_CMD_NET)
+ #define CONFIG_SMC911X
+@@ -246,4 +234,7 @@
+ #define CONFIG_CMD_SPL_WRITE_SIZE	0x2000
+ #endif
+ 
++#define CONFIG_BOOTCOUNT_LIMIT
++#define CONFIG_BOOTCOUNT_ENV
++
+ #endif				/* __CONFIG_H */
+-- 
+2.11.0
+

--- a/meta-mender-overo/recipes-bsp/u-boot/patches/0003-Make-sure-to-run-mmc-dev-command-before-Mender-boot.patch
+++ b/meta-mender-overo/recipes-bsp/u-boot/patches/0003-Make-sure-to-run-mmc-dev-command-before-Mender-boot.patch
@@ -1,0 +1,35 @@
+From 8b3e45eeb4699714dcb0ff542e7ef85363f1d20f Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Fri, 23 Feb 2018 09:53:05 -0500
+Subject: [PATCH 3/3] Make sure to run mmc dev command before Mender boot.
+
+For some inexplicable reason, without this, certain things in the
+Linux environment simply don't work.  Notably, it seems that no
+linux-firmware is loaded and the wifi driver does not come up.
+
+I cannot explain this behavior but simply running the "mmc dev"
+command effectively negates this behavior.
+
+It is completely reproducible so I'm confident this is a
+viable workaround.  I guess there is a bug elsewhere in U-Boot.
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/omap3_overo.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/configs/omap3_overo.h b/include/configs/omap3_overo.h
+index 0f07ed2666..da34283f13 100644
+--- a/include/configs/omap3_overo.h
++++ b/include/configs/omap3_overo.h
+@@ -158,6 +158,7 @@
+ 		"bootz ${loadaddr} - ${fdtaddr}\0" \
+ 
+ #define CONFIG_BOOTCOMMAND \
++	"mmc dev ${mmcdev}; " \
+ 	"if test -z \"${fdtfile}\"; then "\
+ 		"setenv fdtfile omap3-${boardname}-${expansionname}.dtb;" \
+ 	"fi;" \
+-- 
+2.11.0
+

--- a/meta-mender-overo/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/meta-mender-overo/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append_overo = " file://fw_env.config.default "
+
+require u-boot-overo.inc

--- a/meta-mender-overo/recipes-bsp/u-boot/u-boot-overo.inc
+++ b/meta-mender-overo/recipes-bsp/u-boot/u-boot-overo.inc
@@ -5,6 +5,7 @@ SRC_URI_remove_overo += " file://0003-Integration-of-Mender-boot-code-into-U-Boo
 SRC_URI_append_overo += " file://0003-U-Boot-pre-2017.03-integration-of-Mender-boot-code-i.patch"
 
 SRC_URI_append_overo += " file://0002-u-boot-Mender-integration-for-Overo-board.patch"
+SRC_URI_append_overo += " file://0003-Make-sure-to-run-mmc-dev-command-before-Mender-boot.patch"
 
 # Custom DEVICE_NAME based on upstream kernel DTB and UBoot MTD partition table
 # This needs to be kept in sync with arch/arm/boot/dts/omap3-overo-base.dtsi

--- a/meta-mender-overo/recipes-bsp/u-boot/u-boot-overo.inc
+++ b/meta-mender-overo/recipes-bsp/u-boot/u-boot-overo.inc
@@ -1,0 +1,16 @@
+FILESEXTRAPATHS_prepend_overo := "${THISDIR}/patches:"
+
+# Overo board is using 2016.11 u-boot, need to apply a patch that matches our version
+SRC_URI_remove_overo += " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
+SRC_URI_append_overo += " file://0003-U-Boot-pre-2017.03-integration-of-Mender-boot-code-i.patch"
+
+SRC_URI_append_overo += " file://0002-u-boot-Mender-integration-for-Overo-board.patch"
+
+# Custom DEVICE_NAME based on upstream kernel DTB and UBoot MTD partition table
+# This needs to be kept in sync with arch/arm/boot/dts/omap3-overo-base.dtsi
+MENDER_MTD_UBI_DEVICE_NAME_overo = "Filesystem"
+
+# UBoot environment on Overo boards is 128kB.
+# 2 copies are maintained in the environ MTD partition
+BOOTENV_SIZE_overo = "0x20000"
+BOOTENV_RANGE_overo = "0x20000"

--- a/meta-mender-overo/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-overo/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,1 @@
+require u-boot-overo.inc


### PR DESCRIPTION
This is the Gumstix Overo board. This is only tested on the Morty branch and at the time of development the upstream BSP only supported that branch so for now it should stay only on Morty.