### PR TITLE
MEN-3477: Start downloading grub-efi from grub-mender-grubenv URLs.

### DIFF
--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,0 +1,7 @@
+GRUB_MENDER_GRUBENV_REV = "6ffc280e64dd7b6bbc52f7747609f11fbdd1a057"
+GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
+
+GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \
+                efi_gop iso9660 configfile search loadenv test \
+                cat echo gcry_sha256 halt hashsum sleep reboot regexp \
+                loadenv test"

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -1,6 +1,7 @@
 inherit mender-helpers
 require conf/image-uefi.conf
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', 'user-key-store', '', d)}
+inherit grub-mender-grubenv
 
 RPROVIDES_${PN} += "virtual/grub-bootconf"
 

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
@@ -1,9 +1,9 @@
 include grub-mender-grubenv.inc
 
-SRC_URI = "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master"
+SRC_URI = "${GRUB_MENDER_GRUBENV_SRC_URI}"
 
-SRCREV = "9eca26e023ee181b2ab49b6e4d407a6cce232c90"
+SRCREV = "${GRUB_MENDER_GRUBENV_REV}"
 PV = "1.3.0+git${SRCREV}"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=a63d325b69180ec25a59e045c06ec468"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"


### PR DESCRIPTION
The URLs include the revision SHA of grub-mender-grubenv as well as
the version of GRUB, which means we can get a stable checksum instead
of a constantly changing one.

Also standardize on some things that are shared between the
grub-efi-mender-precompiled and grub-mender-grubenv recipes, such as
URIs, revisions and the GRUB module list. We also check that the GRUB
module list defined in Yocto is the same as the one used to compile
the binaries.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>