### PR TITLE
Add OpenSSL as dependency for Git versions of the Mender client.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -22,7 +22,7 @@ S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 inherit go
-
+inherit pkgconfig
 inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "${MENDER_CLIENT}.service"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -1,7 +1,7 @@
 require mender-client.inc
 
-DEPENDS = "xz"
-RDEPENDS_${PN} = "liblzma"
+DEPENDS = "xz openssl"
+RDEPENDS_${PN} = "liblzma openssl"
 
 # The revision listed below is not really important, it's just a way to avoid
 # network probing during parsing if we are not gonna build the git version

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -81,7 +81,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "3e7426c258f60f9876ae3746f54c49d4",
+                   "md5": "7c2fdcfc8c08d9a2a4479be09237c5e4",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"


### PR DESCRIPTION
This actually adds an unnecessary dependency when using Git SHAs for
older versions of Mender, but this should be harmless, and it won't
affect production recipes.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

