### PR TITLE
mender-artifact: make it available in SDK

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
@@ -8,7 +8,7 @@ B = "${WORKDIR}/build"
 
 GOPATHDIR = "${B}/src/${GO_IMPORT}"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"
 
 do_compile() {
     # we could check out the sources at some destsuffix and use default


### PR DESCRIPTION
Add nativesdk to BBCLASSEXTEND to make the tool available as part of the
external SDK. This is useful when creating mender artifacts outside of
yocto build.

Signed-off-by: Bartosz Golaszewski <bgolaszewski@baylibre.com>