### PR TITLE
Revert to "mender.service" when building Git versions < 2.2.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
@@ -9,5 +9,12 @@ def mender_version_of_this_recipe(d, srcpv):
         return version
 PV = "${@mender_version_of_this_recipe(d, '${SRCPV}')}"
 
-# MEN-2948: systemd service for the client is now named mender-client.service
-MENDER_CLIENT="mender-client"
+# MEN-2948: systemd service for the client is now named mender-client.service,
+# but it was called mender.service in 2.2 and earlier.
+def mender_client_name(d):
+    if d.getVar("PV")[0:4] in ["2.0.", "2.1.", "2.2."]:
+        return "mender"
+    else:
+        return "mender-client"
+
+MENDER_CLIENT="${@mender_client_name(d)}"


### PR DESCRIPTION
The new "mender-client.service" will not exist for those versions.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>