### PR TITLE
Add raspberrypi-demo layer to build.

### DIFF
--- a/tests/build-conf/raspberrypi3/bblayers.conf
+++ b/tests/build-conf/raspberrypi3/bblayers.conf
@@ -12,6 +12,7 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-mender/meta-mender-raspberrypi \
+  @WORKSPACE@/meta-mender/meta-mender-raspberrypi-demo \
   @WORKSPACE@/meta-raspberrypi \
   @WORKSPACE@/meta-openembedded/meta-oe \
   @WORKSPACE@/meta-openembedded/meta-multimedia \


### PR DESCRIPTION
Changelog: Fix missing wpa_supplicant in Raspberry Pi demo images.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>