### PR TITLE
Add canary value to U-Boot env to catch bootloader/user-space mismatch.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
@@ -122,7 +122,7 @@ new file mode 100644
 index 0000000..8e10942
 --- /dev/null
 +++ b/include/env_mender.h
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,148 @@
 +/*
 +  Copyright 2017 Northern.tech AS
 +
@@ -192,7 +192,13 @@ index 0000000..8e10942
 +                                                                        \
 +    "mender_post_setup_commands=" MENDER_UBOOT_POST_SETUP_COMMANDS "\0" \
 +                                                                        \
++    "mender_check_saveenv_canary=1\0"                                   \
++                                                                        \
 +    "mender_setup="                                                     \
++    "if test \"${mender_saveenv_canary}\" != \"1\"; then "              \
++    "setenv mender_saveenv_canary 1; "                                  \
++    "saveenv; "                                                         \
++    "fi; "                                                              \
 +    "if test \"${mender_pre_setup_commands}\" != \"\"; "                \
 +    "then "                                                             \
 +    "run mender_pre_setup_commands; "                                   \

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -736,3 +736,56 @@ class TestUpdates:
                 run("mv %s/{mender_grubenv1/lock.backup,mender_grubenv1/lock}" % env_dir)
                 run("mv %s/{mender_grubenv2/env.backup,mender_grubenv2/env}" % env_dir)
                 run("mv %s/{mender_grubenv2/lock.backup,mender_grubenv2/lock}" % env_dir)
+
+    @pytest.mark.only_with_distro_feature('mender-uboot')
+    @pytest.mark.only_with_image('sdimg', 'uefiimg')
+    @pytest.mark.min_mender_version('1.6.0')
+    def test_uboot_mender_saveenv_canary(self, bitbake_variables):
+        """Tests that the mender_saveenv_canary works correctly, which tests
+        that Mender will not proceed unless the U-Boot boot loader has saved the
+        environment."""
+
+        if not env.host_string:
+            # This means we are not inside execute(). Recurse into it!
+            execute(self.test_uboot_mender_saveenv_canary, bitbake_variables)
+            return
+
+        image_type = bitbake_variables["MACHINE"]
+
+        try:
+            # Make a dummy/broken update
+            subprocess.call("dd if=/dev/zero of=image.dat bs=1M count=0 seek=16", shell=True)
+            subprocess.call("mender-artifact write rootfs-image -t %s -n test-update -u image.dat -o image.mender" % image_type, shell=True)
+            put("image.mender", remote_path="/var/tmp/image.mender")
+
+            # Zero the environment, causing the fw-utils to use their built in
+            # default.
+            env_conf = run("cat /etc/fw_env.config")
+            env_conf_lines = env_conf.split('\n')
+            assert len(env_conf_lines) == 2
+            for i in [0, 1]:
+                entry = env_conf_lines[i].split()
+                run("dd if=%s skip=%d bs=%d count=1 iflag=skip_bytes > /old_env%d"
+                    % (entry[0], int(entry[1], 0), int(entry[2], 0), i))
+                run("dd if=/dev/zero of=%s seek=%d bs=%d count=1 oflag=seek_bytes"
+                    % (entry[0], int(entry[1], 0), int(entry[2], 0)))
+
+            try:
+                output = run("mender -rootfs /var/tmp/image.mender -f")
+                pytest.fail("Update succeeded when canary was not present!")
+            except:
+                output = run("fw_printenv upgrade_available")
+                # Upgrade should not have been triggered.
+                assert(output == "upgrade_available=0")
+            finally:
+                # Restore environment to what it was.
+                for i in [0, 1]:
+                    entry = env_conf_lines[i].split()
+                    run("dd of=%s seek=%d bs=%d count=1 oflag=seek_bytes < /old_env%d"
+                        % (entry[0], int(entry[1], 0), int(entry[2], 0), i))
+                    run("rm -f /old_env%d" % i)
+
+        finally:
+            # Cleanup.
+            os.remove("image.mender")
+            os.remove("image.dat")


### PR DESCRIPTION
The way it works is that we store the 'mender_check_saveenv_canary=1'
variable in the default U-Boot environment. We do not store the
corresponding 'mender_saveenv_canary=1' value in the default
environment, but instead we write this during the boot process. When
the Mender client finds the former variable, it will look for the
second value as well, and produce an error if it is not present. If
this happens it is an indication that the U-Boot boot loader and the
user space tools do not agree on the location of the environment. It
will also catch cases where mender_setup is not run.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>