### PR TITLE
Fix and strict check for mender-migrate-configuration MEN-2757

### DIFF
--- a/meta-mender-core/recipes-mender/mender-migrate-configuration/mender-migrate-configuration.bb
+++ b/meta-mender-core/recipes-mender/mender-migrate-configuration/mender-migrate-configuration.bb
@@ -14,6 +14,16 @@ ALLOW_EMPTY_${PN} = "1"
 
 RDEPENDS_${PN} += "jq"
 
+DEPENDS += "mender"
+
+do_check_split_conf() {
+    if [ -f ${STAGING_DIR_TARGET}/data/mender/mender.conf ]; then
+        bbfatal "A persistent Mender configuration file was found on the /data partition. To migrate the configuration, \
+disable split-mender-config by adding PACKAGECONFIG_remove = \" split-mender-config\" to your local.conf"
+    fi
+}
+addtask do_check_split_conf before do_compile
+
 do_compile[vardeps] += "MENDER_PERSISTENT_CONFIGURATION_VARS"
 do_compile() {
 
@@ -31,8 +41,7 @@ do_compile() {
     # Replace the program markers in the script with the jq programs generated above.
     sed -i "s/%jq-program-marker%/${MENDER_JQ_PROGRAM}/" mender-migrate-configuration
     sed -i "s/%jq-delete-fields-marker%/${MENDER_JQ_DELETE}/" mender-migrate-configuration
-}
 
-do_install() {
+    # Deploy script as an State Script
     cp mender-migrate-configuration ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_10_migrate-configuration
 }

--- a/meta-mender-core/recipes-mender/mender/mender.inc
+++ b/meta-mender-core/recipes-mender/mender/mender.inc
@@ -33,6 +33,8 @@ FILES_${PN} += "${systemd_unitdir}/system/mender.service \
                 ${sysconfdir}/udev/mount.blacklist.d/mender \
                "
 
+SYSROOT_DIRS += "/data"
+
 SRC_URI_append_mender-image_mender-systemd = " file://mender-data-dir.service"
 SRC_URI_append_mender-persist-systemd-machine-id = " file://mender-systemd-machine-id.service \
                                                      file://mender-set-systemd-machine-id.sh"


### PR DESCRIPTION
In the one hand, fix the recipe itself by moving the cp statement to
do_compile as required by mender-state-scripts class.

In the other hand, this recipe will only work if split-mender-config is
disabled in the same build. Add a hard check for this making it depend
on mender and document the improve the usage doc in the changelog entry.

Cancel-changelog: 5acbed2

Changelog: Splits the mender.conf configuration file into a transient
configuration /etc/mender/mender.conf and a persistent congiguration in
/data/mender/mender.conf. This split is enabled by default, and it can
be opt-out by adding `PACKAGECONFIG_remove = "split-mender-config"` to
local.conf.

Changelog: Add a new recipe mender-migrate-configuration to ease the
migration of devices with single mender.conf to the new setup of split
configuration files. To build an updgrade for such device, add the
recipe with `IMAGE_INSTALL_append = " mender-migrate-configuration"`,
disable the split feature (for this update only) with
`PACKAGECONFIG_remove = " split-mender-config"`, and specify which
parameters to migrate (at least partitions params) with
`MENDER_PERSISTENT_CONFIGURATION_VARS = "RootfsPartA RootfsPartB"`.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>