### PR TITLE
Allow the machine-id to persist

### DIFF
--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -259,6 +259,9 @@ python() {
 
         # Use PARTUUID to set fixed drive locations.
         'mender-partuuid',
+
+        # Setup the systemd machine ID to be persistent across OTA updates.
+        'mender-persist-systemd-machine-id',
     }
 
     mfe = d.getVar('MENDER_FEATURES_ENABLE')

--- a/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
@@ -1,4 +1,4 @@
-From c07ad477cd5715079a3bd086293e0adf91f15b88 Mon Sep 17 00:00:00 2001
+From 8ecd3470f58cf8022e3188da3c2eb77448c244cb Mon Sep 17 00:00:00 2001
 From: Drew Moseley <drew.moseley@northern.tech>
 Date: Sun, 28 Jan 2018 17:44:32 -0500
 Subject: [PATCH] Generic boot code for Mender.
@@ -7,15 +7,15 @@ Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
 Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
 Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
 ---
- include/config_mender.h |  98 +++++++++++++++++++++++++++++++
- include/env_mender.h    | 152 ++++++++++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 250 insertions(+)
+ include/config_mender.h |  98 +++++++++++++++++++++++++
+ include/env_mender.h    | 157 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 255 insertions(+)
  create mode 100644 include/config_mender.h
  create mode 100644 include/env_mender.h
 
 diff --git a/include/config_mender.h b/include/config_mender.h
 new file mode 100644
-index 0000000..3836a6d
+index 0000000000..3836a6ddd4
 --- /dev/null
 +++ b/include/config_mender.h
 @@ -0,0 +1,98 @@
@@ -119,10 +119,10 @@ index 0000000..3836a6d
 +#endif /* HEADER_CONFIG_MENDER_H */
 diff --git a/include/env_mender.h b/include/env_mender.h
 new file mode 100644
-index 0000000..a1996ab
+index 0000000000..0605f6a9fa
 --- /dev/null
 +++ b/include/env_mender.h
-@@ -0,0 +1,152 @@
+@@ -0,0 +1,157 @@
 +/*
 +  Copyright 2017 Northern.tech AS
 +
@@ -205,6 +205,11 @@ index 0000000..a1996ab
 +    "then "                                                             \
 +    "run mender_pre_setup_commands; "                                   \
 +    "fi; "                                                              \
++    "if test \"${mender_systemd_machine_id}\" != \"\"; "                \
++    "then "                                                             \
++    "setenv bootargs systemd.machine_id=${mender_systemd_machine_id} "  \
++    "${bootargs}; "                                                     \
++    "fi; "                                                              \
 +    "setenv mender_kernel_root " MENDER_STORAGE_DEVICE_BASE "${mender_boot_part}; "    \
 +    "if test ${mender_boot_part} = " __stringify(MENDER_ROOTFS_PART_A_NUMBER) "; "     \
 +    "then "                                                                            \
@@ -276,5 +281,5 @@ index 0000000..a1996ab
 +
 +#endif /* HEADER_ENV_MENDER_H */
 -- 
-2.7.4
+2.21.0
 

--- a/meta-mender-core/recipes-mender/mender/files/mender-set-systemd-machine-id.sh
+++ b/meta-mender-core/recipes-mender/mender/files/mender-set-systemd-machine-id.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Write the systemd machine-id to the bootloader environment
+# so that it will persist between updates.
+#
+
+set -eu
+
+CURRENT_BOOTLOADER_ID=$(fw_printenv mender_systemd_machine_id 2>/dev/null | cut -d= -f2)
+CURRENT_SYSTEMD_ID=$(cat /etc/machine-id)
+
+rc=0
+if [ -z "${CURRENT_BOOTLOADER_ID}" ] && [ ! -z "${CURRENT_SYSTEMD_ID}" ]; then
+    fw_setenv "mender_systemd_machine_id" "${CURRENT_SYSTEMD_ID}"
+    rc=$?
+elif [ "${CURRENT_BOOTLOADER_ID}" != "${CURRENT_SYSTEMD_ID}" ]; then
+    echo "Error; bootloader and systemd disagree on machine-id." >&2
+    rc=1
+fi
+
+exit $rc

--- a/meta-mender-core/recipes-mender/mender/files/mender-systemd-machine-id.service
+++ b/meta-mender-core/recipes-mender/mender/files/mender-systemd-machine-id.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mender persistent machine ID for systemd
+ConditionPathExists=/etc/machine-id
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart=/usr/bin/mender-set-systemd-machine-id.sh
+
+[Install]
+WantedBy=mender.service

--- a/meta-mender-core/recipes-mender/mender/mender.inc
+++ b/meta-mender-core/recipes-mender/mender/mender.inc
@@ -32,8 +32,13 @@ FILES_${PN} += "${systemd_unitdir}/system/mender.service \
                "
 
 SRC_URI_append_mender-image_mender-systemd = " file://mender-data-dir.service"
+SRC_URI_append_mender-persist-systemd-machine-id = " file://mender-systemd-machine-id.service \
+                                                     file://mender-set-systemd-machine-id.sh"
 FILES_${PN}_append_mender-image_mender-systemd = " ${systemd_unitdir}/system/mender-data-dir.service \
                                                    ${systemd_unitdir}/system/mender.service.wants/mender-data-dir.service"
+FILES_${PN}_append_mender-persist-systemd-machine-id = " ${systemd_unitdir}/system/mender-systemd-machine-id.service \
+                                                         ${systemd_unitdir}/system/mender.service.wants/mender-systemd-machine-id.service \
+                                                         ${bindir}/mender-set-systemd-machine-id.sh"
 
 # Go binaries produce unexpected effects that the Yocto QA mechanism doesn't
 # like. We disable those checks here.
@@ -235,4 +240,12 @@ do_install_append_mender-image_mender-systemd() {
     install -m 644 ${WORKDIR}/mender-data-dir.service ${D}${systemd_unitdir}/system/
     install -d -m 755 ${D}${systemd_unitdir}/system/mender.service.wants
     ln -sf ../mender-data-dir.service ${D}${systemd_unitdir}/system/mender.service.wants/
+}
+
+do_install_append_mender-persist-systemd-machine-id() {
+    install -m 644 ${WORKDIR}/mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/
+    install -d -m 755 ${D}${systemd_unitdir}/system/mender.service.wants
+    ln -sf ../mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/mender.service.wants/
+    install -d -m 755 ${D}${bindir}
+    install -m 755 ${WORKDIR}/mender-set-systemd-machine-id.sh ${D}${bindir}
 }


### PR DESCRIPTION
This patchset  passes the machine-id on the kernel command line to systemd. This ensures that it is the same regardless of which partition is /. It also works properly for read-only root.

I have only lightly tested this on Master but I have a version in Thud that has been tested more thoroughly.