### PR TITLE
Warrior updates for 2.4.0b1 Mender Product release

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -1,0 +1,50 @@
+LICENSE = "CLOSED"
+LICENSE_FLAGS = "commercial"
+
+SUB_FOLDER_arm = "arm"
+SUB_FOLDER_aarch64 = "aarch64"
+SUB_FOLDER_x86-64 = "x86_64"
+
+SRC_URI = "file://${SUB_FOLDER}/mender-binary-delta"
+
+COMPATIBLE_HOSTS = "arm|aarch64|x86_64"
+
+# "lsb" is needed because Yocto by default does not provide a cross platform
+# dynamic linker. On x86_64 this manifests as a missing
+# `/lib64/ld-linux-x86-64.so.2`
+RDEPENDS_${PN} = "lsb xz"
+
+FILES_${PN} = " \
+    ${sysconfdir}/mender/mender-binary-delta.conf \
+    ${datadir}/mender/modules/v3/mender-binary-delta \
+"
+
+INSANE_SKIP_${PN} = "already-stripped"
+
+do_version_check() {
+    cp ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${WORKDIR}/
+
+    if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
+        bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+    fi
+}
+addtask do_version_check after do_patch before do_install
+
+do_configure() {
+    # We need the sed operation because bitbake misinterprets the JSON closing
+    # brace as end of function, unless we put spaces in front of it.
+    sed -e 's/^ //' <<EOF | cat > ${WORKDIR}/mender-binary-delta.conf
+ {
+   "RootfsPartA": "${MENDER_ROOTFS_PART_A}",
+   "RootfsPartB": "${MENDER_ROOTFS_PART_B}"
+ }
+EOF
+}
+
+do_install() {
+    install -d -m 755 ${D}${datadir}/mender/modules/v3
+    install -m 755 ${WORKDIR}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
+
+    install -d -m 755 ${D}${sysconfdir}/mender
+    install -m 644 ${WORKDIR}/mender-binary-delta.conf ${D}${sysconfdir}/mender/mender-binary-delta.conf
+}

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.0.1.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.0.1.bb
@@ -1,50 +1,5 @@
-LICENSE = "CLOSED"
-LICENSE_FLAGS = "commercial"
+include mender-binary-delta.inc
 
-SUB_FOLDER_arm = "arm"
-SUB_FOLDER_aarch64 = "aarch64"
-SUB_FOLDER_x86-64 = "x86_64"
-
-SRC_URI = "file://${SUB_FOLDER}/mender-binary-delta"
-
-COMPATIBLE_HOSTS = "arm|aarch64|x86_64"
-
-# "lsb" is needed because Yocto by default does not provide a cross platform
-# dynamic linker. On x86_64 this manifests as a missing
-# `/lib64/ld-linux-x86-64.so.2`
-RDEPENDS_${PN} = "lsb xz"
-
-FILES_${PN} = " \
-    ${sysconfdir}/mender/mender-binary-delta.conf \
-    ${datadir}/mender/modules/v3/mender-binary-delta \
-"
-
-INSANE_SKIP_${PN} = "already-stripped"
-
-do_version_check() {
-    cp ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${WORKDIR}/
-
-    if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
-        bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
-    fi
-}
-addtask do_version_check after do_patch before do_install
-
-do_configure() {
-    # We need the sed operation because bitbake misinterprets the JSON closing
-    # brace as end of function, unless we put spaces in front of it.
-    sed -e 's/^ //' <<EOF | cat > ${WORKDIR}/mender-binary-delta.conf
- {
-   "RootfsPartA": "${MENDER_ROOTFS_PART_A}",
-   "RootfsPartB": "${MENDER_ROOTFS_PART_B}"
- }
-EOF
-}
-
-do_install() {
-    install -d -m 755 ${D}${datadir}/mender/modules/v3
-    install -m 755 ${WORKDIR}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
-
-    install -d -m 755 ${D}${sysconfdir}/mender
-    install -m 644 ${WORKDIR}/mender-binary-delta.conf ${D}${sysconfdir}/mender/mender-binary-delta.conf
-}
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.1.0b1.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.1.0b1.bb
@@ -2,4 +2,4 @@ include mender-binary-delta.inc
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-#DEFAULT_PREFERENCE = "-1"
+DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.4.0b1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.4.0b1.bb
@@ -1,0 +1,25 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.4.x"
+
+# Tag: 3.4.0b1
+SRCREV = "b2c230e73b0e7c90d23ce03caedaec42728fa3f3"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=d1fedd6e15ea779ce58fafea700f0c37"
+
+DEPENDS += "xz"

--- a/meta-mender-core/recipes-mender/mender/mender_2.3.0b1.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_2.3.0b1.bb
@@ -1,0 +1,28 @@
+require mender.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.3.x"
+
+# Tag: 2.3.0b1
+SRCREV = "a78b45e240f9daf3ff47625ae66d97c3f2e33cad"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=3e7426c258f60f9876ae3746f54c49d4"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
+
+DEPENDS += "xz"
+RDEPENDS_${PN} += "liblzma"

--- a/meta-mender-core/recipes-mender/mender/mender_git.inc
+++ b/meta-mender-core/recipes-mender/mender/mender_git.inc
@@ -86,7 +86,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "b1da44667dbb062ba9be70bf325c289c",
+                   "md5": "8d8db5d0360726693734831387ccf0fd",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"


### PR DESCRIPTION
This contains some notable differences from #998, namely that all the references to "mender-client" have been reverted to "mender", since this is the name which is used on warrior.