### PR TITLE
Restore `rpi` based variable selection for Raspberry Pi.

### DIFF
--- a/meta-mender-raspberrypi/conf/layer.conf
+++ b/meta-mender-raspberrypi/conf/layer.conf
@@ -17,5 +17,5 @@ LAYERDEPENDS_mender-raspberrypi = "mender raspberrypi"
 LAYERSERIES_COMPAT_mender-raspberrypi = "thud"
 
 # Raspberry Pi doesn't work with GRUB currently.
-_MENDER_IMAGE_TYPE_DEFAULT = "mender-image-sd"
-_MENDER_BOOTLOADER_DEFAULT = "mender-uboot"
+_MENDER_IMAGE_TYPE_DEFAULT_rpi = "mender-image-sd"
+_MENDER_BOOTLOADER_DEFAULT_rpi = "mender-uboot"


### PR DESCRIPTION
Apparently it is defined through `SOC_FAMILY` in the
github.com/agherzan/meta-raspberrypi layer.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>