### PR TITLE
mender-artifact (3.0.0b1): add missing build dep on "xz"

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.0.0b1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.0.0b1.bb
@@ -21,3 +21,5 @@ DEFAULT_PREFERENCE = "-1"
 
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=3c56d1f34c03d02dc3001a58712e0b7c"
+
+DEPENDS += "xz"


### PR DESCRIPTION
There is one lite quirk here that I have not handled.

The run-time dependency "liblzma" is not available as a native package, not sure how to handle this. 