### PR TITLE
Use Python3 when starting the HTTP server and add connection checks

### DIFF
--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -4,3 +4,4 @@ pytest-html
 paramiko
 python-lzo
 ubi-reader
+requests


### PR DESCRIPTION
We are getting connection refused error some times in the client
acceptance tests. It does not seem possible to reproduce locally.

With this checks we can see if the problem is in the server side or
maybe in the QEMU networking (forwarding 10.0.2.2 to the host).