### PR TITLE
Fix build failing in do_image_ubimg task

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
@@ -52,4 +52,4 @@ do_deploy_append_mender-uboot() {
     dd if=/dev/zero of=${WORKDIR}/uboot.env bs=${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} count=1
     install -m 644 ${WORKDIR}/uboot.env ${DEPLOYDIR}/uboot.env
 }
-addtask deploy after do_compile
+addtask deploy after do_compile before do_package


### PR DESCRIPTION
Fix/workaround for a build problem. The problem can be reproduced by inserting a long sleep at the start of meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc do_deploy_append_mender-uboot().
