### PR TITLE
Fix ERROR: Nothing RPROVIDES 'linux-firmware-raspbian-bcm43430'

### DIFF
--- a/meta-mender-raspberrypi-demo/classes/rpi-demo-wifi.bbclass
+++ b/meta-mender-raspberrypi-demo/classes/rpi-demo-wifi.bbclass
@@ -1,7 +1,7 @@
 # Global variables
 DISTRO_FEATURES_append = " wifi"
 
-IMAGE_INSTALL_append = " iw wpa-supplicant linux-firmware-raspbian-bcm43430 packagegroup-base"
+IMAGE_INSTALL_append = " iw wpa-supplicant linux-firmware-bcm43430 packagegroup-base"
 
 ENABLE_UART = "1"
 


### PR DESCRIPTION
There is no package called  'linux-firmware-raspbian-bcm43430' 

Reference: https://groups.google.com/a/lists.mender.io/forum/#!topic/mender/L7LSR3_719I