### PR TITLE
add 'rootwait' to bootargs

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/files/06_bootargs_grub.cfg
+++ b/meta-mender-core/recipes-bsp/grub/files/06_bootargs_grub.cfg
@@ -1,1 +1,1 @@
-set bootargs="${bootargs} console=tty0 console=ttyS0 console=ttyO0 console=ttyAMA0"
+set bootargs="${bootargs} console=tty0 console=ttyS0 console=ttyO0 console=ttyAMA0 rootwait"


### PR DESCRIPTION
Description of 'rootwait' in kernel docs,

    "Wait (indefinitely) for root device to show up.
     Useful for devices that are detected asynchronously
     (e.g. USB and MMC devices)."

The large majority of devices that we integrate use eMMC for storage
medium, and it is quite common to use a USB "live disk" for provisioning.

Without the 'rootwait' argument, mount of rootfs failes occasionally,
it is simple a race condition at boot and you are only lucky if it works
without it.

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>