### PR TITLE
Fixed do_mender_tar_src function to work with external sources

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
@@ -16,7 +16,7 @@ do_mender_tar_src() {
     cd ${WORKDIR}
     # Zip up all plain files, plus the git directory, but not the rest, because
     # there are a lot of bitbake data directories.
-    tar czf ${TMPDIR}/mender-u-boot-src.tar.gz `find -maxdepth 1 -type f` git
+    tar czf ${TMPDIR}/mender-u-boot-src.tar.gz `find -maxdepth 1 -type f` ${S}
 }
 python() {
     if bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', '1', True, False, d):


### PR DESCRIPTION
This function fails when working on external sources (local on your
machine; e.g. using `devtool`).

Changelog: none

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>