### PR TITLE
Fix error message `Incorrect Usage: flag provided but not defined: -f`

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -46,7 +46,11 @@ IMAGE_CMD_mender () {
         extra_args="$extra_args -s ${DEPLOY_DIR_IMAGE}/mender-state-scripts"
     fi
 
-    image_flag=${@mender_version_is_minimum(d, "mender-artifact", "3.0.0", "-f", "-u")}
+    if mender-artifact write rootfs-image --help | grep -e '-u FILE'; then
+        image_flag=-u
+    else
+        image_flag=-f
+    fi
 
     mender-artifact write rootfs-image \
         -n ${MENDER_ARTIFACT_NAME} \

--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -227,24 +227,3 @@ mender_get_clean_kernel_devicetree() {
     # Return.
     echo "$MENDER_DTB_NAME"
 }
-
-
-def mender_version_is_minimum(d, component, min_version, if_true, if_false):
-    from distutils.version import LooseVersion
-
-    version = d.getVar('PREFERRED_VERSION_pn-%s' % component)
-    if not version:
-        version = d.getVar('PREFERRED_VERSION_%s' % component)
-    if not version:
-        version = "master"
-
-    try:
-        if LooseVersion(min_version) > LooseVersion(version):
-            return if_false
-        else:
-            return if_true
-    except TypeError:
-        # Type error indicates that 'version' is likely a string (branch
-        # name). For now we just default to always consider them higher than the
-        # minimum version.
-        return if_true


### PR DESCRIPTION
Change the detection of mender-artifact file flag from version based
to checking the help screen, which is easier.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit f2160efbd4f3408f356623b80fd643b75ef7dcb5)