### PR TITLE
Enable CI verification of Python formatting for acceptance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+include:
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-python3-format.yml'
+
+stages:
+  - test
+
+test:check-python3-formatting:
+  variables:
+      FORMAT_PYTHON3_DIRECTORIES: "tests/acceptance"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+	target-version = ['py38']


### PR DESCRIPTION
This adds a .gitlab-ci.yml file which includes the
'.gitlab-ci-check-python3-format.yml' file, which ensures that the python code
in the acceptance directory is formatted correctly.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>