### PR TITLE
Switch image names from containing MACHINE to containing DEVICE_TYPE.

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -20,7 +20,7 @@ IMAGE_CMD_mender () {
         bbfatal "Need to define MENDER_ARTIFACT_NAME variable."
     fi
 
-    rootfs_size=$(stat -Lc %s ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${ARTIFACTIMG_FSTYPE})
+    rootfs_size=$(stat -Lc %s ${IMGDEPLOYDIR}/${IMAGE_NAME}.${ARTIFACTIMG_FSTYPE})
     calc_rootfs_size=$(expr ${MENDER_CALC_ROOTFS_SIZE} \* 1024)
     if [ $rootfs_size -gt $calc_rootfs_size ]; then
         bbfatal "Size of rootfs is greater than the calculated partition space ($rootfs_size > $calc_rootfs_size). This image won't fit on a device with the current storage configuration. Try reducing IMAGE_OVERHEAD_FACTOR if it is higher than 1.0, or raise MENDER_STORAGE_TOTAL_SIZE_MB if the device in fact has more storage."
@@ -47,7 +47,7 @@ IMAGE_CMD_mender () {
     mender-artifact write rootfs-image \
         -n ${MENDER_ARTIFACT_NAME} \
         $extra_args \
-        -u ${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.${ARTIFACTIMG_FSTYPE} \
+        -u ${IMGDEPLOYDIR}/${IMAGE_NAME}.${ARTIFACTIMG_FSTYPE} \
         ${MENDER_ARTIFACT_EXTRA_ARGS} \
         -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender
 }

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -59,6 +59,9 @@ MENDER_BOOT_PART_FSTYPE_DEFAULT = "auto"
 MENDER_DEVICE_TYPE ??= "${MENDER_DEVICE_TYPE_DEFAULT}"
 MENDER_DEVICE_TYPE_DEFAULT = "${MACHINE}"
 
+# To tell the difference from a beaglebone-yocto image with only U-Boot.
+MENDER_DEVICE_TYPE_DEFAULT_beaglebone-yocto_mender-grub = "${MACHINE}-grub"
+
 # Space separated list of device types compatible with the built update.
 MENDER_DEVICE_TYPES_COMPATIBLE ??= "${MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT}"
 MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT = "${MENDER_DEVICE_TYPE}"
@@ -151,6 +154,12 @@ MENDER_UBOOT_POST_SETUP_COMMANDS_DEFAULT = ""
 
 IMAGE_INSTALL_append = " mender"
 IMAGE_CLASSES += "mender-part-images mender-ubimg mender-artifactimg mender-dataimg"
+
+# Originally defined in bitbake.conf. We define them here so that images with
+# the same MACHINE name, but different MENDER_DEVICE_TYPE, will not result in
+# the same image file name.
+IMAGE_NAME = "${IMAGE_BASENAME}-${MENDER_DEVICE_TYPE}-${DATETIME}"
+IMAGE_LINK_NAME = "${IMAGE_BASENAME}-${MENDER_DEVICE_TYPE}"
 
 # MENDER_FEATURES_ENABLE and MENDER_FEATURES_DISABLE map to
 # DISTRO_FEATURES_BACKFILL and DISTRO_FEATURES_BACKFILL_CONSIDERED,

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -66,11 +66,6 @@ MENDER_DEVICE_TYPE_DEFAULT_beaglebone-yocto_mender-grub = "${MACHINE}-grub"
 MENDER_DEVICE_TYPES_COMPATIBLE ??= "${MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT}"
 MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT = "${MENDER_DEVICE_TYPE}"
 
-# Upstream poky changed their Beaglebone machine name from "beaglebone" to
-# "beaglebone-yocto". Add the old name to the list of compatible devices, so
-# people can upgrade.
-MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT_append_beaglebone-yocto = " beaglebone"
-
 # Total size of the medium that mender sdimg will be written to. The size of
 # rootfs partition will be calculated automatically by subtracting the size of
 # boot and data partitions along with some predefined overhead (see

--- a/meta-mender-qemu/conf/layer.conf
+++ b/meta-mender-qemu/conf/layer.conf
@@ -18,3 +18,8 @@ EXTRA_IMAGEDEPENDS_append_mender-image-uefi_x86 = " ovmf"
 EXTRA_IMAGEDEPENDS_append_mender-image-uefi_x86-64 = " ovmf"
 MENDER_STORAGE_DEVICE_DEFAULT_qemux86 = "/dev/hda"
 MENDER_STORAGE_DEVICE_DEFAULT_qemux86-64 = "/dev/hda"
+
+# To tell the difference from a vexpress-qemu image with only U-Boot.
+MENDER_DEVICE_TYPE_DEFAULT_vexpress-qemu_mender-grub = "${MACHINE}-grub"
+# To tell the difference from a vexpress-qemu image with GRUB and UEFI.
+MENDER_DEVICE_TYPE_DEFAULT_qemux86-64_mender-grub_mender-bios = "${MACHINE}-bios"

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -135,7 +135,7 @@ class TestUpdates:
 
         (active_before, passive_before) = determine_active_passive_part(bitbake_variables)
 
-        image_type = bitbake_variables["MACHINE"]
+        image_type = bitbake_variables["MENDER_DEVICE_TYPE"]
 
         try:
             # Make a dummy/broken update
@@ -168,7 +168,7 @@ class TestUpdates:
             execute(self.test_too_big_image_update, bitbake_variables)
             return
 
-        image_type = bitbake_variables["MACHINE"]
+        image_type = bitbake_variables["MENDER_DEVICE_TYPE"]
 
         try:
             # Make a too big update
@@ -460,7 +460,7 @@ class TestUpdates:
         else:
             sig_key = None
 
-        image_type = bitbake_variables["MACHINE"]
+        image_type = bitbake_variables["MENDER_DEVICE_TYPE"]
 
         subprocess.check_call("mender-artifact write rootfs-image %s -t %s -n test-update -u image.dat -o image.mender"
                               % (artifact_args, image_type), shell=True)
@@ -636,7 +636,7 @@ class TestUpdates:
 
         orig_env = run("fw_printenv")
 
-        image_type = bitbake_variables["MACHINE"]
+        image_type = bitbake_variables["MENDER_DEVICE_TYPE"]
 
         try:
             # Make a dummy/broken update


### PR DESCRIPTION
Changelog: Switch image names from containing `MACHINE` to containing
`MENDER_DEVICE_TYPE`. So for example, if you have a build for the
raspberrypi3 machine type, with device type of "prod_rpi3", the image
will now be called `core-image-minimal-prod_rpi3.sdimg` instead of
`core-image-minimal-raspberrypi3.sdimg`.

The main reason for doing this change is that MACHINE is not enough to
separate images from each other when multiple boot loader
configurations are involved. For example vexpress-qemu can be booted
both with U-Boot and with GRUB, and these images are not compatible
with each other. To make sure that images have distinct names, this
change is necessary.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>