### PR TITLE
Add recipes for Mender 2.3.0 and 2.2.2 releases

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.3.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.3.0.bb
@@ -10,12 +10,12 @@ require mender-artifact.inc
 
 SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.3.x"
 
-# Tag: 3.3.0b1
+# Tag: 3.3.0
 SRCREV = "b17a7a34da5be5c1e06fd139d94fca7d56b855cb"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 

--- a/meta-mender-core/recipes-mender/mender/mender_2.1.3.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_2.1.3.bb
@@ -1,0 +1,28 @@
+require mender.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.1.x"
+
+# Tag: 2.1.3
+SRCREV = "a5f5f1622b18327508bae7880f7e2cd5e6b03bc1"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=1c872e33af7af0e7ee99e17f38dbcffc"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
+
+DEPENDS += "xz"
+RDEPENDS_${PN} += "liblzma"

--- a/meta-mender-core/recipes-mender/mender/mender_2.2.0.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_2.2.0.bb
@@ -10,18 +10,18 @@ require mender.inc
 
 SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.2.x"
 
-# Tag: 2.2.0b1
-SRCREV = "4084710e43cded556a5e7c1d01874f3ce51b0e8b"
+# Tag: 2.2.0
+SRCREV = "44753ca67caba0deea203a7b9d7785c71a0c05b4"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=b73c5755173fade5704dbf3f4f546e6c"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=80ba3790b689991e47685da401fd3375"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
 
 DEPENDS += "xz"


### PR DESCRIPTION
- Add mender 2.2.0 recipe and remove beta
- Add mender-artifact 3.3.0 recipe and remove beta
- Add mender 2.1.3 recipe