### PR TITLE
Acceptance test files, i.e. py.test configuration and fixture modifie…

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -45,6 +45,12 @@ def pytest_addoption(parser):
                      help="use S3 for transferring images under test to target boards")
     parser.addoption("--s3-address", action="store", default="s3.amazonaws.com",
                      help="address of S3 server, defaults to AWS, override when using minio")
+    parser.addoption("--test-conversion", action="store_true", default=False,
+                     help="""conduct testing of .sdimg image built with mender-convert tool""")
+    parser.addoption("--test-variables", action="store", default="default",
+                     help="configuration file holding settings for dedicated platform")
+    parser.addoption("--mender-image", action="store", default="default",
+                     help="Mender compliant raw disk image")
 
 
 def pytest_configure(config):


### PR DESCRIPTION
…d to work with non-Yocto build images

conftest.py/fixtures.py/common.py modified to work
with non-Yocto build images. Tests stored in the
mender-image-tests repository can be used to validate
whether images built with mender-convert tool are
correct.

Changelog: None

Issues: MEN-2098

Signed-off-by: Adam Podogrocki <a.podogrocki@gmail.com>