### PR TITLE
raspberrypi: busybox compatibility for boot firmware state script

### DIFF
--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
@@ -3,7 +3,7 @@
 set -e
 
 function trap_exit() {
-  umount --lazy /mnt/inactive_part
+  umount -l /mnt/inactive_part
 }
 trap trap_exit EXIT
 


### PR DESCRIPTION
The ArtifactInstall_Leave_50 state script fails on busybox systems because umount does not understand the long `--lazy` flag :

> stderr collected while running script /var/lib/mender/scripts/ArtifactInstall_Leave_50 [umount: unrecognized option '--lazy'\nBusyBox v1.27.2 (2018-12-03 18:22:35 UTC) multi-call binary.\n\nUsage: umount [OPTIONS] FILESYSTEM|DIRECTORY\n]" module=executor

The short `-l` flag is useable with both util-linux and busybox versions of umount.
