### PR TITLE
In demo mode, put demo certificate in same directory as Debian package.

### DIFF
--- a/meta-mender-core/recipes-mender/mender/mender.inc
+++ b/meta-mender-core/recipes-mender/mender/mender.inc
@@ -10,7 +10,7 @@ def cert_location_if_server_crt_in(src_uri, d):
     return ""
 
 MENDER_SERVER_URL ?= "https://docker.mender.io"
-MENDER_CERT_LOCATION ?= "${@cert_location_if_server_crt_in('${SRC_URI}', d)}"
+MENDER_CERT_LOCATION ??= "${@cert_location_if_server_crt_in('${SRC_URI}', d)}"
 # Tenant token
 MENDER_TENANT_TOKEN ?= "dummy"
 SYSTEMD_AUTO_ENABLE ?= "enable"
@@ -213,7 +213,8 @@ do_install() {
 
     #install server certificate
     if [ -f ${WORKDIR}/server.crt ]; then
-        install -m 0444 ${WORKDIR}/server.crt ${D}/${sysconfdir}/mender
+        install -m 0755 -d $(dirname ${D}${MENDER_CERT_LOCATION})
+        install -m 0444 ${WORKDIR}/server.crt ${D}${MENDER_CERT_LOCATION}
     fi
 
     install -d ${D}/${localstatedir}/lib/mender

--- a/meta-mender-demo/recipes-mender/mender/mender_%.bbappend
+++ b/meta-mender-demo/recipes-mender/mender/mender_%.bbappend
@@ -8,6 +8,11 @@ MENDER_RETRY_POLL_INTERVAL_SECONDS = "30"
 
 PACKAGECONFIG_append = " modules"
 
+MENDER_CERT_LOCATION ?= "${docdir}/mender-client/examples/demo.crt"
+# We need this because the certificate will automatically end up in the
+# mender-doc package when placed in ${docdir}.
+RDEPENDS_${PN}_append = " ${PN}-doc"
+
 do_compile_prepend() {
   bbwarn "You are building with the mender-demo layer, which is not intended for production use"
 }

--- a/tests/meta-mender-ci/recipes-testing/read-only-rootfs/mender_%.bbappend
+++ b/tests/meta-mender-ci/recipes-testing/read-only-rootfs/mender_%.bbappend
@@ -3,7 +3,7 @@ FILES_${PN} += "/data/etc/mender"
 do_install_append() {
     mkdir -p ${D}/data/etc/mender
     mv ${D}/etc/mender/mender.conf ${D}/data/etc/mender
-    mv ${D}/etc/mender/server.crt ${D}/data/etc/mender
+    mv ${D}${MENDER_CERT_LOCATION} ${D}/data/etc/mender/server.crt
     ln -s /data/etc/mender/mender.conf ${D}/etc/mender/mender.conf
-    ln -s /data/etc/mender/server.crt ${D}/etc/mender/server.crt 
+    ln -s /data/etc/mender/server.crt ${D}${MENDER_CERT_LOCATION}
 }


### PR DESCRIPTION
This fixes an issue with `mender setup`.

Changelog: Title

MEN-3048

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>