### PR TITLE
MEN-2290: Fix data directory not being empty on rootfs.

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -82,6 +82,13 @@ mender_merge_bootfs_and_image_boot_files() {
     done
 }
 
+def mender_wic_exclude_path_options(exclude_path):
+    exclude_path = exclude_path.strip()
+    if exclude_path:
+        return "--exclude-path %s" % exclude_path
+    else:
+        return ""
+
 mender_part_image() {
     suffix="$1"
     part_type="$2"
@@ -154,11 +161,11 @@ EOF
         bbwarn "MENDER_BOOT_PART_SIZE_MB is set to zero, but IMAGE_BOOT_FILES is not empty. The files are being omitted from the image."
     fi
 
-    exclude_dirs_options="${@" ".join(["--exclude-path %s" % dir for dir in (d.getVar("IMAGE_ROOTFS_EXCLUDE_PATH") or "").split()])}"
+    exclude_path_options="${@mender_wic_exclude_path_options('${IMAGE_ROOTFS_EXCLUDE_PATH}')}"
 
     cat >> "$wks" <<EOF
-part --source rootfs --ondisk "$ondisk_dev" --fstype=${ARTIFACTIMG_FSTYPE} --label primary --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $exclude_dirs_options
-part --source rootfs --ondisk "$ondisk_dev" --fstype=${ARTIFACTIMG_FSTYPE} --label secondary --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $exclude_dirs_options
+part --source rootfs --ondisk "$ondisk_dev" --fstype=${ARTIFACTIMG_FSTYPE} --label primary --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $exclude_path_options
+part --source rootfs --ondisk "$ondisk_dev" --fstype=${ARTIFACTIMG_FSTYPE} --label secondary --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $exclude_path_options
 part --source rootfs --rootfs-dir ${IMAGE_ROOTFS}/data --ondisk "$ondisk_dev" --fstype=${ARTIFACTIMG_FSTYPE} --label data --align $alignment_kb --fixed-size ${MENDER_DATA_PART_SIZE_MB}
 bootloader --ptable $part_type
 EOF


### PR DESCRIPTION
Turns out that argparse works a bit strangely, and wants all arguments
after one flag, instead of one argument per flag. For example:

  --exclude-path data/ boot/efi/

instead of:

  --exclude-path data/ --exclude-path boot/efi/

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>