### PR TITLE
rpi: Fix several assignment bugs regarding `MENDER_BOOTLOADER_DEFAULT`.

### DIFF
--- a/meta-mender-core/classes/mender-full.bbclass
+++ b/meta-mender-core/classes/mender-full.bbclass
@@ -8,8 +8,8 @@ MENDER_FEATURES_ENABLE_append = " \
     mender-systemd \
 "
 
-_MENDER_IMAGE_TYPE_DEFAULT = "mender-image-uefi"
-_MENDER_BOOTLOADER_DEFAULT = "mender-grub"
+_MENDER_IMAGE_TYPE_DEFAULT ?= "mender-image-uefi"
+_MENDER_BOOTLOADER_DEFAULT ?= "mender-grub"
 
 # Beaglebone reads the first VFAT partition and only understands MBR partition
 # table. Even though this is a slight violation of the UEFI spec, change to that

--- a/meta-mender-raspberrypi/conf/layer.conf
+++ b/meta-mender-raspberrypi/conf/layer.conf
@@ -17,5 +17,5 @@ LAYERDEPENDS_mender-raspberrypi = "mender raspberrypi"
 LAYERSERIES_COMPAT_mender-raspberrypi = "thud"
 
 # Raspberry Pi doesn't work with GRUB currently.
-_MENDER_IMAGE_TYPE_DEFAULT_rpi = "mender-image-sd"
-_MENDER_BOOTLOADER_DEFAULT_rpi = "mender-uboot"
+_MENDER_IMAGE_TYPE_DEFAULT = "mender-image-sd"
+_MENDER_BOOTLOADER_DEFAULT = "mender-uboot"


### PR DESCRIPTION
* `rpi` is not a valid machine name, and there are anyway too many
  machine names in that layer to specify all of them. Instead set
  unconditionally for the meta-mender-raspberrypi layer.

* We need weak assignment in the meta-mender-core layer, since the
  `mender-full.bbclass` is evaluated after the `layer.conf` file, even
  if the former layer is listed first.

Changelog: title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>