### PR TITLE
Fix failure in boot log when `MENDER_EXTRA_PARTS` is used.

### DIFF
--- a/meta-mender-core/classes/mender-full.bbclass
+++ b/meta-mender-core/classes/mender-full.bbclass
@@ -6,11 +6,13 @@ MENDER_FEATURES_ENABLE_append = " \
     ${_MENDER_IMAGE_TYPE_DEFAULT} \
     mender-install \
     mender-systemd \
-    mender-growfs-data \
+    ${_MENDER_GROWFS_DATA_DEFAULT} \
 "
 
 _MENDER_IMAGE_TYPE_DEFAULT ?= "mender-image-uefi"
 _MENDER_BOOTLOADER_DEFAULT ?= "mender-grub"
+
+_MENDER_GROWFS_DATA_DEFAULT ?= "${@'' if d.getVar('MENDER_EXTRA_PARTS') else 'mender-growfs-data'}"
 
 # Beaglebone reads the first VFAT partition and only understands MBR partition
 # table. Even though this is a slight violation of the UEFI spec, change to that


### PR DESCRIPTION
`mender-growfs-data` and `MENDER_EXTRA_PARTS` are mutually exclusive,
so set the default of `mender-growfs-data` to off if
`MENDER_EXTRA_PARTS` is being used.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>