### PR TITLE
mender-helpers: Don't rely on creating a hardlink ...

### DIFF
--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -323,7 +323,8 @@ mender_merge_bootfs_and_image_boot_files() {
                     bbfatal "$destfile already exists in boot partition. Please verify that packages do not put files in the boot partition that conflict with IMAGE_BOOT_FILES."
                 fi
             else
-                cp -l "$file" "$destfile"
+                # create a hardlink if possible (prerequisite: the paths are below the same mount point), do a normal copy otherwise
+                cp -l "$file" "$destfile" || cp "$file" "$destfile"
             fi
         done
     done


### PR DESCRIPTION
... in function mender_merge_bootfs_and_image_boot_files

While copying the image boot files, creating a hardlink only works if the
paths are below the same mountpoint.

Otherwise running the task do_image_sdimg results in the following error:
```
+ echo 'WARNING: /<TMPDIR>/work/<MACHINE>/<IMAGE>/1.0-r0/temp/run.do_image_sdimg.22140:1 exit 1 from '\''cp -l "$file" "$destfile"'\'''
WARNING: /<TMPDIR>/work/<MACHINE>/<IMAGE>/1.0-r0/temp/run.do_image_sdimg.22140:1 exit 1 from 'cp -l "$file" "$destfile"'
+ exit 1
ERROR: Function failed: do_image_sdimg (log file is located at /<TMPDIR>/work/<MACHINE>/<IMAGE>/1.0-r0/temp
```
A case where this happens is when DEPLOY_DIR (or DEPLOY_DIR_IMAGE) points
to a path which is on a different mount point than the WORKDIR.

Signed-off-by: Joerg Hofrichter <joerg.hofrichter@ni.com>