### PR TITLE
Update to new grub-mender-grubenv SHA.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
@@ -2,7 +2,7 @@ include grub-mender-grubenv.inc
 
 SRC_URI = "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master"
 
-SRCREV = "b33bb7685454345f8f80da27b7447bdc59e9db55"
+SRCREV = "9eca26e023ee181b2ab49b6e4d407a6cce232c90"
 PV = "1.3.0+git${SRCREV}"
 
 LICENSE = "Apache-2.0"

--- a/meta-mender-core/recipes-mender/mender-client-migrate-configuration/mender-client-migrate-configuration.bb
+++ b/meta-mender-core/recipes-mender/mender-client-migrate-configuration/mender-client-migrate-configuration.bb
@@ -14,7 +14,7 @@ ALLOW_EMPTY_${PN} = "1"
 
 RDEPENDS_${PN} += "jq"
 
-DEPENDS += "mender"
+DEPENDS += "mender-client"
 
 do_check_split_conf() {
     if [ -f ${STAGING_DIR_TARGET}/data/mender/mender.conf ]; then


### PR DESCRIPTION
Changelog: grubenv: Handle debug command prompt when running as EFI
app.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>