### PR TITLE
FIX: Renamed boot.efi to bootia32.efi in mender-setup-grub.inc

### DIFF
--- a/meta-mender-core/classes/mender-setup-grub.inc
+++ b/meta-mender-core/classes/mender-setup-grub.inc
@@ -10,7 +10,7 @@ IMAGE_BOOT_FILES_append = " ${_MENDER_EFI_BOOT_FILE}"
 
 _MENDER_EFI_BOOT_FILE = ""
 _MENDER_EFI_BOOT_FILE_mender-grub_arm = "grub-efi-bootarm.efi;EFI/BOOT/bootarm.efi"
-_MENDER_EFI_BOOT_FILE_mender-grub_x86 = "grub-efi-bootia32.efi;EFI/BOOT/boot.efi"
+_MENDER_EFI_BOOT_FILE_mender-grub_x86 = "grub-efi-bootia32.efi;EFI/BOOT/bootia32.efi"
 _MENDER_EFI_BOOT_FILE_mender-grub_x86-64 = "grub-efi-bootx64.efi;EFI/BOOT/bootx64.efi"
 _MENDER_EFI_BOOT_FILE_mender-grub_mender-bios = ""
 


### PR DESCRIPTION
Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@cfengine.com>