### PR TITLE
MEN-3834: Fix incorrect BOOTENV_SIZE value being used in libubootenv.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -2,37 +2,6 @@ include u-boot-mender-helpers.inc
 
 FILES_${PN}_append_mender-uboot = " /data/u-boot/fw_env.config"
 
-mender_create_fw_env_config_file() {
-    # Takes one argument, which is the file to put it in.
-
-    set -x
-
-    # fw-utils seem to only be able to handle hex values.
-    HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
-
-    # create fw_env.config file
-    cat > $1 <<EOF
-${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE_PATH} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
-${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE_PATH} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
-EOF
-}
-
-# UBI specific version of the fw_env.config file.
-mender_create_fw_env_config_file_mender-ubi() {
-    # Takes one argument, which is the file to put it in.
-
-    set -x
-
-    # fw-utils seem to only be able to handle hex values.
-    HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
-
-    # create fw_env.config file
-    cat > $1 <<EOF
-/dev/${MENDER_STORAGE_DEVICE}_${MENDER_UBOOT_ENV_UBIVOL_NUMBER_1} 0 $HEX_BOOTENV_SIZE ${MENDER_UBI_LEB_SIZE}
-/dev/${MENDER_STORAGE_DEVICE}_${MENDER_UBOOT_ENV_UBIVOL_NUMBER_2} 0 $HEX_BOOTENV_SIZE ${MENDER_UBI_LEB_SIZE}
-EOF
-}
-
 do_compile_append_mender-uboot() {
     alignment_bytes=${MENDER_PARTITION_ALIGNMENT}
     if [ $(expr ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET} % $alignment_bytes) -ne 0 ]; then
@@ -40,12 +9,13 @@ do_compile_append_mender-uboot() {
                 "MENDER_PARTITION_ALIGNMENT"
     fi
 
-    if [ ! -e ${WORKDIR}/fw_env.config.default ]; then
+    if [ ! -e ${DEPLOY_DIR_IMAGE}/fw_env.config.default ]; then
         mender_create_fw_env_config_file ${WORKDIR}/fw_env.config
     else
-        cp ${WORKDIR}/fw_env.config.default ${WORKDIR}/fw_env.config
+        cp ${DEPLOY_DIR_IMAGE}/fw_env.config.default ${WORKDIR}/fw_env.config
     fi
 }
+do_compile[depends] += "u-boot:do_deploy"
 
 do_install_append_mender-uboot() {
     install -d -m 755 ${D}${sysconfdir}

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-helpers.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-helpers.inc
@@ -40,3 +40,34 @@ MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 ?= "${@mender_get_env_offset(${MENDER_U
                                                                       ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE})}"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 ?= "${@mender_get_env_offset(${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET}, 2, \
                                                                       ${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE})}"
+
+mender_create_fw_env_config_file() {
+    # Takes one argument, which is the file to put it in.
+
+    set -x
+
+    # fw-utils seem to only be able to handle hex values.
+    HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
+
+    # create fw_env.config file
+    cat > $1 <<EOF
+${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE_PATH} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1} $HEX_BOOTENV_SIZE
+${MENDER_UBOOT_MMC_ENV_LINUX_DEVICE_PATH} ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2} $HEX_BOOTENV_SIZE
+EOF
+}
+
+# UBI specific version of the fw_env.config file.
+mender_create_fw_env_config_file_mender-ubi() {
+    # Takes one argument, which is the file to put it in.
+
+    set -x
+
+    # fw-utils seem to only be able to handle hex values.
+    HEX_BOOTENV_SIZE="$(printf 0x%x "${BOOTENV_SIZE}")"
+
+    # create fw_env.config file
+    cat > $1 <<EOF
+/dev/${MENDER_STORAGE_DEVICE}_${MENDER_UBOOT_ENV_UBIVOL_NUMBER_1} 0 $HEX_BOOTENV_SIZE ${MENDER_UBI_LEB_SIZE}
+/dev/${MENDER_STORAGE_DEVICE}_${MENDER_UBOOT_ENV_UBIVOL_NUMBER_2} 0 $HEX_BOOTENV_SIZE ${MENDER_UBI_LEB_SIZE}
+EOF
+}

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
@@ -35,6 +35,13 @@ do_provide_mender_defines() {
         bbfatal "To compile U-Boot with mender you have to add 'mender-uboot' to MENDER_FEATURES_ENABLE or DISTRO_FEATURES."
     fi
 
+    # Since the libubootenv recipe will typically not have access to the proper
+    # BOOTENV_SIZE, let's create the fw_env.config file here, so that it can
+    # pick it from the deploy directory.
+    if [ ! -e "${WORKDIR}/fw_env.config.default" ]; then
+        mender_create_fw_env_config_file ${WORKDIR}/fw_env.config.default
+    fi
+
     if [ ${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART} -eq "0" ]; then
         # Only check reserved space for bootloader data when the bootloader data is saved to the user partition of the MMC.
         # In cases where it's saved to the boot partition it's not a part of the rootfs size and MENDER_RESERVED_SPACE_BOOTLOADER_DATA
@@ -380,6 +387,8 @@ do_deploy_append_mender-uboot() {
     # file.
     dd if=/dev/zero of=${WORKDIR}/uboot.env bs=${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} count=1
     install -m 644 ${WORKDIR}/uboot.env ${DEPLOYDIR}/uboot.env
+
+    install -m 644 ${WORKDIR}/fw_env.config.default ${DEPLOYDIR}/fw_env.config.default
 }
 addtask deploy after do_compile before do_package
 


### PR DESCRIPTION
Changelog: Fix incorrect BOOTENV_SIZE value being used in libubootenv
recipe. The symptom of this was a non-working set of `fw_printenv` and
`fw_setenv` tools:
```
root@raspberrypi4:~# fw_printenv
Cannot read environment, using default
Cannot read default environment from file
```

This was accidentally broken in commit f61fa534d43dcd, where the
task was originally handled by the u-boot-fw-utils recipe files.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
