### PR TITLE
fix MENDER_DATA_PART default value when creating image without bootpart

### DIFF
--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -34,7 +34,7 @@ MENDER_ROOTFS_PART_B_NAME_DEFAULT = "${MENDER_ROOTFS_PART_B}"
 
 # The partition number holding the data partition.
 MENDER_DATA_PART ??= "${MENDER_DATA_PART_DEFAULT}"
-MENDER_DATA_PART_DEFAULT = "${MENDER_STORAGE_DEVICE_BASE}${@bb.utils.contains('MENDER_BOOT_PART_SIZE_MB', '0', '4', '5', d)}"
+MENDER_DATA_PART_DEFAULT = "${MENDER_STORAGE_DEVICE_BASE}${@bb.utils.contains('MENDER_BOOT_PART_SIZE_MB', '0', '3', '5', d)}"
 
 # The name of of the MTD part holding your UBI volumes.
 MENDER_MTD_UBI_DEVICE_NAME ??= "${MENDER_MTD_UBI_DEVICE_NAME_DEFAULT}"


### PR DESCRIPTION
The index is "3" when no bootpart is present, because we will get rid of
the "extended" partition if we remove boot part.

Changelog: Fix boot when MENDER_DATA_PART_DEFAULT = "0"

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>