### PR TITLE
Ensure variable changes are reflected on rebuild

### DIFF
--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -4,6 +4,6 @@ SRC_URI += "file://init-install-efi-mender.sh"
 
 do_install_append() {
     # Overwrite the version of this file provided by upstream
-    sed -ie 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh
-    install -m 0755 ${WORKDIR}/init-install-efi-mender.sh ${D}/init.d/install-efi.sh
+    sed -e 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh > init-install-efi-mender-altered.sh
+    install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install-efi.sh
 }


### PR DESCRIPTION
Fixes a rebuild problem that arises when having built with 'MENDER_STORAGE_DEVICE' set to one value, then changing it and rebuilding.
In that case, the 'devnode' variable inside 'init-install-efi-mender.sh' is NOT updated, producing invalid images.

The root cause was that bitbake does not re-fetch the 'init-install-efi-mender.sh' file.
Sed is then executed on the file where 'MENDER_STORAGE_DEVICE' has already been replaced from a previous sed execution.

Fixed by using an intermediate file instead.
If you reach this problem, fixing it requires cleaning: 'bitbake initramfs-module-install-efi -c clean'

Changelog: Title