### PR TITLE
Update mender and mender-artifact recipes after branch renames

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.0.0b1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.0.0b1.bb
@@ -8,7 +8,7 @@ require mender-artifact.inc
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
-SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=mender-artifact-v3"
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.0.x"
 
 # Tag: 3.0.0b1
 SRCREV = "218d5926d13f2f1e4906af05daafea3589d69383"

--- a/meta-mender-core/recipes-mender/mender/mender_2.0.0b1.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_2.0.0b1.bb
@@ -8,7 +8,7 @@ require mender.inc
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
-SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=update_modules"
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.0.x"
 
 # Tag: 2.0.0b1
 SRCREV = "040a234aba2abb1b8d9351674892a1b0c7202fea"


### PR DESCRIPTION
They should use 2.0.x and 3.0.x respectively

Changelog: Fix mender 2.0.x and mender-artifact 3.0.x recipes to use the
correct branches when fetching the source.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit 6728fa4d310652ae1619b19d018f666d86cb01b7)