### PR TITLE
Improve dependency logic to not require U-Boot unconditionally on ARM.

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -259,13 +259,12 @@ _MENDER_PART_IMAGE_DEPENDS += "${@bb.utils.contains('MENDER_DATA_PART_FSTYPE', '
 
 # This is needed because by default 'mender-grub' feature is used on ARM, but
 # it still uses U-boot as an EFI provider/launcher and requires it to be
-# present. We can not add this to '_append_mender-grub' because this is also
-# used by x86 based devices which normally do not use U-boot.
+# present.
 #
 # This assumes that U-boot is used on ARM, this could become problematic
 # if we add support for other bootloaders on ARM, e.g Barebox.
-_MENDER_PART_IMAGE_DEPENDS_append_arm =     " u-boot:do_deploy"
-_MENDER_PART_IMAGE_DEPENDS_append_aarch64 = " u-boot:do_deploy"
+_MENDER_PART_IMAGE_DEPENDS_append_mender-grub_arm =     " u-boot:do_deploy"
+_MENDER_PART_IMAGE_DEPENDS_append_mender-grub_aarch64 = " u-boot:do_deploy"
 
 _MENDER_PART_IMAGE_DEPENDS_append_mender-uboot = " u-boot:do_deploy"
 _MENDER_PART_IMAGE_DEPENDS_append_mender-grub = " grub-efi:do_deploy"


### PR DESCRIPTION
This will help when not using `mender-grub`, and instead using
Barebox, for example.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>