### PR TITLE
Support passing global options to mender-artifact

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -2,6 +2,9 @@ inherit mender-helpers
 
 # ------------------------------ CONFIGURATION ---------------------------------
 
+# Extra global options that should be passed to mender-artifact.
+MENDER_ARTIFACT_EXTRA_OPTS ?= ""
+
 # Extra arguments that should be passed to mender-artifact.
 MENDER_ARTIFACT_EXTRA_ARGS ?= ""
 
@@ -55,7 +58,8 @@ IMAGE_CMD_mender () {
         image_flag=-f
     fi
 
-    mender-artifact write rootfs-image \
+    mender-artifact ${MENDER_ARTIFACT_EXTRA_OPTS} \
+        write rootfs-image \
         -n ${MENDER_ARTIFACT_NAME} \
         $extra_args \
         $image_flag ${IMGDEPLOYDIR}/${ARTIFACTIMG_NAME}.${ARTIFACTIMG_FSTYPE} \

--- a/meta-mender-core/conf/mender-vars.json
+++ b/meta-mender-core/conf/mender-vars.json
@@ -19,6 +19,7 @@
      "'MENDER_FEATURES_ENABLE': ['mender-uboot', 'mender-install']",
      "(using single quote (') for double quote in the above string)"],
     "MENDER_ARTIFACT_EXTRA_ARGS": "",
+    "MENDER_ARTIFACT_EXTRA_OPTS": "",
     "MENDER_ARTIFACT_NAME": "",
     "MENDER_ARTIFACT_SIGNING_KEY": "",
     "MENDER_ARTIFACT_VERIFY_KEY": "",


### PR DESCRIPTION
Starting from mender-artifact v3, the command supports compressing the
image with LZMA. However, there's no way to specify it from the Yocto
building system. With this commit, one's able to do so by inserting the
following variable into `local.conf`.

```
MENDER_ARTIFACT_EXTRA_OPTS_append = " --compression lzma"
```