### PR TITLE
rpi: update U-boot patch to get rid of warning

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
@@ -1,7 +1,7 @@
-From 45a660923a72af8b8448e519f694e54850cd6864 Mon Sep 17 00:00:00 2001
+From de66a004964d8770abe2f36b98be9c0c6cd969f6 Mon Sep 17 00:00:00 2001
 From: Mirza Krak <mirza.krak@gmail.com>
 Date: Tue, 26 Sep 2017 06:23:52 -0400
-Subject: [PATCH] configs: rpi: enable mender requirements
+Subject: [PATCH 1/1] configs: rpi: enable mender requirements
 
 Which are CONFIG_BOOTCOUNT_ENV and CONFIG_BOOTCOUNT_LIMIT.
 
@@ -16,67 +16,68 @@ Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
  configs/rpi_3_32b_defconfig | 1 +
  configs/rpi_3_defconfig     | 1 +
  configs/rpi_defconfig       | 1 +
- include/configs/rpi.h       | 2 ++
- 6 files changed, 7 insertions(+)
+ include/configs/rpi.h       | 3 +++
+ 6 files changed, 8 insertions(+)
 
 diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
-index fcc2ae6..5a7fe6e 100644
+index 9a6d24be22..33e0c86e2a 100644
 --- a/configs/rpi_0_w_defconfig
 +++ b/configs/rpi_0_w_defconfig
-@@ -36,3 +36,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -25,3 +25,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_ENV_IS_IN_MMC=y
 diff --git a/configs/rpi_2_defconfig b/configs/rpi_2_defconfig
-index 204af74..39f2887 100644
+index c45ffb65af..eccb7eabec 100644
 --- a/configs/rpi_2_defconfig
 +++ b/configs/rpi_2_defconfig
-@@ -36,3 +36,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -32,3 +32,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_ENV_IS_IN_MMC=y
 diff --git a/configs/rpi_3_32b_defconfig b/configs/rpi_3_32b_defconfig
-index 9e142ca..f31385f 100644
+index f7aed35797..00280dc890 100644
 --- a/configs/rpi_3_32b_defconfig
 +++ b/configs/rpi_3_32b_defconfig
-@@ -39,3 +39,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -34,3 +34,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_ENV_IS_IN_MMC=y
 diff --git a/configs/rpi_3_defconfig b/configs/rpi_3_defconfig
-index f46e504..5465b10 100644
+index 9416e3b8fe..a74fdf2271 100644
 --- a/configs/rpi_3_defconfig
 +++ b/configs/rpi_3_defconfig
-@@ -39,3 +39,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -34,3 +34,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_ENV_IS_IN_MMC=y
 diff --git a/configs/rpi_defconfig b/configs/rpi_defconfig
-index 82c90d4..3e46eac 100644
+index 3bfa745c2e..3cc1b954a8 100644
 --- a/configs/rpi_defconfig
 +++ b/configs/rpi_defconfig
-@@ -36,3 +36,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -32,3 +32,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_ENV_IS_IN_MMC=y
 diff --git a/include/configs/rpi.h b/include/configs/rpi.h
-index 69a22e1..86e5ae5 100644
+index cab8661779..a3df1a3c43 100644
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
-@@ -76,6 +76,8 @@
- #define CONFIG_ENV_SIZE			SZ_16K
+@@ -91,6 +91,9 @@
  #define CONFIG_SYS_LOAD_ADDR		0x1000000
  #define CONFIG_PREBOOT			"usb start"
+ 
 +#define CONFIG_BOOTCOUNT_ENV
 +#define CONFIG_BOOTCOUNT_LIMIT
- 
++
  /* Shell */
+ #define CONFIG_CMDLINE_EDITING
  
 -- 
-2.7.4
+2.19.1
 


### PR DESCRIPTION
Even though there does not seem to be any problems applying the
current patch it does produce a warning:

WARNING: u-boot-1_2018.01-r0 do_patch:
Some of the context lines in patches were ignored. This can lead to
incorrectly applied patches.
The context lines in the patches can be updated with devtool:

    devtool modify <recipe>
    devtool finish --force-patch-refresh <recipe> <layer_path>

Then the updated patches and the source tree (in devtool's workspace)
should be reviewed to make sure the patches apply in the correct place
and don't introduce duplicate lines (which can, and does happen
when some of the context is ignored). Further information:
http://lists.openembedded.org/pipermail/openembedded-core/2018-March/148675.html
https://bugzilla.yoctoproject.org/show_bug.cgi?id=10450
Details:
Applying patch 0001-CONFIGS-rpi-enable-mender-requirements.patch

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>