### PR TITLE
[MEN-3761]MBR systems don't have a backup header, so always return true

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/files/mender-client-resize-data-part.sh.in
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-client-resize-data-part.sh.in
@@ -34,6 +34,8 @@ fi
 # Parted will refuse to resize the parition because it needs to re-write the
 # partition table and will refuse to do so unless there is a backup. This
 # ensures that GPT backup headers are written to the end of the disk.
-echo "w" | fdisk ${MENDER_STORAGE_DEVICE}
+# Note: On some MBR systems using BusyBox's fdisk this call will fail,
+# this is OK (MBR systems don't have a backup header), always return true. 
+echo "w" | fdisk ${MENDER_STORAGE_DEVICE} &> /dev/null || true
 
 /usr/sbin/parted -s ${MENDER_STORAGE_DEVICE} resizepart @MENDER_DATA_PART_NUMBER@ 100%


### PR DESCRIPTION
This change is needed for warrior MBR systems using BusyBox's fdisk.

Changelog: Title
Signed-off-by: oriday <Ossian.Riday@gmail.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
