### PR TITLE
Fixed config addition python script in Zeus

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
+++ b/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
@@ -118,7 +118,7 @@ def gather_currently_set_kconfig_options():
     set_options = dict()
     with open(args.defconfig_file) as fd:
         for line in fd.readlines():
-            if not (line.startswith("#") or line.strip()):
+            if line.strip() and not line.startswith("#"):
                 key = line.split("=", 2)[0]
                 if not key.startswith("CONFIG_"):
                     raise Exception("Not sure how to handle Kconfig option that doesn't start with 'CONFIG_'")

--- a/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
+++ b/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
@@ -118,7 +118,7 @@ def gather_currently_set_kconfig_options():
     set_options = dict()
     with open(args.defconfig_file) as fd:
         for line in fd.readlines():
-            if not line.startswith("#"):
+            if not (line.startswith("#") or line.strip()):
                 key = line.split("=", 2)[0]
                 if not key.startswith("CONFIG_"):
                     raise Exception("Not sure how to handle Kconfig option that doesn't start with 'CONFIG_'")


### PR DESCRIPTION
The `add_kconfig_option_with_depends.py` file throws `Not sure how to handle Kconfig option that doesn't start with 'CONFIG_'` when the provided defconfig file contains blank lines. It has been fixed be checking for empty lines before processing for keys.

Changelog: Fixed key extraction by skipping new lines in defconfig

Signed-off-by: Daniel Selvan D danilselvan@gmail.com