### PR TITLE
test_uboot_compile: Make sure all cores are used.

### DIFF
--- a/tests/acceptance/files/Makefile.test_uboot_automation
+++ b/tests/acceptance/files/Makefile.test_uboot_automation
@@ -37,12 +37,12 @@ $(LOGS)/%_defconfig:
 		|| ( echo AutoPatchFailed >> $@ )
 
 	# Setup compile.
-	$(MAKE) -C "$(TMP)/`basename $@`/orig" "`basename $@`" \
+	$(MAKE) $(SUBJOBCOUNT) -C "$(TMP)/`basename $@`/orig" "`basename $@`" \
 			>> $@ 2>&1 \
 		|| ( echo AutoPatchFailed >> $@ )
 
 	# Try to compile it.
-	$(MAKE) -C "$(TMP)/`basename $@`/orig" \
+	$(MAKE) $(SUBJOBCOUNT) -C "$(TMP)/`basename $@`/orig" \
 			>> $@ 2>&1 \
 		|| ( echo AutoPatchFailed >> $@ )
 

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -79,7 +79,9 @@ class TestUbootAutomation:
 
         # SHA from meta-mender repository, limited by date.
         meta_mender_uboot_rev = subprocess.check_output(("git log -n1 --format=%%H --after=%d.days.ago HEAD -- "
-                                                         + "recipes-bsp/u-boot tests/acceptance/test_uboot_automation.py")
+                                                         + ("recipes-bsp/u-boot"
+                                                            + " tests/acceptance/test_uboot_automation.py"
+                                                            + " tests/acceptance/files/Makefile.test_uboot_automation"))
                                                         % days_to_be_old,
                                                         cwd=meta_mender_core_dir,
                                                         shell=True).strip()
@@ -89,7 +91,9 @@ class TestUbootAutomation:
 
         # SHA from meta-mender repository, not limited by date.
         meta_mender_uboot_rev = subprocess.check_output("git log -n1 --format=%H HEAD -- "
-                                                        + "recipes-bsp/u-boot tests/acceptance/test_uboot_automation.py",
+                                                        + ("recipes-bsp/u-boot"
+                                                           + " tests/acceptance/test_uboot_automation.py"
+                                                           + " tests/acceptance/files/Makefile.test_uboot_automation"),
                                                         cwd=meta_mender_core_dir,
                                                         shell=True).strip()
         for remote in subprocess.check_output(["git", "remote"]).split():


### PR DESCRIPTION
```
commit 47d604773c1867ed8f144976597909602de33650
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu May 2 13:58:07 2019

    test_uboot_compile: Make sure all cores are used.
    
    Right now we may limit by memory since each build directory is very
    memory consuming (RAM drive). But that may leave cores unused, so make
    sure the sub-make invocations try to use those cores.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 6b97f98ded0f3e59b691d6f700aeb6fdb63f0142
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu May 2 13:56:38 2019

    test_uboot_compile: Make sure the Makefile is counted in time calc.
    
    Otherwise the test might not run even if the file has changed.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```