### PR TITLE
U-Boot compile test fixes

### DIFF
--- a/tests/acceptance/files/Makefile.test_uboot_automation
+++ b/tests/acceptance/files/Makefile.test_uboot_automation
@@ -16,6 +16,7 @@ $(BOARD_LOGS): $(LOGS)
 # Do the auto configuration for each board and make a log. Failure is not
 # recorded in the return code, but in the log instead.
 $(LOGS)/%_defconfig:
+	echo "Starting `basename $@` compile test at `date`"
 	if [ -z "$(TESTS_DIR)" -o -z "$(UBOOT_SRC)" ]; then \
 		echo "Not all variables are set"; \
 		exit 1; \
@@ -47,3 +48,5 @@ $(LOGS)/%_defconfig:
 		|| ( echo AutoPatchFailed >> $@ )
 
 	rm -rf "$(TMP)/`basename $@`"
+
+	echo "Finished `basename $@` compile test at `date`"

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -198,7 +198,9 @@ class TestUbootAutomation:
         print("Checking whether %s is an ARM board..." % config)
         subprocess.check_call("${MAKE:-make} %s" % config, cwd=srcdir, shell=True)
         with open(os.path.join(srcdir, ".config")) as fd:
-            is_arm = "CONFIG_ARM=y\n" in fd.read()
+            content = fd.read()
+            # No ARM64 support at the moment.
+            is_arm = "CONFIG_ARM=y\n" in content and "CONFIG_ARM64=y\n" not in content
             print("%s is %s" % (config, "ARM" if is_arm else "not ARM"))
             return is_arm
 

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -337,12 +337,12 @@ class TestUbootAutomation:
 
             if machine == "vexpress-qemu":
                 # PLEASE UPDATE the version you used to find this number if you update it.
-                # From version: v2018.05
-                measured_failed_ratio = 198.0 / 664.0
+                # From version: v2020.01
+                measured_failed_ratio = 57.0 / 561.0
             elif machine == "vexpress-qemu-flash":
                 # PLEASE UPDATE the version you used to find this number if you update it.
-                # From version: v2019.01
-                measured_failed_ratio = 53.0 / 185.0
+                # From version: v2020.01
+                measured_failed_ratio = 13.0 / 143.0
 
             # We tolerate a certain percentage discrepancy in either direction.
             tolerated_discrepancy = 0.1


### PR DESCRIPTION
```
commit 1e7f2153ca32c10eb0ae7baa30d29e0d98c7d614
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 17:52:55 2020

    test_uboot_compile: Update test conditions after fixes in this area.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 0467a6f855d1013281885b3ef61061c3ff7b7d6b
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 17:47:21 2020

    uboot_auto_configure: Handle unwanted config options better.
    
    Actively disable CONFIG options we want to get rid of instead of just
    removing them from the defconfig file. This helps in the case where we
    try to remove an option, but it's immediately brought back because the
    default is to be on.
    
    Changelog: U-Boot auto-configuration: Better algorithm for removing
    options from defconfig files. This increases board compatibility.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit b3eee9bddbef64c440f853eae9b44bb53554a063
kristian@kristian-Mender-T460s:~/code/poky/meta-mender$ git log origin/master..HEAD|cat
commit 1e7f2153ca32c10eb0ae7baa30d29e0d98c7d614
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 17:52:55 2020

    test_uboot_compile: Update test conditions after fixes in this area.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 0467a6f855d1013281885b3ef61061c3ff7b7d6b
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 17:47:21 2020

    uboot_auto_configure: Handle unwanted config options better.
    
    Actively disable CONFIG options we want to get rid of instead of just
    removing them from the defconfig file. This helps in the case where we
    try to remove an option, but it's immediately brought back because the
    default is to be on.
    
    Changelog: U-Boot auto-configuration: Better algorithm for removing
    options from defconfig files. This increases board compatibility.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit b3eee9bddbef64c440f853eae9b44bb53554a063
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 13:49:48 2020

    test_uboot_compile: Execute defconfig step to identify ARM boards.
    
    Previously we searched through the files to try to detect ARM boards,
    but this is error prone, and especially ARM64 boards are difficult to
    detect. These are becoming more common, so we need another way.
    
    So instead we execute the defconfig step of every board, and then look
    for `CONFIG_ARM=y` inside the resulting configuration. This takes a
    lot longer than the file searching, but is much more accurate. Given
    that it eliminates more than a hundred false positives, it is well
    worth it since we no longer have to compile those, and the total
    testing time still should go down.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit d29d7d02afa239abb2171f8a35640f042716f3f1
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Jun 19 13:45:15 2020

    test_uboot_compile: Add timestamps to aid debugging.
    
    This way it's easier to see which board has ended up in an infinite
    loop, which has been a common occurrence with the latest U-Boot
    versions.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 86fde5f093fe0eab091ac955d7d3bccbc66ca840
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Jun 24 15:53:24 2020

    tests: Fix U-Boot compile test not running for pull requests.
    
    We need to adapt the conditions for Gitlab, which uses "pr_*" branches
    instead of "pull/*" branches. The conditions need to figure out that
    this is a pull request, and it should therefore run the tests. This
    has been broken for a while, but due to the timestamp condition, in
    most cases it still works. However for PRs that are tested more than a
    week after their commit date, the test may be erronously skipped.
    
    In addition, the path to the U-Boot recipe directory has also been
    wrong for a long time, causing only test fixes to be picked up, not
    recipe fixes.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```