### PR TITLE
Fix error message `Incorrect Usage: flag provided but not defined: -f`

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -49,7 +49,11 @@ IMAGE_CMD_mender () {
         extra_args="$extra_args -s ${DEPLOY_DIR_IMAGE}/mender-state-scripts"
     fi
 
-    image_flag=${@mender_version_is_minimum(d, "mender-artifact", "3.0.0", "-f", "-u")}
+    if mender-artifact write rootfs-image --help | grep -e '-u FILE'; then
+        image_flag=-u
+    else
+        image_flag=-f
+    fi
 
     mender-artifact write rootfs-image \
         -n ${MENDER_ARTIFACT_NAME} \

--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -245,23 +245,3 @@ def mender_get_data_part_num(d):
     if n <= 4: return n
     if mender_is_msdos_ptable_image(d): n += 1
     return n
-
-def mender_version_is_minimum(d, component, min_version, if_true, if_false):
-    from distutils.version import LooseVersion
-
-    version = d.getVar('PREFERRED_VERSION_pn-%s' % component)
-    if not version:
-        version = d.getVar('PREFERRED_VERSION_%s' % component)
-    if not version:
-        version = "master"
-
-    try:
-        if LooseVersion(min_version) > LooseVersion(version):
-            return if_false
-        else:
-            return if_true
-    except TypeError:
-        # Type error indicates that 'version' is likely a string (branch
-        # name). For now we just default to always consider them higher than the
-        # minimum version.
-        return if_true


### PR DESCRIPTION
Change the detection of mender-artifact file flag from version based
to checking the help screen, which is easier.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>