### PR TITLE
mender-grub: Use test command to locate kernel.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/files/90_mender_boot_grub.cfg
+++ b/meta-mender-core/recipes-bsp/grub/files/90_mender_boot_grub.cfg
@@ -1,6 +1,8 @@
-if linux (${mender_grub_storage_device},gpt${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} console=ttyS0; then
+if [ -e (${mender_grub_storage_device},gpt${mender_boot_part})/boot/bzImage ]; then
+    linux (${mender_grub_storage_device},gpt${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} console=ttyS0
     boot
 fi
-if linux (${mender_grub_storage_device},msdos${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} console=ttyS0; then
+if [ -e (${mender_grub_storage_device},msdos${mender_boot_part})/boot/bzImage ]; then
+    linux (${mender_grub_storage_device},msdos${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} console=ttyS0
     boot
 fi


### PR DESCRIPTION
This avoids an error message from grub about a missing partition.

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>