### PR TITLE
Amend test_too_big_image_update to accept both stdout/stderr

### DIFF
--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -267,10 +267,15 @@ class TestUpdates:
             output = connection.run(
                 "mender %s /var/tmp/image-too-big.mender ; echo 'ret_code=$?'"
                 % install_flag
-            ).stderr
+            )
 
-            assert "no space left on device" in output, output
-            assert "ret_code=0" not in output, output
+            assert any(
+                [
+                    "no space left on device" in out
+                    for out in [output.stderr, output.stdout]
+                ]
+            ), output
+            assert "ret_code=0" not in output.stdout, output
 
         finally:
             # Cleanup.


### PR DESCRIPTION
Commit cd5c489 made this test strictly not compatible with older mender
releases (where the logger still used stdout).

Furthermore, the commit introduced an error in the second assert, as the
"ret_code=0" will not be seen in stderr in any case.

See #942 