### PR TITLE
[thud] TestFix: Mender-client now returns errcode 2, and ErrorNothingToCommit.

### DIFF
--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -1032,5 +1032,6 @@ class TestUpdates:
         # Make sure committing is not possible anymore afterwards.
         with settings(warn_only=True):
             output = run("mender -commit")
-            assert output.return_code != 0
-            assert "No artifact installation in progress" in output
+            assert output.return_code == 2
+            # Earlier versions used the first string.
+            assert "No artifact installation in progress" in output or "There is nothing to commit" in output


### PR DESCRIPTION
Changelog: None

Based on a patch by Ole Petter <ole.orhagen@northern.tech>

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit c2c21117451e949b52a498b99e242284106bc50c)