### PR TITLE
Switch GRUB/BIOS combination to new machine name to avoid conflict.

### DIFF
--- a/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -3,4 +3,5 @@
 RDEPENDS_${PN}_append_vexpress-qemu = " mender-reboot-detector"
 RDEPENDS_${PN}_append_vexpress-qemu-flash = " mender-reboot-detector"
 RDEPENDS_${PN}_append_qemux86-64 = " mender-reboot-detector"
+RDEPENDS_${PN}_append_mender-qemux86-64-bios = " mender-reboot-detector"
 RDEPENDS_${PN}_append_qemux86 = " mender-reboot-detector"

--- a/meta-mender-qemu/conf/machine/mender-qemux86-64-bios.conf
+++ b/meta-mender-qemu/conf/machine/mender-qemux86-64-bios.conf
@@ -1,0 +1,8 @@
+# Machine definition for qemux86-64 with BIOS booting. We make this distinction
+# in order to not have two machine names that are in fact incompatible.
+
+include conf/machine/qemux86-64.conf
+
+MACHINEOVERRIDES =. "qemux86-64:"
+
+INHERIT += "mender-full-bios"

--- a/meta-mender-qemu/recipes-kernel/linux/linux-yocto/mender-qemux86-64-bios-standard.scc
+++ b/meta-mender-qemu/recipes-kernel/linux/linux-yocto/mender-qemux86-64-bios-standard.scc
@@ -1,0 +1,4 @@
+define KMACHINE mender-qemux86-64-bios 
+
+define KARCH x86-64
+define KTYPE standard

--- a/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -13,6 +13,8 @@ SRC_URI_append_vexpress-qemu-flash = " file://defconfig \
                                        file://reduce-memory-to-256m.patch \
                                        "
 
+SRC_URI_append_mender-qemux86-64-bios = " file://mender-qemux86-64-bios-standard.scc"
+
 COMPATIBLE_MACHINE_vexpress-qemu-flash = "vexpress-qemu-flash"
 
 # See commit 28a1f5cd95cfd in poky. This was added in order to support running

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -686,7 +686,7 @@ class TestUpdates:
             os.remove("image.mender")
             os.remove("image.dat")
 
-    @pytest.mark.only_for_machine('qemux86-64')
+    @pytest.mark.only_for_machine('qemux86-64', 'mender-qemux86-64-bios')
     @pytest.mark.min_mender_version('1.0.0')
     def test_redundant_grub_env(self, successful_image_update_mender, bitbake_variables):
         """This tests pretty much the same thing as the test_redundant_uboot_env

--- a/tests/build-conf/qemux86-64-bios-grub/local.conf
+++ b/tests/build-conf/qemux86-64-bios-grub/local.conf
@@ -11,7 +11,7 @@
 # the option is a question of removing the # character and making any change to the
 # variable as required.
 
-INHERIT += "mender-full-bios rm_work"
+INHERIT += "rm_work"
 RM_WORK_EXCLUDE = "wic-tools"
 
 #
@@ -36,7 +36,7 @@ RM_WORK_EXCLUDE = "wic-tools"
 #MACHINE ?= "mpc8315e-rdb"
 #MACHINE ?= "edgerouter"
 #
-MACHINE ?= "qemux86-64"
+MACHINE ?= "mender-qemux86-64-bios"
 # This sets the default machine to be qemux86 if no other machine is selected:
 # MACHINE ??= "qemux86"
 


### PR DESCRIPTION
Machine names that are equal should reflect images that are
compatible, but this is not true for GRUB/UEFI vs GRUB/BIOS, due to
the mount point of the environment being different (/boot/efi vs
/boot/grub). So switch to a new machine name to distinguish between
the two configurations.

Changelog: Switch GRUB/BIOS combination to new machine name to avoid
conflict: mender-qemux86-64-bios. This only affects the QEMU builds.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>