### PR TITLE
grub-mender-grubenv: Remove kernel_devicetree.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -73,13 +73,6 @@ mender_rootfsa_uuid=$mender_rootfsa_uuid
 mender_rootfsb_uuid=$mender_rootfsb_uuid
 EOF
     fi
-
-    if [ -n "${KERNEL_DEVICETREE}" ]; then
-        MENDER_DTB_NAME=$(mender_get_clean_kernel_devicetree)
-        cat >> ${B}/mender_grubenv_defines <<EOF
-kernel_devicetree=$MENDER_DTB_NAME
-EOF
-    fi
 }
 
 do_compile() {


### PR DESCRIPTION
The only way to use GRUB 2.04 on ARM is via UEFI, and the
kernel_devicetree information is not used when loading via UEFI,
instead it is queried directly from the UEFI provider.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>