### PR TITLE
libubootenv updates for master

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,5 +1,7 @@
 include u-boot-mender-helpers.inc
 
+RPROVIDES_${PN} += "u-boot-default-env"
+
 FILES_${PN}_append_mender-uboot = " /data/u-boot/fw_env.config"
 
 do_compile_append_mender-uboot() {

--- a/meta-mender-core/recipes-bsp/u-boot/libubootenv_0.2.bbappend
+++ b/meta-mender-core/recipes-bsp/u-boot/libubootenv_0.2.bbappend
@@ -1,6 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/patches-libubootenv:"
-
-SRC_URI_append_mender-uboot = " \
-    file://0001-Restore-ability-to-feed-script-file-via-stdin-using-.patch \
-    file://0002-ubi-write-fix-invalid-envsize-ptr-to-UBI_IOCVOLUP.patch \
-"


### PR DESCRIPTION
oecore master has updated libubootenv to v0.3 and added an RRECOMMENDS for u-boot-default-env, which causes conflicts with files installed via the libubootenv bbappend here. This PR updates the meta-mender-core layer for compatiblity with these changes.