### PR TITLE
Fail build upon missing demo WiFi password and/or SSID

### DIFF
--- a/meta-mender-raspberrypi-demo/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-mender-raspberrypi-demo/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -11,6 +11,14 @@ do_install_append() {
 
   install -d ${D}${sysconfdir}/wpa_supplicant
 
+  if [ -z "${MENDER_DEMO_WIFI_SSID}" ]; then
+    bbfatal "No SSID set for the wpa configuration file"
+  fi
+
+  if [ -z "${MENDER_DEMO_WIFI_PASSKEY}" ]; then
+    bbfatal "No PASSKEY set for the wpa configuration file"
+  fi
+
   sed -i -e 's#[@]MENDER_DEMO_WIFI_PASSKEY[@]#${MENDER_DEMO_WIFI_PASSKEY}#' ${WORKDIR}/wpa_supplicant-wlan0.conf
 	sed -i -e 's#[@]MENDER_DEMO_WIFI_SSID[@]#${MENDER_DEMO_WIFI_SSID}#' ${WORKDIR}/wpa_supplicant-wlan0.conf
 


### PR DESCRIPTION
Another possibility is to `Warn` I guess?

Or maybe only fail if one is set, and not the other?

I like this approach though.
