### PR TITLE
MEN-3676: Add acceptance test for syslog functionality.

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -66,7 +66,7 @@ mender_update_fstab_file() {
 }
 
 def mender_default_state_scripts_version(d):
-    pref_mender = d.getVar('PREFERRED_VERSION_pn-mender')
+    pref_mender = d.getVar('PREFERRED_VERSION_pn-mender-client')
     if pref_mender and pref_mender.startswith("1."):
         return "2"
     else:

--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -346,7 +346,7 @@ def build_image_fn(request, prepared_test_build_base, bitbake_image):
             prepared_test_build_base["bitbake_corebase"],
             bitbake_image,
             [
-                'SYSTEMD_AUTO_ENABLE_pn-mender = "disable"',
+                'SYSTEMD_AUTO_ENABLE_pn-mender-client = "disable"',
                 'EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh"',
             ],
         )

--- a/tests/acceptance/test_os_integration.py
+++ b/tests/acceptance/test_os_integration.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+# Copyright 2020 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import pytest
+import time
+
+from common import *
+from helpers import Helpers
+
+
+class TestOsIntegration:
+    @pytest.mark.min_mender_version("2.2.1")
+    def test_syslogger(self, setup_board, connection):
+        """Test that we log to syslog, and that we don't if we specify --no-syslog."""
+
+        def is_mender_in_syslog_messages():
+            now = time.time()
+            while time.time() < now + 60:
+                # Busybox syslog puts messages in /var/log/messages, whereas
+                # syslogd puts them in /var/log/syslog.
+                ret = connection.run(
+                    r"egrep 'mender\[[0-9]+\]:' /var/log/messages /var/log/syslog",
+                    warn=True,
+                )
+                if ret.stdout.strip() != "":
+                    return True
+                time.sleep(5)
+            return False
+
+        connection.run("rm -f /var/log/messages /var/log/syslog")
+        connection.run("systemctl restart syslog")
+        ret = connection.run("mender daemon >& /dev/null & echo $!")
+        pid = ret.stdout.strip()
+        try:
+            assert (
+                is_mender_in_syslog_messages()
+            ), "Could not find mender output in syslog."
+        finally:
+            connection.run("kill -9 %s" % pid)
+
+        # Now try with --no-syslog flag
+        connection.run("rm -f /var/log/messages /var/log/syslog")
+        connection.run("systemctl restart syslog")
+        ret = connection.run("mender --no-syslog daemon >& /dev/null & echo $!")
+        pid = ret.stdout.strip()
+        try:
+            assert not is_mender_in_syslog_messages(), "Found mender output in syslog."
+        finally:
+            connection.run("kill -9 %s" % pid)

--- a/tests/build-conf/beagleboneblack/local.conf
+++ b/tests/build-conf/beagleboneblack/local.conf
@@ -247,4 +247,4 @@ CONF_VERSION = "1"
 INHERIT += "externalsrc"
 # Final variable will be written by Jenkins recipe, since it contains an
 # environment variable (bitbake cannot accept those directly).
-#EXTERNALSRC_pn-mender = "${WORKSPACE}/mender"
+#EXTERNALSRC_pn-mender-client = "${WORKSPACE}/mender"


### PR DESCRIPTION
```
commit 1c2c2d165383e76a6335baa41144bc4479fe8e6a
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 15:30:58 2020

    MEN-3676: Add acceptance test for syslog functionality.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 8c46643d0f7c7b1be2aa53aac505ecf133bdccfd
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 15:29:23 2020

    Fix a few missing renames from "mender" to "mender-client".
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```