### PR TITLE
Fix broken `set-time-epoch` feature in dunfell.

### DIFF
--- a/meta-mender-core/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mender-core/recipes-core/systemd/systemd_%.bbappend
@@ -4,4 +4,5 @@
 # in the future and an fsck will be done.  Setting this to 0 results
 # in an epoch of January 1, 1970 which is detected as an invalid time
 # and the fsck will be skipped.
-PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-systemd', ' set-time-epoch', '', d)}"
+PACKAGECONFIG_append_mender-systemd = " set-time-epoch"
+SOURCE_DATE_EPOCH_mender-systemd = "0"


### PR DESCRIPTION
On dunfell it is apparently not enough anymore to just specify
`set-time-epoch` to force systemd to use 1st Jan 1970 as epoch. It is
apparently possible to to use any epoch you like, and the default is
the build time, so we need to specifically set it to zero. See the
comment above the change for context on why the epoch is needed in the
first place.

Changelog: Fix fsck running on every boot in dunfell.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
