### PR TITLE
Remove explicit tag 2.1.1 from licenses checksum in mender git recipe

### DIFF
--- a/meta-mender-core/recipes-mender/mender/mender_git.inc
+++ b/meta-mender-core/recipes-mender/mender/mender_git.inc
@@ -69,7 +69,7 @@ def mender_license(branch):
                    "md5": "ccb00e21c31df7189b2bd237ed86e7c2",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
-    elif branch.startswith("2.1.1") or branch == "2.1.x":
+    elif branch == "2.1.x":
         return {
                    "md5": "ffc66184ec5a0831e6f5d99b88784670",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",


### PR DESCRIPTION
It is not really required so let's try to keep this function clean.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>