### PR TITLE
grub-mender-grubenv: Fix broken 'debug-pause' `PACKAGECONFIG`.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/files/06_mender_debug_pause_grub.cfg
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/files/06_mender_debug_pause_grub.cfg
@@ -1,0 +1,5 @@
+# Stop here so output can be captured.
+function maybe_pause {
+    echo "$@" "Press ESC to skip"
+    sleep --interruptible 60
+}

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -21,7 +21,7 @@ S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 PACKAGECONFIG[debug-pause] = ",,,"
-SRC_URI_append = "${@bb.utils.contains('PACKAGECONFIG', 'debug-pause', ' file://06_mender_debug_pause_grub.cfg', '', d)}"
+SRC_URI_append = "${@bb.utils.contains('PACKAGECONFIG', 'debug-pause', ' file://06_mender_debug_pause_grub.cfg;subdir=git', '', d)}"
 PACKAGECONFIG[debug-log] = ",,,"
 
 # See https://www.gnu.org/software/grub/manual/grub/grub.html#debug


### PR DESCRIPTION
This got lost when grub-mender-grubenv was converted to its own
repository, so let's restore it.

Changelog: Title

Reported-by: Drew Moseley <drew.moseley@northern.tech>
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>