### PR TITLE
chore(checksum): Update the Mender Artifact master checksum

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -66,7 +66,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "59f508b8bf80a43478109133032530b7",
+                   "md5": "d1fedd6e15ea779ce58fafea700f0c37",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_ARTIFACT_BRANCH'))['md5']}"


### PR DESCRIPTION
This is needed to go along with PR:

https://github.com/mendersoftware/mender-artifact/pull/268

Which adds multiple new entries to the LIC_FILES_CHKSUM.sha256 file as a result
of upgrading dependencies, and moving to go modules.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>