### PR TITLE
meta-mender-demo: remove append from MENDER_DATA_PART_DIR

### DIFF
--- a/meta-mender-demo/recipes-core/images/core-image-full-cmdline.bbappend
+++ b/meta-mender-demo/recipes-core/images/core-image-full-cmdline.bbappend
@@ -1,2 +1,2 @@
-MENDER_DATA_PART_DIR_append = "${DEPLOY_DIR_IMAGE}/persist"
+MENDER_DATA_PART_DIR = "${DEPLOY_DIR_IMAGE}/persist"
 IMAGE_INSTALL_append = " hello-mender"


### PR DESCRIPTION
It is not supported to handle multiple directories and
appending could hint that it would.

[MEN-1980] - MENDER_DATA_PART_DIR does not work as expected

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
(cherry picked from commit 2c8c11a07453d6c4b954a15d46c1084285c4418e)