### PR TITLE
zeus: MEN-3781: Make sure that our Docker rofs image is zeus compatible.

### DIFF
--- a/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
+++ b/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
@@ -1,3 +1,7 @@
 require recipes-extended/images/core-image-full-cmdline.bb
 
 IMAGE_FEATURES_append = " read-only-rootfs"
+
+# See https://tracker.mender.io/browse/MEN-3513 and
+# https://tracker.mender.io/browse/MEN-3781.
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"


### PR DESCRIPTION
On zeus we need the 64bit fix. This fix is already applied in the
meta-mender-commercial layer, but this layer is not used for this
particular test image.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit e4d8ddb58be1291165b3a798b0d576ee4cbb1f2f)
