### PR TITLE
Change default storage on x86 to memory card (mmcblk0).

### DIFF
--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -32,7 +32,7 @@ get_uboot_device_from_device() {
 
 get_grub_device_from_device_base() {
     case "$1" in
-        /dev/[sh]da)
+        /dev/[sh]d[a-z])
             dev_number=${1#/dev/[sh]d}
             dev_number=$(expr $(printf "%d" "'$dev_number") - $(printf "%d" "'a") || true)
             echo "hd$dev_number"

--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -37,6 +37,11 @@ get_grub_device_from_device_base() {
             dev_number=$(expr $(printf "%d" "'$dev_number") - $(printf "%d" "'a") || true)
             echo "hd$dev_number"
             ;;
+        /dev/mmcblk[0-9]p)
+            dev_number=${1#/dev/mmcblk}
+            dev_number=${dev_number%p}
+            echo "hd$dev_number"
+            ;;
         *)
             bberror "Could not determine Grub device from $1"
             exit 1

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -16,9 +16,13 @@ MENDER_STORAGE_DEVICE_DEFAULT_x86-64 = "/dev/hda"
 # The base name of the devices that hold individual partitions.
 # This is often MENDER_STORAGE_DEVICE + "p".
 MENDER_STORAGE_DEVICE_BASE ??= "${MENDER_STORAGE_DEVICE_BASE_DEFAULT}"
-MENDER_STORAGE_DEVICE_BASE_DEFAULT = "${MENDER_STORAGE_DEVICE}p"
-MENDER_STORAGE_DEVICE_BASE_DEFAULT_x86 = "${MENDER_STORAGE_DEVICE}"
-MENDER_STORAGE_DEVICE_BASE_DEFAULT_x86-64 = "${MENDER_STORAGE_DEVICE}"
+def mender_linux_partition_base(dev):
+    import re
+    if re.match("^/dev/[sh]d[a-z]", dev):
+        return dev
+    else:
+        return "%sp" % dev
+MENDER_STORAGE_DEVICE_BASE_DEFAULT = "${@mender_linux_partition_base('${MENDER_STORAGE_DEVICE}')}"
 
 # The partition number holding the boot partition.
 MENDER_BOOT_PART ??= "${MENDER_BOOT_PART_DEFAULT}"

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -10,8 +10,6 @@ export MENDER_MACHINE = "${MACHINE}"
 # The storage device that holds the device partitions.
 MENDER_STORAGE_DEVICE ??= "${MENDER_STORAGE_DEVICE_DEFAULT}"
 MENDER_STORAGE_DEVICE_DEFAULT = "/dev/mmcblk0"
-MENDER_STORAGE_DEVICE_DEFAULT_x86 = "/dev/hda"
-MENDER_STORAGE_DEVICE_DEFAULT_x86-64 = "/dev/hda"
 
 # The base name of the devices that hold individual partitions.
 # This is often MENDER_STORAGE_DEVICE + "p".

--- a/meta-mender-qemu/conf/layer.conf
+++ b/meta-mender-qemu/conf/layer.conf
@@ -12,6 +12,8 @@ BBFILE_COLLECTIONS += "mender-qemu"
 BBFILE_PATTERN_mender-qemu = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender-qemu = "6"
 
-EXTRA_IMAGEDEPENDS_append_mender-image-uefi = " ovmf"
-
 LAYERSERIES_COMPAT_mender-qemu = "sumo"
+
+EXTRA_IMAGEDEPENDS_append_mender-image-uefi = " ovmf"
+MENDER_STORAGE_DEVICE_DEFAULT_qemux86 = "/dev/hda"
+MENDER_STORAGE_DEVICE_DEFAULT_qemux86-64 = "/dev/hda"


### PR DESCRIPTION
It appears that `/dev/hda` is rather uncommon, and quite specific to
QEMU since its IDE driver (which corresponds to `/dev/hda`) is
obsolete in modern hardware, and hence should only be used for
testing.

This is building on #576, only the top commit is new.