### PR TITLE
MEN-3912: Disable filesystem journal on read-only-rootfs.

### DIFF
--- a/meta-mender-commercial/conf/layer.conf
+++ b/meta-mender-commercial/conf/layer.conf
@@ -15,5 +15,6 @@ BBFILE_PRIORITY_mender-commercial = "6"
 LAYERSERIES_COMPAT_mender-commercial = "dunfell"
 LAYERDEPENDS_mender-commercial = "mender"
 
-# See https://tracker.mender.io/browse/MEN-3513.
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"
+# See https://tracker.mender.io/browse/MEN-3513 and
+# https://tracker.mender.io/browse/MEN-3912
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"

--- a/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
+++ b/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
@@ -3,5 +3,6 @@ require recipes-extended/images/core-image-full-cmdline.bb
 IMAGE_FEATURES_append = " read-only-rootfs"
 
 # See https://tracker.mender.io/browse/MEN-3513 and
-# https://tracker.mender.io/browse/MEN-3781.
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"
+# https://tracker.mender.io/browse/MEN-3781 and
+# https://tracker.mender.io/browse/MEN-3912.
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"


### PR DESCRIPTION
There is evidence from users of mender-convert that having the
`has_journal` feature turned on in the filesystem features causes fsck
to break the checksum of the filesystem, even when it doesn't make any
changes. Currently the Yocto-produced image does not run fsck, so it
is not a problem there, but it could be if someone uses an initrd for
example (this is where fsck is run in the mender-convert case). So
this fix is simply about being proactive and disabling it now, before
it becomes a problem.

Changelog: Disable filesystem journal on read-only-rootfs, which
sometimes causes unstable rootfs checksum together with fsck.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
