### PR TITLE
Several fixes for thud and later

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -148,7 +148,7 @@ EOF
     if [ "${MENDER_BOOT_PART_SIZE_MB}" -ne "0" ]; then
         mender_merge_bootfs_and_image_boot_files
         cat >> "$wks" <<EOF
-part --source rootfs --rootfs-dir ${WORKDIR}/bootfs.${BB_CURRENTTASK} --ondisk "$ondisk_dev" --fstype=vfat --label boot --align $alignment_kb --fixed-size ${MENDER_BOOT_PART_SIZE_MB}
+part --source rootfs --rootfs-dir ${WORKDIR}/bootfs.${BB_CURRENTTASK} --ondisk "$ondisk_dev" --fstype=vfat --label boot --align $alignment_kb --fixed-size ${MENDER_BOOT_PART_SIZE_MB} --active
 EOF
     elif [ -n "${IMAGE_BOOT_FILES}" ]; then
         bbwarn "MENDER_BOOT_PART_SIZE_MB is set to zero, but IMAGE_BOOT_FILES is not empty. The files are being omitted from the image."

--- a/meta-mender-core/recipes-devtools/e2fsprogs/e2fsprogs_1.44.%.bbappend
+++ b/meta-mender-core/recipes-devtools/e2fsprogs/e2fsprogs_1.44.%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+SRC_URI_append = " file://0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch"

--- a/meta-mender-core/recipes-devtools/e2fsprogs/patches/0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch
+++ b/meta-mender-core/recipes-devtools/e2fsprogs/patches/0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch
@@ -1,0 +1,28 @@
+From 24bc347ed1303d649347c1dc2f813ab0c29f9f99 Mon Sep 17 00:00:00 2001
+From: Kristian Amlie <kristian.amlie@northern.tech>
+Date: Fri, 30 Nov 2018 09:06:17 +0000
+Subject: [PATCH 1/1] Do not use metadata_csum feature on ext4 by default.
+
+Even very recent versions of e2fsprogs (1.44.3) don't support it.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
+---
+ misc/mke2fs.conf.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/misc/mke2fs.conf.in b/misc/mke2fs.conf.in
+index 25105b3..df643ed 100644
+--- a/misc/mke2fs.conf.in
++++ b/misc/mke2fs.conf.in
+@@ -11,7 +11,7 @@
+ 		features = has_journal
+ 	}
+ 	ext4 = {
+-		features = has_journal,extent,huge_file,flex_bg,metadata_csum,dir_nlink,extra_isize
++		features = has_journal,extent,huge_file,flex_bg,dir_nlink,extra_isize
+ 		inode_size = 256
+ 		auto_64-bit_support = 1
+ 	}
+-- 
+2.7.4
+


### PR DESCRIPTION
```
commit c45085187ec79dc2a2dcbb2a2566fe509f0194f0
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Nov 30 10:20:18 2018

    Fix images not being modifiable by mender-artifact in thud and later.
    
    Changelog: Title
    
    The problem is that the "metadata_csum" feature is very recent, and in
    fact even the version shipped in poky (1.44.3) doesn't support it
    (both fsck.ext4 and tune2fs refuse to handle it). Why they turned it
    on in the first place is a mystery to me. In any case it should be
    safe to turn off for our images, so that debugfs (and hence
    mender-artifact) is able to handle the image.
    
    If anyone requires this feature, it can be flipped on again on the
    built image by a recent version of e2fsprogs/tune2fs.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 84805fae0be5272a04b5b334399384dcb7232154
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 29 11:08:01 2018

    Fix regression that removed boot flag from boot partition.
    
    This was unintentionally removed in 0b737428d0570de.
    
    Changelog: Title
    
    Changelog: Fix regression that caused Beaglebone to not boot.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```