### PR TITLE
rpi: fix rootfs cmdline trailing space

### DIFF
--- a/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi-mender.inc
+++ b/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi-mender.inc
@@ -1,2 +1,2 @@
 CMDLINE_remove = "root=/dev/mmcblk0p2"
-CMDLINE_append = " root=\${mender_kernel_root}"
+CMDLINE_append = " root=\${mender_kernel_root} "


### PR DESCRIPTION
meta-mender removes `root=/dev/mmcblk0p2`, and then appends `root=\${mender_kernel_root}` (notice no trailing whitespace) to CMDLINE. However, when pitft feature is enabled, meta-raspberrypi additionally adds `fbcon=map:10 fbcon=font:VGA8x8` to cmdline.txt (refer [here](https://github.com/agherzan/meta-raspberrypi/blob/251a351fc328d30abcbdb054b9e6b3eb301feebb/recipes-kernel/linux/linux-raspberrypi.inc#L139))

This screws up CMDLINE (no space in-between `root` and `fbcon` arguments) when meta-mender is used with meta-raspberrypi with pitft enabled. The problem can be fixed in either `meta-raspberrypi` or `meta-mender`. So let me know your opinion :+1:  