### PR TITLE
cherry-pick: grub-mender-grubenv: Fix broken debug-log PACKAGECONFIG.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -28,6 +28,7 @@ PACKAGECONFIG[debug-log] = ",,,"
 DEBUG_LOG_CATEGORY ?= "all"
 
 do_provide_debug_log() {
+    install -d ${B}
     echo "debug=${DEBUG_LOG_CATEGORY}" > ${B}/01_mender_debug_log_grub.cfg
 }
 python() {


### PR DESCRIPTION
Make sure the target directory exists when debug-log is enabled.

Changelog: Title
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
(cherry picked from commit a523cacf729a0dc6158709b15db06fc32b5643ca)