### PR TITLE
Ensure that artifact and partition images' checksums are equal.

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -335,7 +335,7 @@ IMAGE_CMD_mtdimg() {
         elif [ "$name" = "u-boot-env" ]; then
             mender_flash_mtdpart "${DEPLOY_DIR_IMAGE}/uboot.env" $size $kbsize $kboffset $name
         elif [ "$name" = "ubi" ]; then
-            mender_flash_mtdpart "${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ubimg" $size $kbsize $kboffset $name
+            mender_flash_mtdpart "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.ubimg" $size $kbsize $kboffset $name
         else
             bbwarn "Don't know how to flash mtdparts '$name'. Filling with zeros."
             mender_flash_mtdpart "/dev/zero" $size $kbsize $kboffset $name
@@ -344,7 +344,7 @@ IMAGE_CMD_mtdimg() {
         i=$(expr $i + 1)
     done
 
-    ln -sfn "${IMAGE_NAME}.mtdimg" "${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.mtdimg"
+    ln -sfn "${IMAGE_NAME}.mtdimg" "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.mtdimg"
 }
 
 IMAGE_TYPEDEP_mtdimg_append = " ubimg"

--- a/meta-mender-core/classes/mender-ubimg.bbclass
+++ b/meta-mender-core/classes/mender-ubimg.bbclass
@@ -56,7 +56,7 @@ IMAGE_CMD_ubimg () {
     cat > ${WORKDIR}/ubimg-${IMAGE_NAME}.cfg <<EOF
 [rootfsA]
 mode=ubi
-image=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ubifs
+image=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.ubifs
 vol_id=0
 vol_size=${MENDER_CALC_ROOTFS_SIZE}KiB
 vol_type=dynamic
@@ -64,7 +64,7 @@ vol_name=rootfsa
 
 [rootfsB]
 mode=ubi
-image=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.ubifs
+image=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.ubifs
 vol_id=1
 vol_size=${MENDER_CALC_ROOTFS_SIZE}KiB
 vol_type=dynamic
@@ -72,7 +72,7 @@ vol_name=rootfsb
 
 [data]
 mode=ubi
-image=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.dataimg
+image=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.dataimg
 vol_id=2
 vol_size=${MENDER_DATA_PART_SIZE_MB}MiB
 vol_type=dynamic

--- a/meta-mender-qemu/classes/vexpress-nor_image.bbclass
+++ b/meta-mender-qemu/classes/vexpress-nor_image.bbclass
@@ -6,7 +6,7 @@ IMAGE_TYPEDEP_vexpress-nor = "mtdimg"
 IMAGE_CMD_vexpress-nor() {
     set -ex
 
-    mtdimgfile=${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.mtdimg
+    mtdimgfile=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.mtdimg
 
     imgsize=$(stat -c '%s' -L ${mtdimgfile})
     if [ "$imgsize" -gt 134217728 ]; then

--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -188,7 +188,11 @@ def latest_mender_image():
     assert(os.environ.get('BUILDDIR', False)), "BUILDDIR must be set"
 
     # Find latest built rootfs.
-    return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.mender")
+    if pytest.config.getoption('--test-conversion'):
+        image_name = os.path.splitext(pytest.config.getoption('--mender-image'))[0]
+        return latest_build_artifact(os.environ['BUILDDIR'], "%s.mender" % image_name)
+    else:
+        return latest_build_artifact(os.environ['BUILDDIR'], "core-image*.mender")
 
 @pytest.fixture(scope="session")
 def latest_part_image():


### PR DESCRIPTION
We also switch the data partition to use the same mechanism, mostly as
a free testing mechanism for our dataimg image type.

A test is added for ubimg and the corresponding part image test is in
the mender-image-tests repository.

MEN-2597

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>