### PR TITLE
MEN-3851: Warn when detecting U-Boot version without script '=' support. 

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender-common.inc
@@ -43,6 +43,10 @@ do_provide_mender_defines() {
         bbfatal "To compile U-Boot with mender you have to add 'mender-uboot' to MENDER_FEATURES_ENABLE or DISTRO_FEATURES."
     fi
 
+    if fgrep -A8 "skip_chars(char *s)" ${S}/tools/env/fw_env.c | fgrep -q "if (isblank(*s))"; then
+        bbwarn "Detected missing fix for '=' sign in fw_setenv script files. You may need to include this patch from the U-Boot project: https://gitlab.denx.de/u-boot/u-boot/-/commit/cd655514aa044c77fe3b895a51677ba47b26ba89"
+    fi
+
     if [ ${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART} -eq "0" ]; then
         # Only check reserved space for bootloader data when the bootloader data is saved to the user partition of the MMC.
         # In cases where it's saved to the boot partition it's not a part of the rootfs size and MENDER_RESERVED_SPACE_BOOTLOADER_DATA

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -86,7 +86,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "47aa5c40a8f1b6764001462bf094ccd9",
+                   "md5": "5649992d13a6fda40abfac7730a62b07",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"


### PR DESCRIPTION
This is needed on zeus and older, which do not use libubootenv.

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
