### PR TITLE
Add pytest-html plugin to pip3 requirements

### DIFF
--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -1,5 +1,6 @@
 pytest>=4.0
 fabric>=2.0
+pytest-html
 paramiko
 python-lzo
 ubi-reader


### PR DESCRIPTION
Add pytest-html plugin to pip3 requirements

So that the CI can generate and collect HTML reports. This dependency
was overlooked during PR #849 