### PR TITLE
MEN-3366: write GPT partition table before resize of data part

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -50,7 +50,7 @@ FILES_${PN} += "${systemd_unitdir}/system/${MENDER_CLIENT}.service \
 SYSROOT_DIRS += "/data"
 
 SRC_URI_append_mender-image_mender-systemd = " file://mender-client-data-dir.service"
-                                               
+
 SRC_URI_append_mender-persist-systemd-machine-id = " file://mender-client-systemd-machine-id.service \
                                                      file://mender-client-set-systemd-machine-id.sh"
 FILES_${PN}_append_mender-image_mender-systemd = " ${systemd_unitdir}/system/${MENDER_CLIENT}-data-dir.service \
@@ -277,6 +277,7 @@ Before=systemd-growfs@data.service
 Type=oneshot
 User=root
 Group=root
+ExecStartPre=/bin/sh -c '/bin/echo "w" | /sbin/fdisk ${MENDER_STORAGE_DEVICE}'
 ExecStart=/usr/sbin/parted -s ${MENDER_STORAGE_DEVICE} resizepart ${MENDER_DATA_PART_NUMBER} 100%
 
 [Install]


### PR DESCRIPTION
It seems that the following command fails:

    /usr/sbin/parted -s /dev/mmcblk0 resizepart 4 100%

if GPT PMBR is not present, e.g

    # fdisk -l /dev/sda
    GPT PMBR size mismatch (8388607 != 125045423) will be corrected by write.
    The backup GPT table is not on the end of the device. This problem will be corrected by write.
    Disk /dev/sda: 59.6 GiB, 64023257088 bytes, 125045424 sectors
    Units: sectors of 1 * 512 = 512 bytes
    Sector size (logical/physical): 512 bytes / 512 bytes
    I/O size (minimum/optimal): 512 bytes / 512 bytes
    Disklabel type: gpt
    Disk identifier: 4024D69C-D9FD-4BBD-9625-4B10975CD498

    Device       Start     End Sectors  Size Type
    /dev/sda1    16384   49151   32768   16M EFI System
    /dev/sda2    49152 4079615 4030464  1.9G Linux filesystem
    /dev/sda3  4079616 8110079 4030464  1.9G Linux filesystem
    /dev/sda4  8110080 8372223  262144  128M Linux filesystem

By performing an write with fdisk, we make sure that the backup
GPT table is written prior to trying to execute the resize
operation on the data partition.

Changelog: Title

Signed-off-by: Mirza Krak <mirza@maneoz.tech>