### PR TITLE
Revert "uboot_auto_patch: Switch kernel address from `kernel_addr_r` …

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_patch.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_patch.sh
@@ -89,6 +89,22 @@ add_definition() {
     fi
 }
 
+append_to_definition() {
+    # Appends something to a string definition.
+
+    if ! definition_exists "$1"; then
+        echo "Tried to append to definition $1, but it doesn't exist!" 1>&2
+        exit 1
+    fi
+
+    if is_kconfig_option "$1"; then
+        sed -re "s%^$1=(.*)\"%$1=\1$2\"%" configs/$CONFIG
+    else
+        # Add it to the last non-backslash-continued line.
+        patch_candidate_list "\\%^[ \t]*#[ \t]*define[ \t]*$1\\b% {:start; /\\\\$/ {p; n; b start}; s%\$% $2%}; p"
+    fi
+}
+
 definition_exists() {
     # Returns 0 if the definition is found either in the source code or in the
     # config definition.
@@ -259,15 +275,15 @@ patch_all_candidates() {
             "fdt_addr_r"
     fi
 
-    # Find load address for kernel and make sure it's in loadaddr.
+    # Find load address for kernel and make sure it's in kernel_addr_r.
     if kernel_addr="$(extract_kernel_addr)"; then
-        if [ "$kernel_addr" != "loadaddr" ]; then
+        if [ "$kernel_addr" != "kernel_addr_r" ]; then
             remove_bootvar \
-                "loadaddr"
+                "kernel_addr_r"
         fi
         rename_bootvar \
             "$kernel_addr" \
-            "loadaddr"
+            "kernel_addr_r"
     else
         # Alright, no dedicated address. Let's try the second best, find it by
         # looking at existing boot commands.
@@ -275,10 +291,11 @@ patch_all_candidates() {
 
         # Using the :- syntax is because "set -u" is in effect.
         if [ -n "${addr:-}" ]; then
-            replace_definition \
-                'CONFIG_LOADADDR' \
-                'CONFIG_LOADADDR' \
-                "$addr"
+            if definition_exists "CONFIG_EXTRA_ENV_SETTINGS"; then
+                append_to_definition "CONFIG_EXTRA_ENV_SETTINGS" "\"kernel_addr_r=$addr\\\\0\""
+            else
+                add_definition "CONFIG_EXTRA_ENV_SETTINGS" "\"kernel_addr_r=$addr\\\\0\""
+            fi
         else
             echo "Could not find kernel load address!" 1>&2
             echo "This is the obtained environment:"

--- a/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
@@ -254,7 +254,7 @@ index 0000000..a1996ab
 +    "if test \"${fdt_addr_r}\" != \"\"; then "                          \
 +    "ubifsload ${fdt_addr_r} /boot/${mender_dtb_name}; "                \
 +    "fi; "                                                              \
-+    "ubifsload ${loadaddr} /boot/${mender_kernel_name}; "
++    "ubifsload ${kernel_addr_r} /boot/${mender_kernel_name}; "
 +#else
 +# define MENDER_BOOTARGS                                                \
 +    "setenv bootargs root=${mender_kernel_root} ${bootargs}; "
@@ -262,14 +262,14 @@ index 0000000..a1996ab
 +    "if test \"${fdt_addr_r}\" != \"\"; then "                          \
 +    "load ${mender_uboot_root} ${fdt_addr_r} /boot/${mender_dtb_name}; " \
 +    "fi; "                                                              \
-+    "load ${mender_uboot_root} ${loadaddr} /boot/${mender_kernel_name}; "
++    "load ${mender_uboot_root} ${kernel_addr_r} /boot/${mender_kernel_name}; "
 +#endif
 +
 +#define CONFIG_MENDER_BOOTCOMMAND                                       \
 +    "run mender_setup; "                                                \
 +    MENDER_BOOTARGS                                                     \
 +    MENDER_LOAD_KERNEL_AND_FDT                                          \
-+    "${mender_boot_kernel_type} ${loadaddr} - ${fdt_addr_r}; "     \
++    "${mender_boot_kernel_type} ${kernel_addr_r} - ${fdt_addr_r}; "     \
 +    "run mender_try_to_recover"
 +
 +#endif /* !MENDER_AUTO_PROBING */

--- a/meta-mender-qemu/recipes-bsp/u-boot/patches/0001-Set-correct-load-addresses-for-QEMU.patch
+++ b/meta-mender-qemu/recipes-bsp/u-boot/patches/0001-Set-correct-load-addresses-for-QEMU.patch
@@ -15,9 +15,9 @@ index bcaf5c9..638b943 100644
 @@ -216,7 +216,9 @@
  		"kernel_addr_r=0xa0008000\0"
  #endif
-+#define CONFIG_LOADADDR 0x60100000
  #define CONFIG_EXTRA_ENV_SETTINGS \
 -		CONFIG_PLATFORM_ENV_SETTINGS \
++                "kernel_addr_r=0x60100000\0" \
 +                "fdt_addr_r=0x60000000\0" \
 +                "bootargs=console=tty0 console=ttyAMA0,38400n8\0" \
                  BOOTENV \


### PR DESCRIPTION
…to `loadaddr`."

This reverts commit 642d57c29eb460f8882210d5e4e6be8ffe7d1093.

Changelog: uboot_auto_patch: Switch kernel address from `loadaddr`
back to `kernel_addr_r`. This was discussed with U-Boot developers and
is the proper address variable going forward.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>