### PR TITLE
Fix: Older versions of the client built from source has the old name

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
@@ -9,5 +9,22 @@ def mender_version_of_this_recipe(d, srcpv):
         return version
 PV = "${@mender_version_of_this_recipe(d, '${SRCPV}')}"
 
+
+# If building from 'externalsrc' with client version
+# 2.1.x, 2.2.x, or 2.3.x, the systemd service file is
+# still called 'mender' with no client extension.
+def mender_client_service_name(d, srcpv):
+    version = mender_version_from_preferred_version(d, srcpv)
+    if version.startswith("2.1"):
+        return "mender"
+    elif version.startswith("2.2"):
+        return "mender"
+    elif version.startswidth("2.3"):
+        return "mender"
+    return "mender-client"
+
+
+
+
 # MEN-2948: systemd service for the client is now named mender-client.service
-MENDER_CLIENT="mender-client"
+MENDER_CLIENT="${@mender_client_service_name(d, '${SRCPV}')}"


### PR DESCRIPTION
This fixes the issue where if making a change to one of the released
clients (i.e., 2.1.x, 2.2.x, 2.3.x), which still has the systemd service named
mender, with no client suffix, the mender-client_git recipe would return the
'mender-client' service file name. Which was wrong.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>