### PR TITLE
mender: Add support for a bootimg FSTYPE.

### DIFF
--- a/meta-mender-core/classes/mender-bootimg.bbclass
+++ b/meta-mender-core/classes/mender-bootimg.bbclass
@@ -1,0 +1,25 @@
+# Class to create the "bootimg" type, which contains the boot partition as a raw
+# filesystem.
+
+inherit mender-helpers
+
+IMAGE_CMD_bootimg() {
+    if [ ${MENDER_BOOT_PART_SIZE_MB} -ne 0 ]; then
+        mender_merge_bootfs_and_image_boot_files
+        rm -f "${WORKDIR}/boot.vfat"
+        dd if=/dev/zero of="${WORKDIR}/boot.vfat" count=0 bs=1M seek=${MENDER_BOOT_PART_SIZE_MB}
+        mkfs.vfat -n "BOOT" "${WORKDIR}/boot.vfat"
+        for i in $(find ${WORKDIR}/bootfs.${BB_CURRENTTASK}/ -mindepth 1 -maxdepth 1); do
+           mcopy -i "${WORKDIR}/boot.vfat" -s "$i" ::/
+        done
+        install -m 0644 "${WORKDIR}/boot.vfat" "${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg"
+    fi
+}
+
+# We need the boot contents intact.
+do_image_bootimg[respect_exclude_path] = "0"
+
+do_image_bootimg[depends] += " \
+    dosfstools-native:do_populate_sysroot \
+    mtools-native:do_populate_sysroot \
+"

--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -245,3 +245,44 @@ def mender_get_data_part_num(d):
     if n <= 4: return n
     if mender_is_msdos_ptable_image(d): n += 1
     return n
+
+# Take the content from the rootfs that is going into the boot partition, coming
+# from MENDER_BOOT_PART_MOUNT_LOCATION, and merge with the files from
+# IMAGE_BOOT_FILES, following the format from the official Yocto documentation.
+mender_merge_bootfs_and_image_boot_files() {
+    W="${WORKDIR}/bootfs.${BB_CURRENTTASK}"
+    rm -rf "$W"
+
+    cp -al "${IMAGE_ROOTFS}/${MENDER_BOOT_PART_MOUNT_LOCATION}" "$W"
+
+    # Put in variable to avoid expansion and ';' being parsed by shell.
+    image_boot_files="${IMAGE_BOOT_FILES}"
+    for entry in $image_boot_files; do
+        if echo "$entry" | grep -q ";"; then
+            dest="$(echo "$entry" | sed -e 's/[^;]*;//')"
+            entry="$(echo "$entry" | sed -e 's/;.*//')"
+        else
+            dest="./"
+        fi
+        if echo "$dest" | grep -q '/$'; then
+            dest_is_dir=1
+            mkdir -p "$W/$dest"
+        else
+            dest_is_dir=0
+            mkdir -p "$(dirname "$W/$dest")"
+        fi
+
+        # Use extra for loop so we can check conflict for each file.
+        for file in ${DEPLOY_DIR_IMAGE}/$entry; do
+            if [ $dest_is_dir -eq 1 ]; then
+                destfile="$W/$dest$(basename $file)"
+            else
+                destfile="$W/$dest"
+            fi
+            if [ -e "$destfile" ]; then
+                bbfatal "$destfile already exists in boot partition. Please verify that packages do not put files in the boot partition that conflict with IMAGE_BOOT_FILES."
+            fi
+            cp -l "$file" "$destfile"
+        done
+    done
+}

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -199,7 +199,7 @@ MENDER_PERSISTENT_CONFIGURATION_VARS ?= "RootfsPartA RootfsPartB"
 # --------------------------- END OF CONFIGURATION -----------------------------
 
 IMAGE_INSTALL_append = " mender"
-IMAGE_CLASSES += "mender-part-images mender-ubimg mender-artifactimg mender-dataimg"
+IMAGE_CLASSES += "mender-part-images mender-ubimg mender-artifactimg mender-dataimg mender-bootimg"
 
 # Originally defined in bitbake.conf. We define them here so that images with
 # the same MACHINE name, but different MENDER_DEVICE_TYPE, will not result in

--- a/tests/acceptance/test_bootimg.py
+++ b/tests/acceptance/test_bootimg.py
@@ -30,4 +30,7 @@ class TestBootImg:
 
         built_img = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.bootimg")
 
-        # What can we check here to validate this?
+        distro_features = bitbake_variables['DISTRO_FEATURES'].split()
+        if "mender-grub" in distro_features and "mender-image-uefi" in distro_features:
+            output = subprocess.check_output(["mdir", "-i", built_img, "-b", "/EFI/BOOT"])
+            assert "mender_grubenv1" in output.split('/')

--- a/tests/acceptance/test_bootimg.py
+++ b/tests/acceptance/test_bootimg.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python
+# Copyright 2019 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+import pytest
+import subprocess
+
+# Make sure common is imported after fabric, because we override some functions.
+from common import *
+
+class TestBootImg:
+    @pytest.mark.min_mender_version('1.0.0')
+    def test_bootimg_creation(self, bitbake_variables, prepared_test_build):
+        """Test that we can build a bootimg successfully."""
+
+        add_to_local_conf(prepared_test_build, 'IMAGE_FSTYPES = "bootimg"')
+        run_bitbake(prepared_test_build)
+
+        built_img = latest_build_artifact(prepared_test_build['build_dir'], "core-image*.bootimg")
+
+        # What can we check here to validate this?


### PR DESCRIPTION
This contains the contents of /boot for systems that need it separate.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>