### PR TITLE
Remove error message during GRUB booting.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/files/cfg
+++ b/meta-mender-core/recipes-bsp/grub/files/cfg
@@ -1,0 +1,1 @@
+set prefix=($root)/EFI/BOOT

--- a/meta-mender-core/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,1 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append_cfg_file += " file://cfg"
+
 include grub-mender.inc


### PR DESCRIPTION
When GRUB is launched it tries to search configuration files in directory ((hd0,gpt1)/EFI/BOOT)/EFI/BOOT/grub.cfg . This directory does not exist. Search command was was setup  redundantly by yocto grub layer. Searching cfg file is not needed, because prefix path already points to the path where the proper grub.cfg exists. Replacing improper yocto cfg file by the correct one causes that there is no strange error message during booting.

Signed-off-by: Dominik Adamski <adamski.dominik@gmail.com>