### PR TITLE
Add textrel skip to Sumo

### DIFF
--- a/meta-mender-core/recipes-mender/mender/mender.inc
+++ b/meta-mender-core/recipes-mender/mender/mender.inc
@@ -36,7 +36,7 @@ FILES_${PN}_append_mender-image_mender-systemd = " ${systemd_unitdir}/system/men
 
 # Go binaries produce unexpected effects that the Yocto QA mechanism doesn't
 # like. We disable those checks here.
-INSANE_SKIP_${PN} = "ldflags"
+INSANE_SKIP_${PN} = "ldflags textrel"
 
 GO_IMPORT = "github.com/mendersoftware/mender"
 


### PR DESCRIPTION
Add textrel to the 'INSANE_SKIP_${PN}' to avoid below Yocto QA warning:

> WARNING: mender-2.0.0-r0 do_package_qa: QA Issue: ELF binary ‘<build_dir>/tmp/work/aarch64-poky-linux/mender/2.0.0-r0/packages-split/mender/usr/bin/mender’ has relocations in .text [textrel]

Changelog: None
Signed-off-by: Ajith P V <ajithpv@outlook.com>