### PR TITLE
[Warrior] Fix EFI boot partition corruption with mtools 4.0.19

### DIFF
--- a/meta-mender-core/recipes-devtools/mtools/mtools/clang_UNUSED.patch
+++ b/meta-mender-core/recipes-devtools/mtools/mtools/clang_UNUSED.patch
@@ -1,0 +1,17 @@
+Undefine UNUSED macros with clang
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Index: mtools-4.0.18/sysincludes.h
+===================================================================
+--- mtools-4.0.18.orig/sysincludes.h
++++ mtools-4.0.18/sysincludes.h
+@@ -101,7 +101,7 @@ typedef void *caddr_t;
+ #if defined __GNUC__ && defined __STDC__
+ /* gcc -traditional doesn't have PACKED, UNUSED and NORETURN */
+ # define PACKED __attribute__ ((packed))
+-# if __GNUC__ == 2 && __GNUC_MINOR__ > 6 || __GNUC__ >= 3
++# if (__GNUC__ == 2 && __GNUC_MINOR__ > 6 || __GNUC__ >= 3) && !defined(__clang__)
+ /* gcc 2.6.3 doesn't have "unused" */		/* mool */
+ #  define UNUSED(x) x __attribute__ ((unused));x
+ #  define UNUSEDP __attribute__ ((unused))

--- a/meta-mender-core/recipes-devtools/mtools/mtools/disable-hardcoded-configs.patch
+++ b/meta-mender-core/recipes-devtools/mtools/mtools/disable-hardcoded-configs.patch
@@ -1,0 +1,32 @@
+From 5c24356762bc4274d3ca4930b0bc7754f4ffd19b Mon Sep 17 00:00:00 2001
+From: Ed Bartosh <ed.bartosh@linux.intel.com>
+Date: Tue, 13 Jun 2017 14:55:52 +0300
+Subject: [PATCH] Disabled reading host configs.
+
+Upstream-Status: Inappropriate [native]
+
+Signed-off-by: Ed Bartosh <ed.bartosh@linux.intel.com>
+
+---
+ config.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/config.c b/config.c
+index f086883..1c3f9bd 100644
+--- a/config.c
++++ b/config.c
+@@ -701,14 +701,6 @@ void read_config(void)
+ 	memcpy(devices, const_devices,
+ 	       nr_const_devices*sizeof(struct device));
+ 
+-    (void) ((parse(CONF_FILE,1) |
+-	     parse(LOCAL_CONF_FILE,1) |
+-	     parse(SYS_CONF_FILE,1)) ||
+-	    (parse(OLD_CONF_FILE,1) |
+-	     parse(OLD_LOCAL_CONF_FILE,1)));
+-    /* the old-name configuration files only get executed if none of the
+-     * new-name config files were used */
+-
+     homedir = get_homedir();
+     if ( homedir ){
+ 	strncpy(conf_file, homedir, MAXPATHLEN );

--- a/meta-mender-core/recipes-devtools/mtools/mtools/mtools-makeinfo.patch
+++ b/meta-mender-core/recipes-devtools/mtools/mtools/mtools-makeinfo.patch
@@ -1,0 +1,69 @@
+Upstream-Status: Inappropriate [licensing]
+
+Index: mtools-4.0.18/configure.in
+===================================================================
+--- mtools-4.0.18.orig/configure.in
++++ mtools-4.0.18/configure.in
+@@ -35,6 +35,33 @@ AC_CANONICAL_SYSTEM
+ AC_C_CONST
+ AC_C_INLINE
+ 
++AC_CHECK_PROG(MAKEINFO, makeinfo, makeinfo, )
++if test "x$MAKEINFO" = "x"; then
++	MAKEINFO="@echo makeinfo missing; true"
++fi
++AC_CHECK_PROG(TEXI2DVI, texi2dvi, texi2dvi, )
++if test "x$TEXI2DVI" = "x"; then
++	TEXI2DVI="@echo texi2dvi missing; true"
++fi
++AC_CHECK_PROG(TEXI2PDF, texi2pdf, texi2pdf, )
++if test "x$TEXI2PDF" = "x"; then
++	TEXI2PDF="@echo texi2pdf missing; true"
++fi
++AC_CHECK_PROG(TEXI2HTML, texi2html, texi2html, )
++if test "x$TEXI2HTML" = "x"; then
++	TEXI2HTML="@echo texi2html missing; true"
++fi    
++AC_CHECK_PROG(DVI2PS, dvi2ps, dvi2ps, )
++if test "x$DVI2PS" = "x"; then
++	DVI2PS="@echo dvi2ps missing; true"
++fi
++
++AC_SUBST(MAKEINFO)
++AC_SUBST(TEXI2DVI)
++AC_SUBST(TEXI2PDF)
++AC_SUBST(TEXI2HTML)
++AC_SUBST(DVI2PS)
++
+ 
+ dnl Check for configuration options
+ dnl Enable OS/2 extended density format disks
+Index: mtools-4.0.18/Makefile.in
+===================================================================
+--- mtools-4.0.18.orig/Makefile.in
++++ mtools-4.0.18/Makefile.in
+@@ -26,10 +26,11 @@ USERCFLAGS =
+ USERLDFLAGS =
+ USERLDLIBS =
+ 
+-MAKEINFO = makeinfo
+-TEXI2DVI = texi2dvi
+-TEXI2PDF = texi2pdf
+-TEXI2HTML = texi2html
++MAKEINFO = @MAKEINFO@
++TEXI2DVI = @TEXI2DVI@
++TEXI2PDF = @TEXI2PDF@
++TEXI2HTML = @TEXI2HTML@
++DVI2PS = @DVI2PS@
+ 
+ 
+ # do not edit below this line
+@@ -198,7 +199,7 @@ dvi: mtools.dvi
+ 
+ ps: mtools.ps
+ %.ps: %.dvi
+-	dvips -f < $< > $@
++	$(DVI2PS) -f < $< > $@
+ 
+ pdf: mtools.pdf
+ %.pdf: %.texi sysconfdir.texi

--- a/meta-mender-core/recipes-devtools/mtools/mtools/no-x11.gplv3.patch
+++ b/meta-mender-core/recipes-devtools/mtools/mtools/no-x11.gplv3.patch
@@ -1,0 +1,18 @@
+Disable building with X11 support.
+
+Upstream-Status: Inappropriate [disable feature]
+
+Signed-off-by: Scott Garman <scott.a.garman@intel.com>
+
+diff -urN mtools-4.0.15.orig//Makefile.in mtools-4.0.15//Makefile.in
+--- mtools-4.0.15.orig//Makefile.in	2010-10-17 08:41:09.000000000 -0700
++++ mtools-4.0.15//Makefile.in	2010-11-23 13:59:49.258258374 -0800
+@@ -146,7 +146,7 @@
+ CXXFLAGS  = $(CPPFLAGS) $(DEFS) $(MYCXXFLAGS) -I. @extraincludedir@ -I@srcdir@ $(USERCFLAGS)
+ LINK      = $(CC) $(LDFLAGS) $(USERLDFLAGS) @extralibdir@
+ ALLLIBS   = $(USERLDLIBS) $(MACHDEPLIBS) $(SHLIB) $(LIBS)
+-X_LDFLAGS = $(X_EXTRA_LIBS) $(X_LIBS) -lXau -lX11 $(LIBS)
++X_LDFLAGS = $(X_EXTRA_LIBS) $(X_LIBS) $(LIBS)
+ X_CCFLAGS = $(X_CFLAGS) $(CFLAGS)
+ 
+ all:    mtools $(LINKS) mkmanifest @FLOPPYD@ mtools.1 mtools.5

--- a/meta-mender-core/recipes-devtools/mtools/mtools_4.0.23.bb
+++ b/meta-mender-core/recipes-devtools/mtools/mtools_4.0.23.bb
@@ -1,0 +1,51 @@
+SUMMARY = "Utilities to access MS-DOS disks without mounting them"
+DESCRIPTION = "Mtools is a collection of utilities to access MS-DOS disks from GNU and Unix without mounting them."
+HOMEPAGE = "http://www.gnu.org/software/mtools/"
+SECTION = "optional"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
+
+DEPENDS += "virtual/libiconv"
+
+RDEPENDS_${PN}_libc-glibc = "glibc-gconv-ibm850"
+RRECOMMENDS_${PN}_libc-glibc = "\
+	glibc-gconv-ibm437 \
+	glibc-gconv-ibm737 \
+	glibc-gconv-ibm775 \
+	glibc-gconv-ibm851 \
+	glibc-gconv-ibm852 \
+	glibc-gconv-ibm855 \
+	glibc-gconv-ibm857 \
+	glibc-gconv-ibm860 \
+	glibc-gconv-ibm861 \
+	glibc-gconv-ibm862 \
+	glibc-gconv-ibm863 \
+	glibc-gconv-ibm865 \
+	glibc-gconv-ibm866 \
+	glibc-gconv-ibm869 \
+	"
+SRC_URI[md5sum] = "1d17b58c53a46b29c7f521d4a55ccef1"
+SRC_URI[sha256sum] = "f188db26751aeb5692a79b2380b440ecc05fd1848a52f869d7ca1193f2ef8ee3"
+
+SRC_URI = "${GNU_MIRROR}/mtools/mtools-${PV}.tar.bz2 \
+           file://mtools-makeinfo.patch \
+           file://no-x11.gplv3.patch \
+           file://clang_UNUSED.patch \
+           "
+
+SRC_URI_append_class-native = " file://disable-hardcoded-configs.patch"
+
+inherit autotools texinfo distro_features_check
+
+EXTRA_OECONF = "--without-x"
+
+BBCLASSEXTEND = "native nativesdk"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[libbsd] = "ac_cv_lib_bsd_main=yes,ac_cv_lib_bsd_main=no,libbsd"
+
+do_install_prepend () {
+    # Create bindir to fix parallel installation issues
+    mkdir -p ${D}/${bindir}
+    mkdir -p ${D}/${datadir}
+}


### PR DESCRIPTION
## Description

With mtools 4.0.19 in Yocto Warrior, 'mcopy' causes corruption in the boot partition when copying the EFI directory.

Fix this by importing mtools 4.0.23 from the Yocto Zeus branch.

Observed error:

```
fsck.fat 4.1 (2017-01-24)
/EFI/BOOT/.
  Bad short file name (.).
  Auto-renaming it.
  Renamed to FSCK0000.000
/EFI/BOOT/..
  Bad short file name (..).
  Auto-renaming it.
  Renamed to FSCK0000.001
/EFI/BOOT/FSCK0000.000
  File size is 0 bytes, cluster chain length is > 0 bytes.
  Truncating file to 0 bytes.
/EFI/BOOT/FSCK0000.001
  File size is 0 bytes, cluster chain length is > 0 bytes.
  Truncating file to 0 bytes.
/EFI/BOOT/mender_grubenv1
  Has a large number of bad entries. (2/5)
  Not dropping it in auto-mode.
/EFI/BOOT/mender_grubenv1/.
  Bad short file name (.).
  Auto-renaming it.
  Renamed to FSCK0000.000
/EFI/BOOT/mender_grubenv1/..
  Bad short file name (..).
  Auto-renaming it.
  Renamed to FSCK0000.001
/EFI/BOOT/mender_grubenv1/FSCK0000.000
  File size is 0 bytes, cluster chain length is > 0 bytes.
  Truncating file to 0 bytes.
/EFI/BOOT/mender_grubenv1/FSCK0000.001
  Contains a free cluster (3). Assuming EOF.
```

## How has this been tested?

Applied the patch. Ran `fsck.fat -a -l -v -w /dev/mmcblk0p1`. Result:

```
fsck.fat 4.1 (2017-01-24)
Checking we can access the last sector of the filesystem
Boot sector contents:
System ID "mkfs.fat"
Media byte 0xf8 (hard disk)
       512 bytes per logical sector
      2048 bytes per cluster
         4 reserved sectors
First FAT starts at byte 2048 (sector 4)
         2 FATs, 16 bit entries
     32768 bytes per FAT (= 64 sectors)
Root directory starts at byte 67584 (sector 132)
       512 root directory entries
Data area starts at byte 83968 (sector 164)
     16343 data clusters (33470464 bytes)
32 sectors/track, 64 heads
         0 hidden sectors
     65536 sectors total
Checking file /boot
Checking file /EFI
Checking file /DTB
Checking file /mender-install.sh (MENDER~1.SH)
Checking file /EFI/.
Checking file /EFI/..
Checking file /EFI/BOOT
Checking file /EFI/BOOT/.
Checking file /EFI/BOOT/..
Checking file /EFI/BOOT/mender_grubenv1 (MENDER~1)
Checking file /EFI/BOOT/mender_grubenv2 (MENDER~2)
Checking file /EFI/BOOT/BOOTARM.EFI
Checking file /EFI/BOOT/GRUB.CFG
Checking file /EFI/BOOT/mender_grubenv1/.
Checking file /EFI/BOOT/mender_grubenv1/..
Checking file /EFI/BOOT/mender_grubenv1/LOCK
Checking file /EFI/BOOT/mender_grubenv1/ENV
Checking file /EFI/BOOT/mender_grubenv1/lock.sha256sum (LOCK~1.SHA)
Checking file /EFI/BOOT/mender_grubenv2/.
Checking file /EFI/BOOT/mender_grubenv2/..
Checking file /EFI/BOOT/mender_grubenv2/LOCK
Checking file /EFI/BOOT/mender_grubenv2/ENV
Checking file /EFI/BOOT/mender_grubenv2/lock.sha256sum (LOCK~1.SHA)
Checking file /DTB/.   
Checking file /DTB/..  
Checking file /DTB/am335x-bonegreen-wireless--5.3.18-r0-beaglebone-20200620212708.dtb (AM335X~1.DTB)
Checking file /DTB/am335x-boneblack--5.3.18-r0-beaglebone-20200620212708.dtb (AM335X~2.DTB)
Checking file /DTB/am335x-boneblue--5.3.18-r0-beaglebone-20200620212708.dtb (AM335X~3.DTB)
Checking file /DTB/am335x-boneblue-beaglebone.dtb (AM335X~4.DTB)
Checking file /DTB/am335x-boneblack-wireless--5.3.18-r0-beaglebone-20200620212708.dtb (AM335X~5.DTB)
Checking file /DTB/am335x-bonegreen--5.3.18-r0-beaglebone-20200620212708.dtb (AM335X~6.DTB)
Checking file /DTB/am335x-bonegreen-wireless-beaglebone.dtb (AM335X~7.DTB)
Checking file /DTB/am335x-bonegreen-wireless.dtb (AM335X~8.DTB)
Checking file /DTB/am335x-bonegreen-beaglebone.dtb (AM335X~9.DTB)
Checking file /DTB/am335x-boneblack-beaglebone.dtb (AM335~10.DTB)
Checking file /DTB/am335x-boneblack-wireless.dtb (AM335~11.DTB)
Checking file /DTB/am335x-boneblack.dtb (AM335~12.DTB)
Checking file /DTB/am335x-boneblue.dtb (AM335~13.DTB)
Checking file /DTB/am335x-bonegreen.dtb (AM335~14.DTB)
Checking file /DTB/am335x-boneblack-wireless-beaglebone.dtb (AM335~15.DTB)
Reclaiming unconnected clusters.
boot_partition.fat: 30 files, 706/16343 clusters
```

## External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.
