### PR TITLE
MEN-2337: Enable dynamic resizing of the data partition

### DIFF
--- a/meta-mender-core/classes/mender-full.bbclass
+++ b/meta-mender-core/classes/mender-full.bbclass
@@ -6,6 +6,7 @@ MENDER_FEATURES_ENABLE_append = " \
     ${_MENDER_IMAGE_TYPE_DEFAULT} \
     mender-install \
     mender-systemd \
+    mender-growfs-data \
 "
 
 _MENDER_IMAGE_TYPE_DEFAULT ?= "mender-image-uefi"

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -262,6 +262,9 @@ python() {
 
         # Setup the systemd machine ID to be persistent across OTA updates.
         'mender-persist-systemd-machine-id',
+
+        # Enable dynamic resizing of the data filesystem through systemd's growfs
+        'mender-growfs-data',
     }
 
     mfe = d.getVar('MENDER_FEATURES_ENABLE')
@@ -392,6 +395,9 @@ python mender_vars_handler() {
         with open (path, 'w') as f:
             json.dump(mender_vars, f, sort_keys=True, indent=4)
 }
+
+
+MENDER_DATA_PART_FSTAB_OPTS_append = "${MENDER_DATA_PART_FSTAB_OPTS_DEFAULT}${bb.utils.contains{'MENDER_FEATURES', 'mender-growfs-data' ',x-systemd.growfs', '', d)"
 
 # Including these does not mean that all these features will be enabled, just
 # that their configuration will be considered. Use DISTRO_FEATURES to enable and


### PR DESCRIPTION
Changelog: Title. This is done through enabling systemd's growfs
feature. Hereforth the feature is enabled by default when inheriting
from 'mender-full'. The feature can be disabled, and must be done so
explicitly through the 'MENDER_DATA_PART_FSTAB_OPTS' variable.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>