### PR TITLE
uboot_auto_config: Fixed key extraction by skipping new lines in defconfig

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
+++ b/meta-mender-core/recipes-bsp/u-boot/files/add_kconfig_option_with_depends.py
@@ -118,7 +118,7 @@ def gather_currently_set_kconfig_options():
     set_options = dict()
     with open(args.defconfig_file) as fd:
         for line in fd.readlines():
-            if not line.startswith("#"):
+            if line.strip() and not line.startswith("#"):
                 key = line.split("=", 2)[0]
                 if not key.startswith("CONFIG_"):
                     raise Exception("Not sure how to handle Kconfig option that doesn't start with 'CONFIG_'")


### PR DESCRIPTION
Changelog: Fixed key extraction by skipping new lines in defconfig.
The `add_kconfig_option_with_depends.py` file throws `Not sure how to
handle Kconfig option that doesn't start with 'CONFIG_'` when the
provided defconfig file contains blank lines. It has been fixed by
checking for empty lines before processing for keys.

Signed-off-by: Daniel Selvan D <danilselvan@gmail.com>

Modified-by: Kristian Amlie <kristian.amlie@northern.tech>
* Adjusted commit message and squashed.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
