### PR TITLE
Improve warning when multiple DTB files are in KERNEL_DEVICETREE

### DIFF
--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -220,8 +220,8 @@ mender_get_clean_kernel_devicetree() {
     DTB_COUNT=$(echo "$MENDER_DTB_NAME" | wc -l)
 
     if [ "$DTB_COUNT" -ne 1 ]; then
-        bbwarn "Found more than one dtb specified in KERNEL_DEVICETREE. Only one should be specified. Choosing the last one."
         MENDER_DTB_NAME="$(echo "$MENDER_DTB_NAME" | tail -1)"
+        bbwarn "Found more than one dtb specified in KERNEL_DEVICETREE (${KERNEL_DEVICETREE}). Only one should be specified. Choosing the last one: ${MENDER_DTB_NAME}. Set KERNEL_DEVICETREE to the desired dtb file to silence this warning."
     fi
 
     # Now strip any subdirectories off.  Some kernel builds require KERNEL_DEVICETREE to be defined, for example,


### PR DESCRIPTION
Signed-off-by: Matthew Beckler <matthew@packetpower.com>
Changelog: Title

Hello, this is my first contribution to Mender. I ran into [MEN-2494](https://tracker.mender.io/browse/MEN-2494) and thought it might be a good first PR. Hope I followed the guidelines correctly.

Here's how the new warning appears when building for beaglebone:

`WARNING: u-boot-1_2019.01-r0 do_provide_mender_defines: Found more than one dtb specified in KERNEL_DEVICETREE (am335x-bone.dtb am335x-boneblack.dtb am335x-bonegreen.dtb). Only one should be specified. Choosing the last one: am335x-bonegreen.dtb. Set KERNEL_DEVICETREE to the desired dtb file to silence this warning.`