### PR TITLE
tests: Fix U-Boot compile test not running for pull requests.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
@@ -4,7 +4,7 @@ set -e
 
 BUILD_AR="${BUILD_AR:-ar}"
 BUILD_CC="${BUILD_CC:-gcc}"
-CC=${CC:-${CROSS_COMPILE}gcc}
+CC="${CROSS_COMPILE}gcc"
 MAKE="${MAKE:-make}"
 MAKEFLAGS="${MAKEFLAGS:-}"
 MAYBE_UBI=

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -340,6 +340,7 @@ do_mender_uboot_auto_configure() {
 
     env \
         BUILDCC="${BUILD_CC}" \
+        CROSS_COMPILE="${TARGET_PREFIX}" \
         ./uboot_auto_configure.sh \
         --config=$MENDER_UBOOT_MACHINE \
         --src-dir=${S} \

--- a/tests/acceptance/files/Makefile.test_uboot_automation
+++ b/tests/acceptance/files/Makefile.test_uboot_automation
@@ -16,6 +16,7 @@ $(BOARD_LOGS): $(LOGS)
 # Do the auto configuration for each board and make a log. Failure is not
 # recorded in the return code, but in the log instead.
 $(LOGS)/%_defconfig:
+	echo "Starting `basename $@` compile test at `date`"
 	if [ -z "$(TESTS_DIR)" -o -z "$(UBOOT_SRC)" ]; then \
 		echo "Not all variables are set"; \
 		exit 1; \
@@ -47,3 +48,5 @@ $(LOGS)/%_defconfig:
 		|| ( echo AutoPatchFailed >> $@ )
 
 	rm -rf "$(TMP)/`basename $@`"
+
+	echo "Finished `basename $@` compile test at `date`"

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -112,7 +112,7 @@ class TestUbootAutomation:
                 (
                     "git log -n1 --format=%%H --after=%d.days.ago HEAD -- "
                     + (
-                        "recipes-bsp/u-boot"
+                        "meta-mender-core/recipes-bsp/u-boot"
                         + " tests/acceptance/test_uboot_automation.py"
                         + " tests/acceptance/files/Makefile.test_uboot_automation"
                     )
@@ -165,8 +165,10 @@ class TestUbootAutomation:
         )
         is_upstream = False
         for branch in contained_in:
-            if branch.startswith("%s/" % upstream_remote) and not branch.startswith(
-                "%s/pull/" % upstream_remote
+            if (
+                branch.startswith("%s/" % upstream_remote)
+                and not branch.startswith("%s/pull/" % upstream_remote)
+                and not branch.startswith("%s/pr_" % upstream_remote)
             ):
                 is_upstream = True
                 break


### PR DESCRIPTION
```
    We need to adapt the conditions for Gitlab, which uses "pr_*" branches
    instead of "pull/*" branches. The conditions need to figure out that
    this is a pull request, and it should therefore run the tests. This
    has been broken for a while, but due to the timestamp condition, in
    most cases it still works. However for PRs that are tested more than a
    week after their commit date, the test may be erronously skipped.
    
    In addition, the path to the U-Boot recipe directory has also been
    wrong for a long time, causing only test fixes to be picked up, not
    recipe fixes.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```

In addition #1008 is also included.