### PR TITLE
Several partition type fixes

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -111,7 +111,7 @@ EOF
     if [ "${MENDER_BOOT_PART_SIZE_MB}" -ne "0" ]; then
         mender_merge_bootfs_and_image_boot_files
         cat >> "$wks" <<EOF
-part --source rootfs --rootfs-dir ${WORKDIR}/bootfs.${BB_CURRENTTASK} --ondisk "$ondisk_dev" --fstype=vfat --label boot --align $alignment_kb --fixed-size ${MENDER_BOOT_PART_SIZE_MB} --active
+part --source rootfs --rootfs-dir ${WORKDIR}/bootfs.${BB_CURRENTTASK} --ondisk "$ondisk_dev" --fstype=vfat --label boot --align $alignment_kb --fixed-size ${MENDER_BOOT_PART_SIZE_MB} --active $boot_part_params
 EOF
     elif [ -n "$IMAGE_BOOT_FILES_STRIPPED" ]; then
         bbwarn "MENDER_BOOT_PART_SIZE_MB is set to zero, but IMAGE_BOOT_FILES is not empty. The files are being omitted from the image."
@@ -194,16 +194,16 @@ EOF
 }
 
 IMAGE_CMD_sdimg() {
-    mender_part_image sdimg msdos "--source bootimg-partition"
+    mender_part_image sdimg msdos
 }
 IMAGE_CMD_uefiimg() {
-    mender_part_image uefiimg gpt "--source bootimg-partition --part-type EF00"
+    mender_part_image uefiimg gpt "--part-type EF00"
 }
 IMAGE_CMD_biosimg() {
-    mender_part_image biosimg msdos "--source bootimg-partition"
+    mender_part_image biosimg msdos
 }
 IMAGE_CMD_gptimg() {
-    mender_part_image gptimg gpt "--source bootimg-partition"
+    mender_part_image gptimg gpt
 }
 
 


### PR DESCRIPTION
```
commit b66beb2945ebb4ceb1465914c53118a48921a6b2
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Sep 6 07:36:14 2019

    Fix incorrect partition types after we started using `rawcopy`.
    
    This was introduced in 30a27a9f5e9ba8edb1e879380a64fc8cc994af43. When
    we switched away from the `rootfs` source, we lost the identity of the
    filesystem, and all partitions became the generic "Microsoft basic
    data" type. We fix GPT by using `--part-type` argument, but the MBR
    code in wic doesn't support using it, so we need to fix those entries
    manually with fdisk.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 4eb39076050b08c3a9ce5a335914fb1bd1f45459
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Sep 6 08:38:31 2019

    Fix incorrect boot partition type for EFI boot partitions.
    
    This was broken in 0b737428d0570de16935e0758db7752de4134d2a, where we
    lost the `boot_part_params` along the way.
    
    Changelog: Title
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```