### PR TITLE
MEN-3730 OpenSSL: set SECLEVEL=2 in /etc/ssl/openssl.cnf

### DIFF
--- a/meta-mender-qemu/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/meta-mender-qemu/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,9 @@
+
+do_install_append () {
+	# see MEN-3730, this is to align with the current default settings on raspbian
+	cat >> "${D}${sysconfdir}/ssl/openssl.cnf" <<EOF
+[system_default_sect]
+MinProtocol = TLSv1.2
+CipherString = DEFAULT@SECLEVEL=2
+EOF
+}


### PR DESCRIPTION

_Note_: goes with [mender/pull/581](https://github.com/mendersoftware/mender/pull/581)

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>
