### PR TITLE
More fixes after colibri imx7 testing

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -4,8 +4,10 @@ IMAGE_FSTYPES_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image-ub
 IMAGE_FSTYPES_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image-uefi', ' uefiimg uefiimg.bmap', '', d)}"
 IMAGE_FSTYPES_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image-bios', ' biosimg biosimg.bmap', '', d)}"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_x86 = " kernel-image"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_x86-64 = " kernel-image"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_x86 =     " kernel-image"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_x86-64 =  " kernel-image"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_arm =     " kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_aarch64 = " kernel-image kernel-devicetree"
 
 python() {
     features = d.getVar('DISTRO_FEATURES').split()

--- a/meta-mender-core/classes/mender-setup-ubi.inc
+++ b/meta-mender-core/classes/mender-setup-ubi.inc
@@ -174,10 +174,10 @@ def mender_make_mtdparts(d):
         return ""
 
     u_boot_part_size = int(d.getVar('MENDER_STORAGE_PEB_SIZE'))
-    # Default to at least 512KiB for U-Boot binary. Can be changed by setting
+    # Default to at least 1MiB for U-Boot binary. Can be changed by setting
     # MENDER_MTDPARTS manually.
-    if u_boot_part_size < 524288:
-        u_boot_part_size = 524288
+    if u_boot_part_size < 1048576:
+        u_boot_part_size = 1048576
 
     bootloader = ""
     if bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', True, False, d):

--- a/meta-mender-core/classes/mender-setup-ubi.inc
+++ b/meta-mender-core/classes/mender-setup-ubi.inc
@@ -95,7 +95,7 @@ MENDER_MTDIDS ??= ""
 # If there is more than one mtdid, the mtdid that contains Mender.
 # This should be the one after the equals sign in MENDER_MTDIDS.
 # Currently there is no support for spreading over more than one.
-MENDER_IS_ON_MTDID ??= "${@mender_default_mender_mtdid('${MENDER_MTDIDS}')}"
+MENDER_IS_ON_MTDID ??= "${@mender_default_mender_mtdid(d)}"
 
 # The mtdparts string for the MTD layout. Usually auto-set from MENDER_MTDIDS
 # if possible. It should contain a "u-boot" label and a "ubi" label.
@@ -153,11 +153,18 @@ MENDER_UBOOT_ENV_UBIVOL_NUMBER_2 ??= "4"
 # Functions
 ################################################################################
 
-def mender_warn_only_if_ubi(d, msg):
+def mender_warn_only_if_ubi(d, msg, fatal=False):
     if bb.utils.contains('DISTRO_FEATURES', 'mender-ubi', True, False, d):
-        bb.warn(msg)
+        if fatal:
+            bb.fatal(msg)
+        else:
+            bb.warn(msg)
 
-def mender_default_mender_mtdid(mtdids):
+def mender_default_mender_mtdid(d):
+    mtdids = d.getVar("MENDER_MTDIDS")
+    if mtdids is None or mtdids == "":
+        mender_warn_only_if_ubi(d, "MENDER_MTDIDS must be defined", fatal=True)
+
     if len(mtdids.split(",")) == 1 and len(mtdids.split("=")) == 2:
         return mtdids.split("=")[1]
     else:

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/patches/0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/patches/0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch
@@ -1,0 +1,31 @@
+From 17236152bf80436567bf3f1f27af3915364ec0b6 Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@northern.tech>
+Date: Wed, 4 Apr 2018 10:01:04 +0200
+Subject: [PATCH 5/5] fw_env_main.c: Fix incorrect size for malloc'ed string.
+
+Using sizeof gives the size of the pointer only, not the string.
+
+Upstream-Status: Backport
+http://git.denx.de/?p=u-boot.git;a=commit;h=8a0b827b1a12cf3e224a4c083de7a1e448356a16
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+---
+ tools/env/fw_env_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
+index 6fdf41c..f8e3f07 100644
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
+ 	argv += optind;
+ 
+ 	if (env_opts.lockname) {
+-		lockname = malloc(sizeof(env_opts.lockname) +
++		lockname = malloc(strlen(env_opts.lockname) +
+ 				sizeof(CMD_PRINTENV) + 10);
+ 		if (!lockname) {
+ 			fprintf(stderr, "Unable allocate memory");
+-- 
+2.7.4
+

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/patches/u-boot_v2016.11-backport-of-34255b92e6e68941ab1134299faa86acc5a1abc8.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/patches/u-boot_v2016.11-backport-of-34255b92e6e68941ab1134299faa86acc5a1abc8.patch
@@ -1,0 +1,381 @@
+From 96fc54b2d6eb99dcd32ccf9fc2b74c6a80249906 Mon Sep 17 00:00:00 2001
+From: "S. Lockwood-Childs" <sjl@vctlabs.com>
+Date: Tue, 14 Nov 2017 23:01:26 -0800
+Subject: [PATCH 1/1] tools: env: Add support for direct read/write UBI volumes
+
+Up to now we were able to read/write environment data from/to UBI
+volumes only indirectly by gluebi driver. This driver creates NAND MTD
+on top of UBI volumes, which is quite a workaroung for this use case.
+
+Add support for direct read/write UBI volumes in order to not use
+obsolete gluebi driver.
+
+Forward-ported from this patch:
+http://patchwork.ozlabs.org/patch/619305/
+
+Original patch:
+Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>
+
+Forward port:
+Signed-off-by: S. Lockwood-Childs <sjl@vctlabs.com>
+
+Upstream-Status: Backport
+http://git.denx.de/?p=u-boot.git;a=commit;h=34255b92e6e68941ab1134299faa86acc5a1abc8
+
+Conflicts:
+	tools/env/fw_env.c
+---
+ tools/env/fw_env.c      | 255 +++++++++++++++++++++++++++++++++++++++++++++++-
+ tools/env/fw_env.config |   8 ++
+ 2 files changed, 261 insertions(+), 2 deletions(-)
+
+diff --git a/tools/env/fw_env.c b/tools/env/fw_env.c
+index f18c8dd..ced8757 100644
+--- a/tools/env/fw_env.c
++++ b/tools/env/fw_env.c
+@@ -26,6 +26,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
+ #include <unistd.h>
++#include <dirent.h>
+ 
+ #ifdef MTD_OLD
+ # include <stdint.h>
+@@ -35,6 +36,8 @@
+ # include <mtd/mtd-user.h>
+ #endif
+ 
++#include <mtd/ubi-user.h>
++
+ #include "fw_env.h"
+ 
+ struct env_opts default_opts = {
+@@ -58,6 +61,7 @@ struct envdev_s {
+ 	ulong erase_size;		/* device erase size */
+ 	ulong env_sectors;		/* number of environment sectors */
+ 	uint8_t mtd_type;		/* type of the MTD device */
++	int is_ubi;			/* set if we use UBI volume */
+ };
+ 
+ static struct envdev_s envdevices[2] =
+@@ -76,6 +80,7 @@ static int dev_current;
+ #define DEVESIZE(i)   envdevices[(i)].erase_size
+ #define ENVSECTORS(i) envdevices[(i)].env_sectors
+ #define DEVTYPE(i)    envdevices[(i)].mtd_type
++#define IS_UBI(i)     envdevices[(i)].is_ubi
+ 
+ #define CUR_ENVSIZE ENVSIZE(dev_current)
+ 
+@@ -122,6 +127,228 @@ static unsigned char obsolete_flag = 0;
+ #define DEFAULT_ENV_INSTANCE_STATIC
+ #include <env_default.h>
+ 
++#define UBI_DEV_START "/dev/ubi"
++#define UBI_SYSFS "/sys/class/ubi"
++#define UBI_VOL_NAME_PATT "ubi%d_%d"
++
++static int is_ubi_devname(const char *devname)
++{
++	return !strncmp(devname, UBI_DEV_START, sizeof(UBI_DEV_START) - 1);
++}
++
++static int ubi_check_volume_sysfs_name(const char *volume_sysfs_name,
++				       const char *volname)
++{
++	char path[256];
++	FILE *file;
++	char *name;
++	int ret;
++
++	strcpy(path, UBI_SYSFS "/");
++	strcat(path, volume_sysfs_name);
++	strcat(path, "/name");
++
++	file = fopen(path, "r");
++	if (!file)
++		return -1;
++
++	ret = fscanf(file, "%ms", &name);
++	fclose(file);
++	if (ret <= 0 || !name) {
++		fprintf(stderr,
++			"Failed to read from file %s, ret = %d, name = %s\n",
++			path, ret, name);
++		return -1;
++	}
++
++	if (!strcmp(name, volname)) {
++		free(name);
++		return 0;
++	}
++	free(name);
++
++	return -1;
++}
++
++static int ubi_get_volnum_by_name(int devnum, const char *volname)
++{
++	DIR *sysfs_ubi;
++	struct dirent *dirent;
++	int ret;
++	int tmp_devnum;
++	int volnum;
++
++	sysfs_ubi = opendir(UBI_SYSFS);
++	if (!sysfs_ubi)
++		return -1;
++
++#ifdef DEBUG
++	fprintf(stderr, "Looking for volume name \"%s\"\n", volname);
++#endif
++
++	while (1) {
++		dirent = readdir(sysfs_ubi);
++		if (!dirent)
++			return -1;
++
++		ret = sscanf(dirent->d_name, UBI_VOL_NAME_PATT,
++			     &tmp_devnum, &volnum);
++		if (ret == 2 && devnum == tmp_devnum) {
++			if (ubi_check_volume_sysfs_name(dirent->d_name,
++							volname) == 0)
++				return volnum;
++		}
++	}
++
++	return -1;
++}
++
++static int ubi_get_devnum_by_devname(const char *devname)
++{
++	int devnum;
++	int ret;
++
++	ret = sscanf(devname + sizeof(UBI_DEV_START) - 1, "%d", &devnum);
++	if (ret != 1)
++		return -1;
++
++	return devnum;
++}
++
++static const char *ubi_get_volume_devname(const char *devname,
++					  const char *volname)
++{
++	char *volume_devname;
++	int volnum;
++	int devnum;
++	int ret;
++
++	devnum = ubi_get_devnum_by_devname(devname);
++	if (devnum < 0)
++		return NULL;
++
++	volnum = ubi_get_volnum_by_name(devnum, volname);
++	if (volnum < 0)
++		return NULL;
++
++	ret = asprintf(&volume_devname, "%s_%d", devname, volnum);
++	if (ret < 0)
++		return NULL;
++
++#ifdef DEBUG
++	fprintf(stderr, "Found ubi volume \"%s:%s\" -> %s\n",
++		devname, volname, volume_devname);
++#endif
++
++	return volume_devname;
++}
++
++static void ubi_check_dev(unsigned int dev_id)
++{
++	char *devname = (char *)DEVNAME(dev_id);
++	char *pname;
++	const char *volname = NULL;
++	const char *volume_devname;
++
++	if (!is_ubi_devname(DEVNAME(dev_id)))
++		return;
++
++	IS_UBI(dev_id) = 1;
++
++	for (pname = devname; *pname != '\0'; pname++) {
++		if (*pname == ':') {
++			*pname = '\0';
++			volname = pname + 1;
++			break;
++		}
++	}
++
++	if (volname) {
++		/* Let's find real volume device name */
++		volume_devname = ubi_get_volume_devname(devname, volname);
++		if (!volume_devname) {
++			fprintf(stderr, "Didn't found ubi volume \"%s\"\n",
++				volname);
++			return;
++		}
++
++		free(devname);
++		DEVNAME(dev_id) = volume_devname;
++	}
++}
++
++static int ubi_update_start(int fd, int64_t bytes)
++{
++	if (ioctl(fd, UBI_IOCVOLUP, &bytes))
++		return -1;
++	return 0;
++}
++
++static int ubi_read(int fd, void *buf, size_t count)
++{
++	ssize_t ret;
++
++	while (count > 0) {
++		ret = read(fd, buf, count);
++		if (ret > 0) {
++			count -= ret;
++			buf += ret;
++
++			continue;
++		}
++
++		if (ret == 0) {
++			/*
++			 * Happens in case of too short volume data size. If we
++			 * return error status we will fail it will be treated
++			 * as UBI device error.
++			 *
++			 * Leave catching this error to CRC check.
++			 */
++			fprintf(stderr, "Warning: end of data on ubi volume\n");
++			return 0;
++		} else if (errno == EBADF) {
++			/*
++			 * Happens in case of corrupted volume. The same as
++			 * above, we cannot return error now, as we will still
++			 * be able to successfully write environment later.
++			 */
++			fprintf(stderr, "Warning: corrupted volume?\n");
++			return 0;
++		} else if (errno == EINTR) {
++			continue;
++		}
++
++		fprintf(stderr, "Cannot read %u bytes from ubi volume, %s\n",
++			(unsigned int)count, strerror(errno));
++		return -1;
++	}
++
++	return 0;
++}
++
++static int ubi_write(int fd, const void *buf, size_t count)
++{
++	ssize_t ret;
++
++	while (count > 0) {
++		ret = write(fd, buf, count);
++		if (ret <= 0) {
++			if (ret < 0 && errno == EINTR)
++				continue;
++
++			fprintf(stderr, "Cannot write %u bytes to ubi volume\n",
++				(unsigned int)count);
++			return -1;
++		}
++
++		count -= ret;
++		buf += ret;
++	}
++
++	return 0;
++}
++
+ static int flash_io (int mode);
+ static int parse_config(struct env_opts *opts);
+ 
+@@ -1008,6 +1235,12 @@ static int flash_write (int fd_current, int fd_target, int dev_target)
+ 		DEVOFFSET (dev_target), DEVNAME (dev_target));
+ #endif
+ 
++	if (IS_UBI(dev_target)) {
++		if (ubi_update_start(fd_target, CUR_ENVSIZE) < 0)
++			return 0;
++		return ubi_write(fd_target, environment.image, CUR_ENVSIZE);
++	}
++
+ 	rc = flash_write_buf(dev_target, fd_target, environment.image,
+ 			     CUR_ENVSIZE);
+ 	if (rc < 0)
+@@ -1032,6 +1265,12 @@ static int flash_read (int fd)
+ {
+ 	int rc;
+ 
++	if (IS_UBI(dev_current)) {
++		DEVTYPE(dev_current) = MTD_ABSENT;
++
++		return ubi_read(fd, environment.image, CUR_ENVSIZE);
++	}
++
+ 	rc = flash_read_buf(dev_current, fd, environment.image, CUR_ENVSIZE,
+ 			    DEVOFFSET(dev_current));
+ 	if (rc != CUR_ENVSIZE)
+@@ -1200,7 +1439,8 @@ int fw_env_open(struct env_opts *opts)
+ 			   DEVTYPE(!dev_current) == MTD_UBIVOLUME) {
+ 			environment.flag_scheme = FLAG_INCREMENTAL;
+ 		} else if (DEVTYPE(dev_current) == MTD_ABSENT &&
+-			   DEVTYPE(!dev_current) == MTD_ABSENT) {
++			   DEVTYPE(!dev_current) == MTD_ABSENT &&
++			   IS_UBI(dev_current) == IS_UBI(!dev_current)) {
+ 			environment.flag_scheme = FLAG_INCREMENTAL;
+ 		} else {
+ 			fprintf (stderr, "Incompatible flash types!\n");
+@@ -1290,8 +1530,12 @@ int fw_env_open(struct env_opts *opts)
+ static int check_device_config(int dev)
+ {
+ 	struct stat st;
++	int32_t lnum = 0;
+ 	int fd, rc = 0;
+ 
++	/* Fills in IS_UBI(), converts DEVNAME() with ubi volume name */
++	ubi_check_dev(dev);
++
+ 	fd = open(DEVNAME(dev), O_RDONLY);
+ 	if (fd < 0) {
+ 		fprintf(stderr,
+@@ -1307,7 +1551,14 @@ static int check_device_config(int dev)
+ 		goto err;
+ 	}
+ 
+-	if (S_ISCHR(st.st_mode)) {
++	if (IS_UBI(dev)) {
++		rc = ioctl(fd, UBI_IOCEBISMAP, &lnum);
++		if (rc < 0) {
++			fprintf(stderr, "Cannot get UBI information for %s\n",
++				DEVNAME(dev));
++			goto err;
++		}
++	} else if (S_ISCHR(st.st_mode)) {
+ 		struct mtd_info_user mtdinfo;
+ 		rc = ioctl(fd, MEMGETINFO, &mtdinfo);
+ 		if (rc < 0) {
+diff --git a/tools/env/fw_env.config b/tools/env/fw_env.config
+index 7916ebd..053895a 100644
+--- a/tools/env/fw_env.config
++++ b/tools/env/fw_env.config
+@@ -28,3 +28,11 @@
+ 
+ # VFAT example
+ #/boot/uboot.env	0x0000          0x4000
++
++# UBI volume
++#/dev/ubi0_0		0x0		0x1f000		0x1f000
++#/dev/ubi0_1		0x0		0x1f000		0x1f000
++
++# UBI volume by name
++#/dev/ubi0:env		0x0		0x1f000		0x1f000
++#/dev/ubi0:env-redund	0x0		0x1f000		0x1f000
+-- 
+2.7.4
+

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/u-boot-toradex_2016.11.bbappend
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/u-boot-toradex_2016.11.bbappend
@@ -1,0 +1,3 @@
+SRC_URI_remove = "file://0006-env-Kconfig-Add-descriptions-so-environment-options-.patch"
+SRC_URI_append = " file://0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch \
+                   file://u-boot_v2016.11-backport-of-34255b92e6e68941ab1134299faa86acc5a1abc8.patch"

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -311,7 +311,7 @@ class TestBuild:
             "expected": {
                 "MENDER_MTDIDS": "nor2=40000000.flash",
                 "MENDER_IS_ON_MTDID": "40000000.flash",
-                "MENDER_MTDPARTS": "40000000.flash:512k(u-boot)ro,-(ubi)",
+                "MENDER_MTDPARTS": "40000000.flash:1m(u-boot)ro,-(ubi)",
             },
         }),
         ("custom_mtdids", {
@@ -322,7 +322,7 @@ class TestBuild:
             "expected": {
                 "MENDER_MTDIDS": "nor3=40000001.flash",
                 "MENDER_IS_ON_MTDID": "40000001.flash",
-                "MENDER_MTDPARTS": "40000001.flash:512k(u-boot)ro,-(ubi)",
+                "MENDER_MTDPARTS": "40000001.flash:1m(u-boot)ro,-(ubi)",
             },
         }),
         ("multiple_mtdids_no_selected_one", {
@@ -349,13 +349,13 @@ class TestBuild:
             "vars": [
                 'MENDER_MTDIDS = "nor2=40000000.flash,nor3=50000000.flash"',
                 'MENDER_IS_ON_MTDID = "40000000.flash"',
-                'MENDER_MTDPARTS = "50000000.flash:1m(whatever);40000000.flash:1m(u-boot)ro,3m(u-boot-env),-(ubi)"',
+                'MENDER_MTDPARTS = "50000000.flash:1m(whatever);40000000.flash:2m(u-boot)ro,3m(u-boot-env),-(ubi)"',
             ],
             "success": True,
             "expected": {
                 "MENDER_MTDIDS": "nor2=40000000.flash,nor3=50000000.flash",
                 "MENDER_IS_ON_MTDID": "40000000.flash",
-                "MENDER_MTDPARTS": "50000000.flash:1m(whatever);40000000.flash:1m(u-boot)ro,3m(u-boot-env),-(ubi)",
+                "MENDER_MTDPARTS": "50000000.flash:1m(whatever);40000000.flash:2m(u-boot)ro,3m(u-boot-env),-(ubi)",
             },
         }),
     ])


### PR DESCRIPTION
I think this should be the last fixes. After this, I only have device specific settings left in my `local.conf`:

* `MENDER_MTDIDS = "nand0=gpmi-nand"`
* `MENDER_MTDPARTS = "gpmi-nand:512k(mx7-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,512k(u-boot-env),-(ubi)"`
* `MENDER_STORAGE_PEB_SIZE = "131072"`
* `MENDER_STORAGE_TOTAL_SIZE_MB = "512"`

I am not sure how strongly these are tied to the `colibri-imx7` machine type, especially the last one. We could potentially put these also into the `machine.conf`, but is it appropriate, or should the user set them?

No other changes are required to build for `colibri-imx7`.

See individual commits for details.