### PR TITLE
mender-setup-image.inc: Fix recipe append syntax

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -20,7 +20,7 @@ MENDER_BOOT_PART_MOUNT_LOCATION_mender-uboot = "/uboot"
 MENDER_BOOT_PART_MOUNT_LOCATION_mender-grub_mender-bios = "/boot/grub"
 
 # Update fstab for Mender
-ROOTFS_POSTPROCESS_COMMAND_append += " mender_update_fstab_file ; "
+ROOTFS_POSTPROCESS_COMMAND_append = " mender_update_fstab_file;"
 mender_update_fstab_file() {
     if ! ${@bb.utils.contains('DISTRO_FEATURES', 'mender-image-ubi', 'true', 'false', d)}; then
         if [ "${MENDER_BOOT_PART_SIZE_MB}" != "0" ] && [ -n "${MENDER_BOOT_PART}" ]; then
@@ -38,7 +38,7 @@ mender_update_fstab_file() {
 
 # Setup state script version file.
 MENDER_STATE_SCRIPTS_VERSION = "2"
-ROOTFS_POSTPROCESS_COMMAND_append += "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image', ' mender_create_scripts_version_file ; ', '', d)}"
+ROOTFS_POSTPROCESS_COMMAND_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image', ' mender_create_scripts_version_file;', '', d)}"
 
 mender_create_scripts_version_file() {
     install -d -m 755 ${IMAGE_ROOTFS}${sysconfdir}/mender/scripts/


### PR DESCRIPTION
It is incorrect to use both types of append syntax and also to add
spaces between functions and semi-colons, this is confusing and causes
unexpected behaviour.

First, the += adds the string defined to the
ROOTFS_POSTPROCESS_COMMAND_append variable, with an extra space at the
start. Then, the _append syntax adds this new string to the
ROOTFS_POSTPROCESS_COMMAND variable, after all previous += operations.
It is only necessary to add one space at the beginning of an _append
operation, or no spaces for a += operation.

Also, by adding a space between `mender_update_fstab_file` and `;` (for
example) we make it impossible to remove `mender_update_fstab_file ;`
from the ROOTFS_POSTPROCESS_COMMAND list. The following describes each
_remove syntax and its associated error:

* `ROOTFS_POSTPROCESS_COMMAND_remove = "mender_update_fstab_file"`
  Removes all instances of `mender_update_fstab_file` but leaves a rogue
  semi-colon, causing bitbake to error.

* `ROOTFS_POSTPROCESS_COMMAND_remove = ";"`
  Removes all instances of `;`, causing bitbake to error.

* `ROOTFS_POSTPROCESS_COMMAND_remove = "mender_update_fstab_file ;"`
  Removes all instances of `mender_update_fstab_file` and `;`, causing
  bitbake to error because of the missing semi-colons.

To fix, this I have decided to use only the _append syntax with a single
space prefix, and to join the function names with associated
semi-colons.  It is now possible to remove this function using the
syntax:

	ROOTFS_POSTPROCESS_COMMAND_remove = "mender_update_fstab_file;"

https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#recipe-syntax

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>