### PR TITLE
GRUB: Pass kernel arguments from bootargs variable instead of hardcoded.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/files/06_bootargs_grub.cfg
+++ b/meta-mender-core/recipes-bsp/grub/files/06_bootargs_grub.cfg
@@ -1,0 +1,1 @@
+set bootargs="${bootargs} console=tty0 console=ttyS0"

--- a/meta-mender-core/recipes-bsp/grub/files/90_mender_boot_grub.cfg
+++ b/meta-mender-core/recipes-bsp/grub/files/90_mender_boot_grub.cfg
@@ -1,6 +1,6 @@
-if linux (${mender_grub_storage_device},gpt${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} console=ttyS0; then
+if linux (${mender_grub_storage_device},gpt${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} ${bootargs}; then
     boot
 fi
-if linux (${mender_grub_storage_device},msdos${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} console=ttyS0; then
+if linux (${mender_grub_storage_device},msdos${mender_boot_part})/boot/bzImage root=${mender_kernel_root_base}${mender_boot_part} ${bootargs}; then
     boot
 fi

--- a/meta-mender-core/recipes-bsp/grub/grub-mender-grubenv_1.0.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-mender-grubenv_1.0.bb
@@ -13,6 +13,7 @@ FILES_${PN} += "/data/mender_grubenv.config"
 SRC_URI = " \
     file://LICENSE \
     file://05_mender_setup_grub.cfg \
+    file://06_bootargs_grub.cfg \
     file://90_mender_boot_grub.cfg \
     file://91_mender_try_to_recover_grub.cfg \
     file://blank_grubenv \


### PR DESCRIPTION
This allows it to be overridden or modified by adding a script snippet
which sets the variable.

Also log kernel messages to both screen and serial port by default,
and have systemd log to serial port (last "console" argument,
apparently it cannot log to both).

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>