### PR TITLE
[acceptance tests] Do not create empty "coverage" dir

### DIFF
--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -134,8 +134,8 @@ def setup_qemu(request, build_dir, conn):
                 manual_uboot_commit(conn)
                 # Collect the coverage files from /data/mender/ if present
                 try:
-                    Path("coverage").mkdir(exist_ok=True)
                     conn.run("ls /data/mender/cover*")
+                    Path("coverage").mkdir(exist_ok=True)
                     get_no_sftp("/data/mender/cover*", conn, local="coverage")
                 except:
                     pass


### PR DESCRIPTION
It the target did not generate coverage reports, skip creating locally a
"coverage" dir so that the CI does not expect files there.