### PR TITLE
u-boot-mender: set correct boot command for fitImage

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -98,7 +98,7 @@ do_provide_mender_defines() {
     fi
 
     case "$MENDER_KERNEL_IMAGETYPE" in
-        *uImage*)
+        *uImage*|*fitImage*)
             MENDER_BOOT_KERNEL_TYPE=bootm
             ;;
         *zImage*)


### PR DESCRIPTION
When u-boot is built with KERNEL_IMAGETYPE="fitImage", the wrong boot command
(MENDER_BOOT_KERNEL_TYPE) was chosen in do_provide_mender_defines because
the selection defaults to "bootz". The correct command is "bootm" because a
fitImage is an extended uImage format. For details about this format, see:
https://github.com/u-boot/u-boot/blob/master/doc/uImage.FIT/howto.txt

Changelog: none

Signed-off-by: Joerg Hofrichter <joerg.hofrichter@ni.com>