### PR TITLE
grub: ensure "test" module is builtin

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/grub-mender.inc
+++ b/meta-mender-core/recipes-bsp/grub/grub-mender.inc
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 
 # Mender needs these.
-GRUB_BUILDIN_append_mender-grub = " cat echo gcry_sha256 halt hashsum loadenv sleep reboot"
+GRUB_BUILDIN_append_mender-grub = " cat echo gcry_sha256 halt hashsum loadenv sleep reboot test"
 
 GRUBPLATFORM_arm_mender-grub = "efi"
 


### PR DESCRIPTION
Mender generates a grub.cfg that utilizes `[` which is an alias for `test` and
we should probably make sure that it is builtin when grub-mender.inc is used.

This has probably gone unnoticed because the upstream recipe includes this by
default. 

I experienced problems when working with a downstream grub-efi recipe,
which did not include the `test` module in GRUB_BUILDIN. 

Changelog: Title

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>