### PR TITLE
raspberrypi: add state script to update boot firmware

### DIFF
--- a/meta-mender-raspberrypi/classes/rpi-update-firmware.bbclass
+++ b/meta-mender-raspberrypi/classes/rpi-update-firmware.bbclass
@@ -1,0 +1,16 @@
+rpi_install_firmware_to_rootfs() {
+    install -d ${IMAGE_ROOTFS}/boot/firmware/overlays
+
+    cp ${DEPLOY_DIR_IMAGE}/bcm2835-bootfiles/* ${IMAGE_ROOTFS}/boot/firmware/
+
+    # To exclude files such as bcm2710-rpi-3-b-1-4.19.88+git0+988cc7beac-r0-raspberrypi3-20200323173633.dtb
+    # as only the link names are actually valid and searched for on the device.
+    find ${DEPLOY_DIR_IMAGE}/ -type l \( -iname "*.dtb" \) -exec cp {} ${IMAGE_ROOTFS}/boot/firmware/ \;
+    find ${DEPLOY_DIR_IMAGE}/ -type l \( -iname "*.dtbo" \) -exec cp {} ${IMAGE_ROOTFS}/boot/firmware/overlays/ \;
+
+    cp ${DEPLOY_DIR_IMAGE}/u-boot.bin ${IMAGE_ROOTFS}/boot/firmware/${SDIMG_KERNELIMAGE}
+    cp ${DEPLOY_DIR_IMAGE}/boot.scr ${IMAGE_ROOTFS}/boot/firmware/
+}
+ROOTFS_POSTPROCESS_COMMAND += "rpi_install_firmware_to_rootfs; "
+
+IMAGE_INSTALL_append = " update-firmware-state-script"

--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+function trap_exit() {
+  umount --lazy /mnt/inactive_part
+}
+trap trap_exit EXIT
+
+MENDER_ROOTFS_PART_A="@@MENDER_ROOTFS_PART_A@@"
+MENDER_ROOTFS_PART_B="@@MENDER_ROOTFS_PART_B@@"
+
+if mount | grep ${MENDER_ROOTFS_PART_A}; then
+  inactive_part="${MENDER_ROOTFS_PART_B}"
+else
+  inactive_part="${MENDER_ROOTFS_PART_A}"
+fi
+
+mkdir -p /mnt/inactive_part
+mount -o ro ${inactive_part} /mnt/inactive_part
+
+# These are dangerous operations and if they fail (partial copy) it might
+# render the device unusable.
+
+# Copy 'core' firmware files first
+find /mnt/inactive_part/boot/firmware/ -maxdepth 1 -type f | xargs -I {} cp -v {} /uboot/
+
+# Synchronize before trying to copy the rest of the files
+sync
+
+# Copy overlays
+find /mnt/inactive_part/boot/firmware/overlays/ -maxdepth 1 -type f | xargs -I {} cp -v {} /uboot/overlays/
+
+# Synchronize to ensure all files are written before leaving the ArtifactInstall state
+sync
+
+
+exit 0

--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/update-firmware-state-script.bb
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/update-firmware-state-script.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Mender state-script to update firmware files on Raspberry Pi boards"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit mender-state-scripts
+
+SRC_URI = "file://ArtifactInstall_Leave_50.in"
+
+do_deploy() {
+    sed -e 's#@@MENDER_ROOTFS_PART_A@@#'"${MENDER_ROOTFS_PART_A}"'#' \
+        -e 's#@@MENDER_ROOTFS_PART_B@@#'"${MENDER_ROOTFS_PART_B}"'#' \
+        "${WORKDIR}/ArtifactInstall_Leave_50.in" > "${WORKDIR}/ArtifactInstall_Leave_50"
+    cp ${WORKDIR}/ArtifactInstall_Leave_50 ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_50
+}
+
+ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Raspberry Pi boards have a set of boot firmware files that are
located on the vfat boot part, and these files are normally not updated
when you perform an update of the root filesystem.

Occasionally there will be changes to the Raspberry Pi software stack
that requires that these files are update. Typically there is something
in the Linux kernel that requires something that is in the boot
firmware. This means that to update the Linux kernel you must also
update the boot firmware files.

Above is really sub-optimal design of the Raspberry Pi boards but a
limitation that we must live with.

Note that the DTB files are also part of "boot firmware" and included in
the state script update.

The provided state-script can be enabled by adding the following to e.g
local.conf:

    INHERIT += "rpi-update-firmware"

The ArtifactInstall_Leave_50 script can be overriden to customize what
files to update, e.g only DTB files. By default all files on the boot
part will be updated including config.txt and cmdline.txt.

Changelog: Add state-script that can be enabled to update RPi boot firmware files

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>