### PR TITLE
MEN-3345: Merge Artifact depends i4

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -81,7 +81,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "35d2db42eadb67a437a408f4bdaa5034",
+                   "md5": "9a5ed6f3796665f5faff24f2bd3519cc",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"


### PR DESCRIPTION
Checksum update for mender-artifact dependency in mender.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>