### PR TITLE
Set pytest version and fix warnings

### DIFF
--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -1,7 +1,7 @@
-pytest>=4.0
-fabric>=2.0
-pytest-html
-paramiko
-python-lzo
-ubi-reader
-requests
+pytest==5.3.2
+fabric==2.5.0
+pytest-html==2.0.1
+paramiko==2.7.1
+python-lzo==1.12
+ubi-reader==0.6.5
+requests==2.22.0

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -30,7 +30,7 @@ def extract_partition(img, number):
         if re.search("img%d" % number, line.decode()) is None:
             continue
 
-        match = re.match("\s*\S+\s+(\S+)\s+(\S+)", line.decode())
+        match = re.match(r"\s*\S+\s+(\S+)\s+(\S+)", line.decode())
         assert match is not None
         start = int(match.group(1))
         end = int(match.group(2)) + 1

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -252,7 +252,7 @@ class TestMenderArtifact:
         output = subprocess.check_output(["mender-artifact", "read", mender_image])
 
         match = re.search(
-            ".*name:\s+(?P<image>[a-z-.0-9]+).*\n.*size:\s+(?P<size>[0-9]+)",
+            r".*name:\s+(?P<image>[a-z-.0-9]+).*\n.*size:\s+(?P<size>[0-9]+)",
             output.decode(),
             flags=re.MULTILINE,
         )
@@ -265,7 +265,7 @@ class TestMenderArtifact:
         size_from_build = int(bitbake_variables["MENDER_CALC_ROOTFS_SIZE"]) * 1024
 
         print("matched:", gd)
-        if re.match(".*\.ubifs", gd["image"]):
+        if re.match(r".*\.ubifs", gd["image"]):
             # some filesystems (eg. ubifs) may use compression or empty space may
             # not be a part of the image, in which case the image will be smaller
             # or equal to MENDER_CALC_ROOTFS_SIZE
@@ -273,7 +273,7 @@ class TestMenderArtifact:
             # assume that the compressed image will be not less than 30% of
             # allocated rootfs size size
             assert size_from_artifact >= 0.3 * size_from_build
-        elif re.match(".*\.ext[234]", gd["image"]):
+        elif re.match(r".*\.ext[234]", gd["image"]):
             assert size_from_artifact == size_from_build
         else:
             pytest.skip("unsupported image artifact {}".format(gd["image"]))

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -38,7 +38,7 @@ class TestUbootAutomation:
         # approximately 1G, and that we can use half of the memory for that.
         with open("/proc/meminfo") as fd:
             for line in fd.readlines():
-                match = re.match("^MemTotal:\s+([0-9]+)\s*kB", line)
+                match = re.match(r"^MemTotal:\s+([0-9]+)\s*kB", line)
                 if match:
                     memory_kb = int(match.group(1))
                     break

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -106,9 +106,9 @@ class Helpers:
     @staticmethod
     def get_install_flag(connection):
         output = connection.run("mender --help 2>&1", warn=True).stdout
-        if re.search("^\s*install(\s|$)", output, flags=re.MULTILINE):
+        if re.search(r"^\s*install(\s|$)", output, flags=re.MULTILINE):
             return "install"
-        elif re.search("^\s*-install(\s|$)", output, flags=re.MULTILINE):
+        elif re.search(r"^\s*-install(\s|$)", output, flags=re.MULTILINE):
             return "-install"
         else:
             return "-rootfs"


### PR DESCRIPTION
```
commit d0087be0812aa5817b67ffec0eeb2a02fafebd0b
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Jan 20 14:12:00 2020 +0100

    Set pytest version to 5.3.2 and fix the rest of the dependencies
    
    The acceptance tests started failing on 18/01/2020 just after upstream
    release of latest pytest 5.3.3.
    
    The actual issue requires further investigation, but for now let's block
    the versions used for testing: setting pytest to 5.3.2 and the rest to
    the latest release.

commit a4f49639d2e3c7575025645b26bc5aaccd8cf101
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Jan 20 14:10:46 2020 +0100

    Get the rid of all warnings related to scape chars in regex
```