### PR TITLE
mender-setup: do not add systemd options to fstab without mender-systemd

### DIFF
--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -396,7 +396,7 @@ python mender_vars_handler() {
             json.dump(mender_vars, f, sort_keys=True, indent=4)
 }
 
-MENDER_DATA_PART_FSTAB_OPTS_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-growfs-data', ',x-systemd.growfs', '', d)}"
+MENDER_DATA_PART_FSTAB_OPTS_append_mender-systemd = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-growfs-data', ',x-systemd.growfs', '', d)}"
 
 # Including these does not mean that all these features will be enabled, just
 # that their configuration will be considered. Use DISTRO_FEATURES to enable and


### PR DESCRIPTION
Fix related to #822. Please include in the `warrior` branch.