### PR TITLE
tests: Add mender-image-tests as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "tests/acceptance/image-tests"]
+	path = tests/acceptance/image-tests
+	url = https://github.com/mendersoftware/mender-image-tests
+	branch = master
+	ignore = all

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -15,6 +15,7 @@
 
 import os
 import os.path
+import subprocess
 
 from fabric.api import *
 
@@ -39,6 +40,8 @@ def pytest_addoption(parser):
                      help="image to build during the tests")
     parser.addoption("--no-tmp-build-dir", action="store_true", default=False,
                      help="Do not use a temporary build directory. Faster, but may mess with your build directory.")
+    parser.addoption("--no-pull", action="store_true", default=False,
+                     help="Do not pull submodules. Handy if debugging something locally.")
     parser.addoption("--board-type", action="store", default='qemu',
                      help="type of board to use in testing, supported types: qemu, bbb, colibri-imx7")
     parser.addoption("--use-s3", action="store_true", default=False,
@@ -81,6 +84,10 @@ def pytest_configure(config):
 
     env.connection_attempts = 10
     env.timeout = 30
+
+    if not config.getoption("--no-pull"):
+        print("Automatically pulling submodules. Use --no-pull to disable")
+        subprocess.check_call("git submodule update --init --remote", shell=True)
 
 
 def current_hosts():


### PR DESCRIPTION
This is attempting to deal with the fact that image tests now live in
a separate repository. The existing method where we copy over the
tests from that repository is very fragile, and doesn't allow
specifying alternate branches, which will be important as newer
versions of mender-image-tests drift out of sync with older branches
of meta-mender. We will then need to branch mender-image-tests and
switch the submodule over to that.

One slight complication with our use of this submodule is that we want
to track branches, not explicit commits. We solve this by having an
automatic pull before testing starts, which can be disabled if you're
debugging something locally, or in the Jenkins case where we will
check out the exact commit that was specified in the build.

The "repo" tool was considered as an alternative to submodules, but I
didn't see enough benefit, given that repo is very workflow oriented,
and this submodule is not really meant to be used by users very much
(hence the "ignore" attribute in the .gitmodules file). This also has
the benefit of not requiring another tool.

Changelog: None
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

Goes together with https://github.com/mendersoftware/mender-qa/pull/217.