### PR TITLE
mender: Add MENDER_MACHINE to BB_HASHBASE_WHITELIST.

### DIFF
--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -6,6 +6,7 @@ inherit mender-helpers
 # For some reason 'bitbake -e' does not report the MACHINE value so
 # we use this as a proxy in case it is not available when needed.
 export MENDER_MACHINE = "${MACHINE}"
+BB_HASHBASE_WHITELIST += "MENDER_MACHINE"
 
 # The storage device that holds the device partitions.
 MENDER_STORAGE_DEVICE ??= "${MENDER_STORAGE_DEVICE_DEFAULT}"


### PR DESCRIPTION
This avoids unnecessary rebuilds when adding or removing the meta-mender-core
layer.

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>