### PR TITLE
mender-client: fix install of systemd-machine-id.service

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/files/mender-client-systemd-machine-id.service
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-client-systemd-machine-id.service
@@ -6,7 +6,7 @@ ConditionPathExists=/etc/machine-id
 Type=oneshot
 User=root
 Group=root
-ExecStart=/usr/bin/mender-set-systemd-machine-id.sh
+ExecStart=/usr/bin/mender-client-set-systemd-machine-id.sh
 
 [Install]
 WantedBy=mender-client.service

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -80,9 +80,9 @@ FILES_${PN}_append_mender-growfs-data_mender-systemd = " \
 "
 
 FILES_${PN}_append_mender-persist-systemd-machine-id = " \
-    ${systemd_unitdir}/system/mender-systemd-machine-id.service \
-    ${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/${MENDER_CLIENT}-systemd-machine-id.service \
-    ${bindir}/${MENDER_CLIENT}-set-systemd-machine-id.sh \
+    ${systemd_unitdir}/system/mender-client-systemd-machine-id.service \
+    ${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/mender-client-systemd-machine-id.service \
+    ${bindir}/mender-client-set-systemd-machine-id.sh \
 "
 
 # Go binaries produce unexpected effects that the Yocto QA mechanism doesn't
@@ -311,9 +311,9 @@ do_install_append_mender-growfs-data_mender-systemd() {
 }
 
 do_install_append_mender-persist-systemd-machine-id() {
-    install -m 644 ${WORKDIR}/mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}-systemd-machine-id.service
+    install -m 644 ${WORKDIR}/mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/
     install -d -m 755 ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants
-    ln -sf ../${MENDER_CLIENT}-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/
+    ln -sf ../mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/
     install -d -m 755 ${D}${bindir}
-    install -m 755 ${WORKDIR}/mender-client-set-systemd-machine-id.sh ${D}${bindir}/${MENDER_CLIENT}-set-systemd-machine-id.sh
+    install -m 755 ${WORKDIR}/mender-client-set-systemd-machine-id.sh ${D}${bindir}/
 }


### PR DESCRIPTION
Please note that I'm submitting this PR to dunfell because that's where I've tested this, but the same change appears to be applicable to master as well. 

---

Fix for the the following:

```
ERROR: mender-client-2.3.0-r0 do_package: QA Issue: mender-client: Files/directories were installed but not shipped in any package:
  /lib/systemd/system/mender-client-systemd-machine-id.service
```

This service is installed with a name based on the MENDER_CLIENT
variable, but this variable was not used in FILES. Previously, the
file names matched, but it now needs to be updated as the value of
MENDER_CLIENT has been changed.