### PR TITLE
mender: Setup Live installer.

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -261,6 +261,33 @@ IMAGE_TYPEDEP_biosimg_append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', '
 IMAGE_TYPEDEP_gptimg_append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'biosimg', ' biosimg', '', d)}"
+# Make sure the Mender part image is available in the live installer
+IMAGE_TYPEDEP_hddimg_append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
+                               ${@bb.utils.contains('IMAGE_FSTYPES', 'gptimg', ' gptimg', '', d)} \
+                               ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)} \
+                               ${@bb.utils.contains('IMAGE_FSTYPES', 'biosimg', ' biosimg', '', d)}"
+
+# Use the Mender part image as the Live image
+python() {
+    if bb.utils.contains('IMAGE_FSTYPES', 'sdimg', True, False, d):
+        type='sdimg'
+    elif bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', True, False, d):
+        type='uefiimg'
+    elif bb.utils.contains('IMAGE_FSTYPES', 'biosimg', True, False, d):
+        type='biosimg'
+    elif bb.utils.contains('IMAGE_FSTYPES', 'gptimg', True, False, d):
+        type='gptimg'
+    else:
+        return
+
+    d.setVar('LIVE_ROOTFS_TYPE', type)
+    d.setVar('ROOTFS', "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.%s.bz2" % type)
+    d.setVar('IMAGE_FSTYPES_append', ' %s.bz2 ' % type)
+
+    # Remove the boot option on the Live installer; it won't work since Mender hard codes
+    # the device nodes
+    d.setVar('LABELS_LIVE_remove', 'boot')
+}
 
 # So that we can use the files from excluded paths in the full images.
 do_image_sdimg[respect_exclude_path] = "0"

--- a/meta-mender-core/recipes-core/initrdscripts/files/init-install-efi-mender.sh
+++ b/meta-mender-core/recipes-core/initrdscripts/files/init-install-efi-mender.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -ue
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
+devnode=@MENDER_STORAGE_DEVICE@
+
+if [ -b ${devnode} ]; then
+    echo "Installing image on ${devnode} ..."
+else
+    echo "No device available matching ${devnode}. Installation aborted."
+    exit 1
+fi
+
+if [ -e /run/media/$1/$2 ]; then
+    echo "Writing Mender-enabled Yocto image /run/media/$1/$2 to ${devnode}"
+    echo "bzcat /run/media/$1/$2 | /bin/dd of=$devnode bs=8M"
+    echo -n "OK to proceed? <y/n> "
+    read yn
+    if [ "$yn" = "y" ] || [ "$yn" = "Y" ]; then
+        rc=0
+        bzcat /run/media/$1/$2 | /bin/dd of=$devnode bs=8M || rc=$?
+        sync
+        if [ $rc = 0 ]; then
+            echo "Installation successful."
+        else
+            echo "/bin/dd returned error $rc. Review above log. Installation aborted"
+        fi
+    else
+        echo "Installation aborted"
+    fi
+else
+    echo "Unable to locate $2. Installation aborted"
+fi
+
+echo "Remove your installation media and press ENTER to reboot."
+read enter
+
+echo "Rebooting..."
+reboot -f

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://init-install-efi-mender.sh"
+
+do_install_append() {
+    # Overwrite the version of this file provided by upstream
+    sed -ie 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh
+    install -m 0755 ${WORKDIR}/init-install-efi-mender.sh ${D}/init.d/install-efi.sh
+}


### PR DESCRIPTION
The current HDDIMG (and ISO for that matter) support in Yocto sets up multiple
bootloader options. One is standard live boot but the other is an install mechanism
so you can install your build onto a target without removable media. This patch
provides a version of this scripting that works with Mender. Basically, the SDIMG
UEFIIMG or MTDIMG file are copied into the HDDIMG and the initrd runs a script
which uses 'dd' to write the image.

This has been tested on an X86 platform with an internal MSATA drive and an external
USB drive.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>