### PR TITLE
raspberrypi: split RPi3 and RPi4 integration

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-CONFIGS-rpi-enable-mender-requirements.patch
@@ -15,12 +15,10 @@ Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
  configs/rpi_2_defconfig     | 3 +--
  configs/rpi_3_32b_defconfig | 3 +--
  configs/rpi_3_defconfig     | 3 +--
- configs/rpi_4_32b_defconfig | 3 +--
- configs/rpi_4_defconfig     | 3 +--
  configs/rpi_defconfig       | 3 +--
  env/Kconfig                 | 1 -
  include/configs/rpi.h       | 3 +++
- 9 files changed, 10 insertions(+), 15 deletions(-)
+ 7 files changed, 8 insertions(+), 11 deletions(-)
 
 diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
 index 39da54c3e7..9a0fc1f0b5 100644
@@ -90,42 +88,6 @@ index ea40351dc4..46c26b2f3c 100644
  CONFIG_DM_KEYBOARD=y
  CONFIG_DM_MMC=y
 @@ -41,3 +39,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
- CONFIG_CONSOLE_SCROLL_LINES=10
- CONFIG_PHYS_TO_BUS=y
- CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_ENV_IS_IN_MMC=y
-diff --git a/configs/rpi_4_32b_defconfig b/configs/rpi_4_32b_defconfig
-index a31a617a5f..78cda8549a 100644
---- a/configs/rpi_4_32b_defconfig
-+++ b/configs/rpi_4_32b_defconfig
-@@ -16,8 +16,6 @@ CONFIG_SYS_PROMPT="U-Boot> "
- CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
- CONFIG_CMD_FS_UUID=y
--CONFIG_ENV_FAT_INTERFACE="mmc"
--CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_DM_KEYBOARD=y
- CONFIG_DM_MMC=y
-@@ -31,3 +29,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
- CONFIG_CONSOLE_SCROLL_LINES=10
- CONFIG_PHYS_TO_BUS=y
- CONFIG_OF_LIBFDT_OVERLAY=y
-+CONFIG_ENV_IS_IN_MMC=y
-diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
-index da8c960a2a..c5f7116dac 100644
---- a/configs/rpi_4_defconfig
-+++ b/configs/rpi_4_defconfig
-@@ -16,8 +16,6 @@ CONFIG_SYS_PROMPT="U-Boot> "
- CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
- CONFIG_CMD_FS_UUID=y
--CONFIG_ENV_FAT_INTERFACE="mmc"
--CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_DM_KEYBOARD=y
- CONFIG_DM_MMC=y
-@@ -31,3 +29,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
  CONFIG_OF_LIBFDT_OVERLAY=y

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-2019.01/0001-configs-rpi4-mender-integration.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-2019.01/0001-configs-rpi4-mender-integration.patch
@@ -1,0 +1,37 @@
+Index: git/configs/rpi_4_32b_defconfig
+===================================================================
+--- git.orig/configs/rpi_4_32b_defconfig
++++ git/configs/rpi_4_32b_defconfig
+@@ -16,8 +16,6 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_FS_UUID=y
+-CONFIG_ENV_FAT_INTERFACE="mmc"
+-CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_DM_KEYBOARD=y
+ CONFIG_DM_MMC=y
+@@ -31,3 +29,5 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_ENV_IS_IN_MMC=y
++
+Index: git/configs/rpi_4_defconfig
+===================================================================
+--- git.orig/configs/rpi_4_defconfig
++++ git/configs/rpi_4_defconfig
+@@ -16,8 +16,6 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_FS_UUID=y
+-CONFIG_ENV_FAT_INTERFACE="mmc"
+-CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_DM_KEYBOARD=y
+ CONFIG_DM_MMC=y
+@@ -31,3 +29,4 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_ENV_IS_IN_MMC=y

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_2019.01.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_2019.01.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
+SRC_URI_append_raspberrypi4 = " file://0001-configs-rpi4-mender-integration.patch"


### PR DESCRIPTION
Cherry pick commit 55ba2acc7fbe699d8535997ed6c286a88307414c

This fix : 
|diff --git a/configs/rpi_4_32b_defconfig b/configs/rpi_4_32b_defconfig
|index a31a617a5f..78cda8549a 100644
|--- a/configs/rpi_4_32b_defconfig
|+++ b/configs/rpi_4_32b_defconfig
No file to patch.  Skipping patch.
2 out of 2 hunks ignored
can't find file to patch at input line 119
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
|diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
|index da8c960a2a..c5f7116dac 100644
|--- a/configs/rpi_4_defconfig
|+++ b/configs/rpi_4_defconfig

No file to patch.  Skipping patch.
2 out of 2 hunks ignored
patching file configs/rpi_defconfig
patching file env/Kconfig
patching file include/configs/rpi.h
Patch 0001-CONFIGS-rpi-enable-mender-requirements.patch does not apply (enforce with -f)
ERROR: Task (/poky/meta/recipes-bsp/u-boot/u-boot_2019.01.bb:do_patch) failed with exit code '1'

Signed-off-by: Joris Offouga <offougajoris@gmail.com>
