### PR TITLE
MEN-2421: Make sure that external Busybox runs on Yocto demo images.

### DIFF
--- a/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -6,3 +6,8 @@ RDEPENDS_${PN}_append_vexpress-qemu = " mender-reboot-detector"
 RDEPENDS_${PN}_append_vexpress-qemu-flash = " mender-reboot-detector"
 RDEPENDS_${PN}_append_qemux86-64 = " mender-reboot-detector"
 RDEPENDS_${PN}_append_qemux86 = " mender-reboot-detector"
+
+# In our demo package we use busybox, which is built in a generic, non-Yocto
+# way. Therefore we need LSB support so that the dynamic linker is found.
+# Specifically, this creates the symlink /lib64 -> /lib.
+RDEPENDS_${PN}_append = " lsb"


### PR DESCRIPTION
x86-64 seems to have a problem because Yocto does not include a
`/lib64` folder by default, and this is where most externally built
binaries are built to load the dynamic linker from. Include the LSB
package to make the image LSB compliant and include the `/lib64`
symlink to `/lib`.

Changelog: Demo images now include Yocto LSB package.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>