### PR TITLE
update mender-client LIC md5 for mender/pull/587

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -86,7 +86,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "47aa5c40a8f1b6764001462bf094ccd9",
+                   "md5": "5649992d13a6fda40abfac7730a62b07",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"


### PR DESCRIPTION
Update of the LIC_FILES_CHKSUM.sha256 check sum
for https://github.com/mendersoftware/mender/pull/587
ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>
