### PR TITLE
Install standard Mender Update Modules by default.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -92,6 +92,8 @@ INSANE_SKIP_${PN}-ptest = "ldflags textrel"
 
 GO_IMPORT = "github.com/mendersoftware/mender"
 
+PACKAGECONFIG ?= "modules"
+
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-client-install', ' mender-client-install', '', d)}"
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', ' u-boot', '', d)}"
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-grub', ' grub', '', d)}"

--- a/meta-mender-demo/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/meta-mender-demo/recipes-mender/mender-client/mender-client_%.bbappend
@@ -6,8 +6,6 @@ MENDER_UPDATE_POLL_INTERVAL_SECONDS = "5"
 MENDER_INVENTORY_POLL_INTERVAL_SECONDS = "5"
 MENDER_RETRY_POLL_INTERVAL_SECONDS = "30"
 
-PACKAGECONFIG_append = " modules"
-
 MENDER_CERT_LOCATION ?= "${docdir}/mender-client/examples/demo.crt"
 # We need this because the certificate will automatically end up in the
 # mender-doc package when placed in ${docdir}.


### PR DESCRIPTION
The default is changed in order to have a better chance to fix
problems on devices, when the rootfs-image setup us not working, for
example by using the script module.

Changelog: Install standard Mender Update Modules by default. These
are:
* deb
* directory
* docker
* rpm
* script
* single-file
To disable the automatic installation of these Update Modules, add
`PACKAGECONFIG_remove = "modules"` to your `mender_%.bbappend` file,
or set `PACKAGECONFIG` explicitly.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>