### PR TITLE
uboot_auto_configure: build U-Boot the same way Yocto does

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
@@ -4,7 +4,7 @@ set -e
 
 BUILD_AR="${BUILD_AR:-ar}"
 BUILD_CC="${BUILD_CC:-gcc}"
-CC=${CC:-${CROSS_COMPILE}gcc}
+CC="${CROSS_COMPILE}gcc"
 MAKE="${MAKE:-make}"
 MAKEFLAGS="${MAKEFLAGS:-}"
 MAYBE_UBI=

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -340,6 +340,7 @@ do_mender_uboot_auto_configure() {
 
     env \
         BUILDCC="${BUILD_CC}" \
+        CROSS_COMPILE="${TARGET_PREFIX}" \
         ./uboot_auto_configure.sh \
         --config=$MENDER_UBOOT_MACHINE \
         --src-dir=${S} \


### PR DESCRIPTION
The uboot_auto_configure.sh script uses the cross compiler to build
cmd/version.o from the U-Boot sources so it can generate a list of files to
patch. However, this will fail if the target board (and therefore the target
toolchain) uses floating point flags (e.g. armv5tehf-vfp) since U-Boot is not
meant to be built with floating-point.

The Yocto recipes invoke the cross toolchain when building U-Boot in a way
so that any floating-point build flags are not passed to the build. Tweak
the way the cross toolchain is invoked by following the way Yocto invokes
it.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>