### PR TITLE
uboot_auto_patch: handle more complex dependency strings in add_kconf… 

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
+++ b/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
@@ -16,6 +16,22 @@ parser.add_argument("option", metavar="OPTION", nargs=1,
                     help="Option to add to Kconfig, expressed as KEY=VALUE.")
 args = parser.parse_args()
 
+def parse_dependencies(depends_string):
+    # if depends_string has multiple alternative dependencies ("A || B"),
+    # select the first one ("A")
+    depends_string = re.split("\s*\|\|\s*", depends_string)[0]
+
+    # if there are parentheses around ("(A && B)"), remove them ("A && B")
+    match = re.match("^\(\s*(.*)\s*\)$", depends_string)
+    if match:
+        depends_string = match[1]
+
+    # if depends_string has multiple required dependencies ("A && B"),
+    # return all of them
+    dependencies = re.split("\s*&&\s*", depends_string)
+
+    return dependencies
+
 def add_kconfig_option(option):
     key, value = option.split("=", 1)
 
@@ -44,14 +60,14 @@ def add_kconfig_option(option):
                     if not inside_option:
                         continue
 
-                    match = re.match("^\s*depends *on *(\S+)", line)
+                    match = re.match("^\s*depends\s*on\s*(.+)", line)
                     if not match:
                         continue
-                    dependee = match.group(1)
-                    if dependee.startswith("!"):
-                        # We're not handling negative dependencies right now.
-                        continue
-                    add_kconfig_option("CONFIG_%s=y" % dependee)
+                    for dependee in parse_dependencies(match.group(1)):
+                        if dependee.startswith("!"):
+                            # We're not handling negative dependencies right now.
+                            continue
+                        add_kconfig_option("CONFIG_%s=y" % dependee)
 
     with open(args.defconfig_file, "a") as fd:
         fd.write("%s\n" % option)


### PR DESCRIPTION
…ig_option_with_depends script

The change makes the script capable of handling more complex depends-strings which
contain or-operators ("||") where the first alternative is used, parentheses, and
and-operators ("&&").

This makes the script compatible with U-Boot 2019.10.

U-Boot 2019.10 has the following ENV_OFFSET dependencies:
    depends on (!ENV_IS_IN_UBI && !ENV_IS_NOWHERE) || ARCH_STM32MP
(see https://gitlab.denx.de/u-boot/u-boot/blob/v2019.10/env/Kconfig#L469)

In comparison, U-Boot 2019.01 has the following ENV_OFFSET dependencies:
    depends on !ENV_IS_IN_UBI
    depends on !ENV_IS_NOWHERE
(see https://gitlab.denx.de/u-boot/u-boot/blob/v2019.01/env/Kconfig#L436)

Signed-off-by: Joerg Hofrichter <joerg.hofrichter@ni.com>