### PR TITLE
Add MENDER_DTB_NAME_FORCE 

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -95,12 +95,16 @@ do_provide_mender_defines() {
             ;;
     esac
 
-    # Strip leading and trailing whitespace, then newline divide, and remove dtbo's.
-    MENDER_DTB_NAME="$(echo "${KERNEL_DEVICETREE}" | sed -r 's/(^\s*)|(\s*$)//g; s/\s+/\n/g' | sed -ne '/\.dtbo$/b; p')"
+    if [ -n "${MENDER_DTB_NAME_FORCE}" ]; then
+        MENDER_DTB_NAME="${MENDER_DTB_NAME_FORCE}"
+    else
+        # Strip leading and trailing whitespace, then newline divide, and remove dtbo's.
+        MENDER_DTB_NAME="$(echo "${KERNEL_DEVICETREE}" | sed -r 's/(^\s*)|(\s*$)//g; s/\s+/\n/g' | sed -ne '/\.dtbo$/b; p')"
 
-    if [ -z "$MENDER_DTB_NAME" ]; then
-        bbfatal "Did not find a dtb specified in KERNEL_DEVICETREE"
-        exit 1
+        if [ -z "$MENDER_DTB_NAME" ]; then
+            bbfatal "Did not find a dtb specified in KERNEL_DEVICETREE"
+            exit 1
+        fi
     fi
 
     DTB_COUNT=$(echo "$MENDER_DTB_NAME" | wc -l)


### PR DESCRIPTION
This new define is to allow builds when no dtb is produced or the dtb is included inside another file, fit image for example.