### PR TITLE
Fix vexpress qemu not starting

### DIFF
--- a/meta-mender-qemu/docker/vexpress-qemu/Dockerfile
+++ b/meta-mender-qemu/docker/vexpress-qemu/Dockerfile
@@ -21,90 +21,11 @@ FROM alpine:3.7
 # Install packages
 RUN apk update && apk upgrade && \
     apk add util-linux multipath-tools \
-            bash e2fsprogs-extra python3 && \
-    rm -rf /var/cache/apk/*
+            bash e2fsprogs-extra python3
 
-# Install qemu from source
-RUN apk update && apk add --virtual build-dependencies \
-    alsa-lib-dev \
-    bison \
-    curl-dev \
-    flex \
-	  glib-dev \
-	  glib-static \
-	  gnutls-dev \
-	  gtk+3.0-dev \
-	  libaio-dev \
-	  libcap-dev \
-	  libcap-ng-dev \
-	  libjpeg-turbo-dev \
-	  libnfs-dev \
-	  libpng-dev \
-	  libssh2-dev \
-	  libusb-dev \
-	  linux-headers \
-	  lzo-dev \
-	  ncurses-dev \
-	  paxmark \
-	  snappy-dev \
-	  spice-dev \
-	  texinfo \
-	  usbredir-dev \
-	  util-linux-dev \
-	  vde2-dev \
-	  xfsprogs-dev \
-	  zlib-dev \
-    git \
-    alpine-sdk \
-    && \
-    git clone --progress -b qemu-system-reset-race-fix git://github.com/mendersoftware/qemu.git && \
-    cd qemu && \
-    git submodule update --init dtc && \
-    ./configure --target-list=arm-softmmu \
-                --disable-werror \
-                --prefix=/usr \
-                --localstatedir=/var \
-		            --sysconfdir=/etc \
-		            --libexecdir=/usr/lib/qemu \
-		            --disable-glusterfs \
-		            --disable-debug-info \
-		            --disable-bsd-user \
-		            --disable-werror \
-		            --disable-sdl \
-		            --disable-xen \
-                --disable-attr \
-                --disable-gtk \
-                && \
-    make install -j4 V=1 && \
-    cd .. && \
-    rm -rf qemu && \
-    apk del build-dependencies && \
-    apk add so:libaio.so.1 \
-            so:libasound.so.2 \
-            so:libbz2.so.1 \
-            so:libc.musl-x86_64.so.1 \
-            so:libcurl.so.4 \
-            so:libepoxy.so.0 \
-            so:libgbm.so.1 \
-            so:libgcc_s.so.1 \
-            so:libglib-2.0.so.0 \
-            so:libgnutls.so.30 \
-            so:libjpeg.so.8 \
-            so:liblzo2.so.2 \
-            so:libncursesw.so.6 \
-            so:libnettle.so.6 \
-            so:libnfs.so.8 \
-            so:libpixman-1.so.0 \
-            so:libpng16.so.16 \
-            so:libsnappy.so.1 \
-            so:libspice-server.so.1 \
-            so:libssh2.so.1 \
-            so:libstdc++.so.6 \
-            so:libusb-1.0.so.0 \
-            so:libusbredirparser.so.1 \
-            so:libvdeplug.so.3 \
-            so:libz.so.1 \
-    rm -rf /var/cache/apk/*
+RUN apk add qemu-system-arm
+
+RUN rm -rf /var/cache/apk/*
 
 RUN echo vexpress-qemu > /machine.txt
 

--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -114,7 +114,7 @@ case $DISK_IMG in
 esac
 
 echo "--- qemu version"
-$QEMU_SYSTEM --version
+$QEMU_SYSTEM --version || exit 1
 
 echo "--- starting qemu"
 


### PR DESCRIPTION
```
commit 41091d8dfde32a0bfad205d9d7f769a610c46123 (HEAD -> fix-vexpress-qemu-not-starting, lluiscampos/fix-vexpress-qemu-not-starting)
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Tue Jul 30 12:42:39 2019 +0200

    Switch to upstream qemu for ARM architecture
    
    Building it from source does not work for Alpine Linux 3.7. The
    resulting Docker image is unable to start-up qemu, as many shared
    libraries ar not found.
    
    It is unknown if the reset race bug is fixed upstream for this Linux
    version.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit 93e733b67a312f1e05d7266891c70ec72efa926a
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Tue Jul 30 12:40:54 2019 +0200

    Exit with failure when qemu-system-xxx cannot start
    
    This was the case when building it from source on Alpine Linux 3.7, but
    the error went unnoticed
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```