### PR TITLE
MEN-3263: Explicitly add liblzma to RDEPENDS

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.0.1.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.0.1.bb
@@ -12,7 +12,7 @@ COMPATIBLE_HOSTS = "arm|aarch64|x86_64"
 # "lsb-ld" is needed because Yocto by default does not provide a cross platform
 # dynamic linker. On x86_64 this manifests as a missing
 # `/lib64/ld-linux-x86-64.so.2`
-RDEPENDS_${PN} = "lsb-ld xz"
+RDEPENDS_${PN} = "lsb-ld xz liblzma"
 
 FILES_${PN} = " \
     ${sysconfdir}/mender/mender-binary-delta.conf \


### PR DESCRIPTION
From the Yocto Manual changes to zeus:

``` The file-rdeps runtime dependency check no longer expands RDEPENDS
recursively as there is no mechanism to ensure they can be fully computed, and
thus races sometimes result in errors either showing up or not. Thus, you might
now see errors for missing runtime dependencies that were previously satisfied
recursively. Here is an example: package A contains a shell script starting with
B, which does depend on bash. You need to add the missing dependency or
dependencies to resolve the warning.
```

Which is what did bite us this time, as the `xz` dependency did resolve it
recursively previously.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>