### PR TITLE
rename boot.efi to bootia32.efi in mender-setup-grub.inc

### DIFF
--- a/meta-mender-core/classes/mender-setup-grub.inc
+++ b/meta-mender-core/classes/mender-setup-grub.inc
@@ -7,7 +7,7 @@ MENDER_GRUB_STORAGE_DEVICE ??= "${MENDER_GRUB_STORAGE_DEVICE_DEFAULT}"
 MENDER_GRUB_STORAGE_DEVICE_DEFAULT = ""
 
 IMAGE_BOOT_FILES_append_mender-grub = " \
-    ${@bb.utils.contains('TRANSLATED_TARGET_ARCH', 'x86-64', 'grub-efi-bootx64.efi;EFI/BOOT/bootx64.efi', 'grub-efi-bootia32.efi;EFI/BOOT/boot.efi', d)} \
+    ${@bb.utils.contains('TRANSLATED_TARGET_ARCH', 'x86-64', 'grub-efi-bootx64.efi;EFI/BOOT/bootx64.efi', 'grub-efi-bootia32.efi;EFI/BOOT/bootia32.efi', d)} \
     grub.cfg;EFI/BOOT/grub.cfg \
     mender_grubenv1/env;EFI/BOOT/mender_grubenv1/env \
     mender_grubenv1/lock;EFI/BOOT/mender_grubenv1/lock \


### PR DESCRIPTION
The correct name is "bootia32.efi" on x86, otherwise it will fail
to boot.

This is an backport of:

5fbb3074913a9 ("FIX: Renamed boot.efi to bootia32.efi in mender-setup-grub.inc")

Changelog: Fix GRUB start-up on x86 by renaming "boot.efi" to "bootia32.efi"

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>