### PR TITLE
raspberrypi: add patch to always use 'fdt_addr' passed on by firmware

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-rpi-Drop-reading-of-fdt_addr-from-environment.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-rpi-Drop-reading-of-fdt_addr-from-environment.patch
@@ -1,0 +1,33 @@
+From 2daa5becef4560b3b09485162a1978135dbe1e78 Mon Sep 17 00:00:00 2001
+From: Marek Belisko <marek.belisko@open-nandra.com>
+Date: Mon, 20 May 2019 09:10:13 +0200
+Subject: [PATCH 1/1] rpi: Drop reading of fdt_addr from environment
+
+Use always one reported by firmware. It can happen that with manipulation
+with e.g. cmdline.txt fdt_addr is different then stored in in env.
+
+Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>
+
+Upstream-status: Pending
+
+---
+ board/raspberrypi/rpi/rpi.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index 9dac64b920..de7648cff9 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -324,9 +324,6 @@ static void set_fdtfile(void)
+  */
+ static void set_fdt_addr(void)
+ {
+-	if (env_get("fdt_addr"))
+-		return;
+-
+ 	if (fdt_magic(fw_dtb_pointer) != FDT_MAGIC)
+ 		return;
+
+--
+2.23.0
+

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
@@ -9,5 +9,7 @@ MENDER_UBOOT_AUTO_CONFIGURE ?= "0"
 SRC_URI_append_rpi_mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
                                                         '1', \
                                                         '', \
-                                                        ' file://0001-CONFIGS-rpi-enable-mender-requirements.patch', \
+                                                        ' file://0001-CONFIGS-rpi-enable-mender-requirements.patch \
+                                                          file://0001-rpi-Drop-reading-of-fdt_addr-from-environment.patch \
+                                                        ', \
                                                         d)}"


### PR DESCRIPTION
Current U-Boot logic will use the value in the 'fdt_addr' variable if present in
U-boot enviroment to load DTB. This has shown to be problematic as the address of
where the boot firmware places the DTB can change depending on what is
set in config.txt and cmdline.txt.

For this reason always use the value that is passed on by the boot firmware.

This is what the error looks like:

U-Boot 2019.01 (Sep 26 2019 - 11:56:02 +0000)

DRAM:  948 MiB
RPI 3 Model B+ (0xa020d3)
MMC:   mmc@7e202000: 0, sdhci@7e300000: 1
Loading Environment from MMC... OK
In:    serial
Out:   vidconsole
Err:   vidconsole
Net:   No ethernet found.
starting USB...
USB0:   scanning bus 0 for devices... 4 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
300 bytes read in 1 ms (293 KiB/s)
libfdt fdt_check_header(): FDT_ERR_BADMAGIC
switch to partitions #0, OK
mmc0 is current device
5485768 bytes read in 234 ms (22.4 MiB/s)
   Image Name:   Linux-4.19.71
   Image Type:   ARM Linux Kernel Image (uncompressed)
   Data Size:    5485704 Bytes = 5.2 MiB
   Load Address: 00008000
   Entry Point:  00008000
   Verifying Checksum ... OK
ERROR: Did not find a cmdline Flattened Device Tree
Could not find a valid device tree
SCRIPT FAILED: continuing...

Changelog: Fix issue where U-boot is not able to find a valid DTB on Raspberry Pi boards

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>