### PR TITLE
u-boot-fw-utils: set PACKAGE_ARCH as MACHINE_ARCH

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender-auto-provided_1.0.bb
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender-auto-provided_1.0.bb
@@ -74,3 +74,5 @@ do_install () {
     install -m 755 ${B}/tools/env/fw_printenv ${D}${base_sbindir}/fw_setenv
     install -m 0644 ${B}/tools/env/fw_env.config ${D}${sysconfdir}/fw_env.config
 }
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Add PACKAGE_ARCH to force package to be machine-dependent

Changelog: Title

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>