### PR TITLE
MEN-2574: QEMU: Add inventory script for Docker IP and open port 80.

### DIFF
--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -27,11 +27,16 @@ if [ -f /mnt/config/artifact-verify-key.pem ]; then
     CONFIG_ARGS="$CONFIG_ARGS --verify-key=/mnt/config/artifact-verify-key.pem"
 fi
 
+# Extract Docker IP and exclude loopback address.
+DOCKER_IP="$(ip addr | sed -ne '/^ *inet /{/127\.0\.0\.1/d;s/^ *inet  *\([^ ]*\) .*/\1/;p}')"
+
 if [ ! -e /mender-setup-complete ]; then
     ./setup-mender-configuration.py --img="$DISK_IMG" \
                                     --server-url=$SERVER_URL \
-                                    --tenant-token=$TENANT_TOKEN $CONFIG_ARGS
+                                    --tenant-token=$TENANT_TOKEN $CONFIG_ARGS \
+                                    --docker-ip="$DOCKER_IP"
     touch /mender-setup-complete
 fi
 
+export QEMU_NET_HOSTFWD=",hostfwd=tcp::80-:80"
 ./mender-qemu "$@"

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -125,7 +125,7 @@ for maybe_kvm in -enable-kvm ""; do
             -m 256M \
             $BOOTLOADER_ARG \
             -net nic,macaddr="$RANDOM_MAC" \
-            -net user,hostfwd=tcp::8822-:22 \
+            -net user,hostfwd=tcp::8822-:22$QEMU_NET_HOSTFWD \
             -display vnc=:23 \
             -nographic \
             $maybe_kvm \


### PR DESCRIPTION
We can only connect using the Docker IP, so make sure this IP is
reported to the backend. This can then be used to construct a link to
this address.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>