### PR TITLE
[sumo] Add Mender 1.7.0 release recipes.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.3.1.bb
@@ -8,14 +8,14 @@ require mender-artifact.inc
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
-SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=2.4.x"
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=2.3.x"
 
-# Tag: 2.4.0b1
-SRCREV = "1bedfca0cd74246b5c4bc8f3015c48dc34bbf1dc"
+# Tag: 2.3.1
+SRCREV = "03d2e84786c16225fdf5813630a23cc2f76ace39"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.4.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.4.0.bb
@@ -1,0 +1,23 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=2.4.x"
+
+# Tag: 2.4.0
+SRCREV = "325087948144ccc26907d8ebb24feab9f1f82a0d"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=8ce3d9108b58e4a185a5f812536f03a5"

--- a/meta-mender-core/recipes-mender/mender/mender_1.6.1.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_1.6.1.bb
@@ -1,0 +1,25 @@
+require mender.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=1.6.x"
+
+# Tag: 1.6.1
+SRCREV = "31caee72ba26b266ba0a0f344796b6acd11d3a6e"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=debbe5e440f2e65465e86b25fc7c9fcc"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & MIT & OLDAP-2.8"

--- a/meta-mender-core/recipes-mender/mender/mender_1.7.0.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_1.7.0.bb
@@ -10,12 +10,12 @@ require mender.inc
 
 SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=1.7.x"
 
-# Tag: 1.7.0b1
-SRCREV = "f63441b72e9d07db1114fa63f298563d2e812902"
+# Tag: 1.7.0
+SRCREV = "e3eda1307476eb8992d45b0b1cc7d926a7cce1b2"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 


### PR DESCRIPTION
Changelog: Add mender 1.6.1 and 1.7.0 recipes.
Changelog: Add mender-artifact 2.3.1 and 2.4.0 recipes.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 95ef48ee322a0db9187ea4d6c25f3c85d5e4db16)