### PR TITLE
[tests] Create coverage dir before calling scp

### DIFF
--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import time
 import errno
+from pathlib import Path
 
 from paramiko.client import WarningPolicy
 from common import *
@@ -133,6 +134,7 @@ def setup_qemu(request, build_dir, conn):
                 manual_uboot_commit(conn)
                 # Collect the coverage files from /data/mender/ if present
                 try:
+                    Path("coverage").mkdir(exist_ok=True)
                     conn.run("ls /data/mender/cover*")
                     get_no_sftp("/data/mender/cover*", conn, local="coverage")
                 except:


### PR DESCRIPTION
Otherwise all remote reports get copied to the same local file
named "coverage", overriding it every time.