### PR TITLE
Add recipes for 2.3.1 and 2.4.0 release.

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.1.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.1.0.bb
@@ -2,4 +2,4 @@ include mender-binary-delta.inc
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.3.1.bb
@@ -1,0 +1,25 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.3.x"
+
+# Tag: 3.3.1
+SRCREV = "feaabfc1d292092e120d86fee66dc0f1d8639785"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=99143e34cf23a99976a299da9fa93bcf"
+
+DEPENDS += "xz"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.4.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.4.0.bb
@@ -10,12 +10,12 @@ require mender-artifact.inc
 
 SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.4.x"
 
-# Tag: 3.4.0b1
+# Tag: 3.4.0
 SRCREV = "b2c230e73b0e7c90d23ce03caedaec42728fa3f3"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.2.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.2.1.bb
@@ -1,0 +1,31 @@
+require mender-client.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.2.x"
+
+# Tag: 2.2.1
+SRCREV = "fc12e8f72a58c10734ce41ad2c39e6dcd927af97"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=80ba3790b689991e47685da401fd3375"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
+
+DEPENDS += "xz"
+RDEPENDS_${PN} += "liblzma"
+
+# MEN-2948: systemd service is still named mender.service in 2.2.x
+MENDER_CLIENT = "mender"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.0.bb
@@ -10,12 +10,12 @@ require mender-client.inc
 
 SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.3.x"
 
-# Tag: 2.3.0b1
-SRCREV = "a78b45e240f9daf3ff47625ae66d97c3f2e33cad"
+# Tag: 2.3.0
+SRCREV = "c570a7662d8c8766cebfe236dd71bc8657e61b71"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 


### PR DESCRIPTION
Changelog: Add mender-2.2.1 and mender-artifact-3.3.1 recipes.
Changelog: Add mender-2.3.0 and mender-artifact-3.4.0 recipes.
Changelog: Add mender-binary-delta-1.1.0 release.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 7834378344e159d2cb10397f60ecf4578087dd7a)
