### PR TITLE
Update min_mender_version sentinel to 2.2.0 for artifact deps tests

### DIFF
--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -707,7 +707,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
                             "depenceygroup2"])
     ]
 
-    @pytest.mark.min_mender_version('2.0.0')
+    @pytest.mark.min_mender_version('2.2.0')
     @pytest.mark.parametrize('dependsprovides', test_cases)
     def test_build_artifact_depends_and_provides(
             self,


### PR DESCRIPTION
The current mender-version guard had a version of 2.0.0, which is too low, since
the changes in mender-artifact which holds the depends and provides
functionality is only available in master at the moment of this writing. Hence
set the tag to 2.2.0, which for now only includes the master branch.

Without this fix, cherry-picks to older branches will fail the acceptance tests,
if they employ older versions of mender-artifact.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>