### PR TITLE
mender-artifact(3.0.0b1):Add "xz" build dependency

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.0.0b1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.0.0b1.bb
@@ -21,3 +21,5 @@ DEFAULT_PREFERENCE = "-1"
 
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=3c56d1f34c03d02dc3001a58712e0b7c"
+
+DEPENDS += "xz"


### PR DESCRIPTION
Changelog: Add missing build dependency on "xz" in Mender Artifact recipe for 3.0.0b1 version

This dependency should be added to resolve the below error:
| # github.com/mendersoftware/mender-artifact/vendor/github.com/mendersoftware/go-liblzma
| ../../../../../../../build/src/github.com/mendersoftware/mender-artifact/vendor/github.com/mendersoftware/go-liblzma/reader.go:9:18: fatal error: lzma.h: No such file or directory
| compilation terminated.

Signed-off-by: Ajith P Venugopal <ajithpv@outlook.com>
(cherry picked from commit e9585a446f8690729f66e0fce675a033b457ca05)