### PR TITLE
mender: Adapt LIC_FILES_CHKSUM definitions to older golang support.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.3.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.3.0.bb
@@ -20,4 +20,4 @@ SRCREV = "e05327b84000068c6528d6f87f8c03783456433d"
 ################################################################################
 
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=8ce3d9108b58e4a185a5f812536f03a5"
+LIC_FILES_CHKSUM = "file://LIC_FILES_CHKSUM.sha256;md5=8ce3d9108b58e4a185a5f812536f03a5"

--- a/meta-mender-core/recipes-mender/mender/mender_1.5.1.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_1.5.1.bb
@@ -21,5 +21,5 @@ SRCREV = "294d30166b47bb3361cc2cea7550bc14f582cfa3"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=debbe5e440f2e65465e86b25fc7c9fcc"
+LIC_FILES_CHKSUM = "file://LIC_FILES_CHKSUM.sha256;md5=debbe5e440f2e65465e86b25fc7c9fcc"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & MIT & OLDAP-2.8"

--- a/meta-mender-core/recipes-mender/mender/mender_1.6.0.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_1.6.0.bb
@@ -21,5 +21,5 @@ SRCREV = "329eba697b086386f191e11836fc709e821fdb2a"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=debbe5e440f2e65465e86b25fc7c9fcc"
+LIC_FILES_CHKSUM = "file://LIC_FILES_CHKSUM.sha256;md5=debbe5e440f2e65465e86b25fc7c9fcc"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & MIT & OLDAP-2.8"

--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -318,7 +318,7 @@ def prepared_test_build(prepared_test_build_base):
 
 @pytest.fixture(autouse=True)
 def min_mender_version(request, bitbake_variables):
-    version_mark = request.node.get_marker("min_mender_version")
+    version_mark = request.node.get_closest_marker("min_mender_version")
     if version_mark is None:
         pytest.fail(('%s must be marked with @pytest.mark.min_mender_version("<VERSION>") to '
                      + 'indicate lowest Mender version for which the test will work.')
@@ -345,7 +345,7 @@ def only_for_machine(request, bitbake_variables):
            pass
 
     """
-    mach_mark = request.node.get_marker('only_for_machine')
+    mach_mark = request.node.get_closest_marker('only_for_machine')
     if mach_mark is not None:
         machines = mach_mark.args
         current = bitbake_variables.get('MACHINE', None)
@@ -366,7 +366,7 @@ def only_with_image(request, bitbake_variables):
            pass
 
     """
-    mark = request.node.get_marker('only_with_image')
+    mark = request.node.get_closest_marker('only_with_image')
     if mark is not None:
         images = mark.args
         current = bitbake_variables.get('IMAGE_FSTYPES', '').strip().split(' ')


### PR DESCRIPTION
This is necessary for pyro and earlier.

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>