### PR TITLE
Break mender_git recipe into pre- and post-2.0 recipes.

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -46,8 +46,15 @@ mender_update_fstab_file() {
     printf "%-20s %-20s %-10s %-21s %-2s %s\n" ${tmpDataPart} /data ${MENDER_DATA_PART_FSTYPE} ${MENDER_DATA_PART_FSTAB_OPTS} 0 0 >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
 }
 
+def mender_default_state_scripts_version(d):
+    pref_mender = d.getVar('PREFERRED_VERSION_pn-mender')
+    if pref_mender and pref_mender.startswith("1."):
+        return "2"
+    else:
+        return "3"
+
 # Setup state script version file.
-MENDER_STATE_SCRIPTS_VERSION = "3"
+MENDER_STATE_SCRIPTS_VERSION = "${@mender_default_state_scripts_version(d)}"
 ROOTFS_POSTPROCESS_COMMAND_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image', ' mender_create_scripts_version_file;', '', d)}"
 
 mender_create_scripts_version_file() {

--- a/meta-mender-core/recipes-mender/mender/mender_git.inc
+++ b/meta-mender-core/recipes-mender/mender/mender_git.inc
@@ -1,0 +1,76 @@
+require mender.inc
+
+DEPENDS = "xz"
+RDEPENDS_${PN} = "liblzma"
+
+# The revision listed below is not really important, it's just a way to avoid
+# network probing during parsing if we are not gonna build the git version
+# anyway. If git version is enabled, the AUTOREV will be chosen instead of the
+# SHA.
+def mender_autorev_if_git_version(d):
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is not None and "git" in version:
+        return d.getVar("AUTOREV")
+    else:
+        return "f6ffa190892202263fdb75975059fbb201adab6a"
+SRCREV ?= '${@mender_autorev_if_git_version(d)}'
+
+def mender_branch_from_preferred_version(d):
+    import re
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is None:
+        version = ""
+    match = re.match(r"^[0-9]+\.[0-9]+\.", version)
+    if match is not None:
+        # If the preferred version is some kind of version, use the branch name
+        # for that one (1.0.x style).
+        return match.group(0) + "x"
+    else:
+        # Else return master as branch.
+        return "master"
+MENDER_BRANCH = "${@mender_branch_from_preferred_version(d)}"
+
+def mender_version_from_preferred_version(d, srcpv):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is not None and pref_version.find("-git") >= 0:
+        # If "-git" is in the version, remove it along with any suffix it has,
+        # and then readd it with commit SHA.
+        return "%s-git%s" % (pref_version[0:pref_version.index("-git")], srcpv)
+    elif pref_version is not None and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, use the version as is. This means that
+        # we can build tags with "-build" in them from this recipe, but not
+        # final tags, which will need their own recipe.
+        return pref_version
+    else:
+        # Else return the default "master-git".
+        return "master-git%s" % srcpv
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=${MENDER_BRANCH}"
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+def mender_license(branch):
+    if branch == "1.7.x":
+        return {
+                   "md5": "5632b9f17043c6f5f532501778595c78",
+                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+        }
+    elif branch.startswith("1."):
+        return {
+                   "md5": "debbe5e440f2e65465e86b25fc7c9fcc",
+                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+        }
+    else:
+        return {
+                   "md5": "ccb00e21c31df7189b2bd237ed86e7c2",
+                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+        }
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"
+LICENSE = "${@mender_license(d.getVar('MENDER_BRANCH'))['license']}"
+
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-core/recipes-mender/mender/mender_git1.x.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_git1.x.bb
@@ -1,10 +1,11 @@
 require mender_git.inc
+require mender-old-makefile.inc
 
 def mender_version_of_this_recipe(d, srcpv):
     version = mender_version_from_preferred_version(d, srcpv)
     if version.startswith("1."):
-        # Pre-2.0. We don't want to match this.
-        return "non-matching-version-" + version
-    else:
         return version
+    else:
+        # Post-2.0. We don't want to match this.
+        return "non-matching-version-" + version
 PV = "${@mender_version_of_this_recipe(d, '${SRCPV}')}"


### PR DESCRIPTION
This is required in order build 1.x recipes using the git recipe,
since it uses the old makefile style and many other conditionals as
well, such as module inclusion.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>