### PR TITLE
Rename ARM mender-binary-delta subfolders to 'arm' and 'aarch64'

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_0.1.1.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_0.1.1.bb
@@ -1,8 +1,8 @@
 LICENSE = "CLOSED"
 LICENSE_FLAGS = "commercial"
 
-SUB_FOLDER_arm = "armhf"
-SUB_FOLDER_aarch64 = "arm64"
+SUB_FOLDER_arm = "arm"
+SUB_FOLDER_aarch64 = "aarch64"
 SUB_FOLDER_x86-64 = "x86_64"
 
 SRC_URI = "file://${SUB_FOLDER}/mender-binary-delta"


### PR DESCRIPTION
Following modification in deploy naming for the module and therefore
keeping consistency with Yocto name convention.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>