### PR TITLE
example-state-scripts: use show-artifact instead of parsing file

### DIFF
--- a/meta-mender-demo/recipes-mender/example-state-scripts/example-state-scripts_1.0.bb
+++ b/meta-mender-demo/recipes-mender/example-state-scripts/example-state-scripts_1.0.bb
@@ -17,4 +17,5 @@ do_compile() {
     cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_99
     cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactReboot_Leave_50
     cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_50
+    cp example-script ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Leave_50
 }

--- a/meta-mender-demo/recipes-mender/example-state-scripts/files/example-script
+++ b/meta-mender-demo/recipes-mender/example-state-scripts/files/example-script
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "$(cat /etc/mender/artifact_info): $(basename "$0") was called!" >&2
+echo "$(mender -show-artifact): $(basename "$0") was called!" >&2
 exit 0


### PR DESCRIPTION
The /etc/mender/artifact_info file is deprecated from Mender 2.0,
as such info is now saved in the database.

Changelog: Title

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>