### PR TITLE
feat: aarch64 support

### DIFF
--- a/meta-mender-core/classes/mender-full.bbclass
+++ b/meta-mender-core/classes/mender-full.bbclass
@@ -7,6 +7,7 @@ MENDER_FEATURES_ENABLE_append = " \
 "
 
 MENDER_FEATURES_ENABLE_append_arm = " mender-image-sd mender-uboot"
+MENDER_FEATURES_ENABLE_append_aarch64 = " mender-image-sd mender-uboot"
 
 MENDER_FEATURES_ENABLE_append_x86 = " mender-image-uefi mender-grub"
 MENDER_FEATURES_ENABLE_append_x86-64 = " mender-image-uefi mender-grub"

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -1,6 +1,6 @@
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 run mender_setup
 mmc dev ${mender_uboot_dev}
-load ${mender_uboot_root} ${kernel_addr_r} /boot/uImage
+load ${mender_uboot_root} ${kernel_addr_r} /boot/@@KERNEL_IMAGETYPE@@
 @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}
 run mender_try_to_recover


### PR DESCRIPTION
# What I did

The first commit ensures Image can also be used. This is relevant as it is uImage is not on aarch64.
The second commit ensures the sdimg is built for aarch64.

For the sake of keeping track, I started a discussion [here](https://groups.google.com/a/lists.mender.io/forum/#!topic/mender/GR0jQjlDtYQ) about this PR

Thanks to @mirzak for the assistance on google groups

# How I tested
I built **rpi-basic-image** for **raspberrypi3-64** and tested a **standalone** update.


PS: I can rename the PR name, I was not sure which tag to put