### PR TITLE
Add recipes for Mender 2.3.1 components to thud

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.3.1.bb
@@ -1,4 +1,4 @@
-require mender.inc
+require mender-artifact.inc
 
 ################################################################################
 #-------------------------------------------------------------------------------
@@ -8,10 +8,10 @@ require mender.inc
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
-SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.2.x"
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.3.x"
 
-# Tag: 2.2.0b1
-SRCREV = "4084710e43cded556a5e7c1d01874f3ce51b0e8b"
+# Tag: 3.3.1
+SRCREV = "feaabfc1d292092e120d86fee66dc0f1d8639785"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
@@ -19,10 +19,7 @@ DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 
-# DO NOT change the checksum here without make sure that ALL licenses (including
-# dependencies) are included in the LICENSE variable below.
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=b73c5755173fade5704dbf3f4f546e6c"
-LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=99143e34cf23a99976a299da9fa93bcf"
 
 DEPENDS += "xz"
-RDEPENDS_${PN} += "liblzma"

--- a/meta-mender-core/recipes-mender/mender/mender_2.2.1.bb
+++ b/meta-mender-core/recipes-mender/mender/mender_2.2.1.bb
@@ -1,4 +1,4 @@
-require mender-artifact.inc
+require mender.inc
 
 ################################################################################
 #-------------------------------------------------------------------------------
@@ -8,10 +8,10 @@ require mender-artifact.inc
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
-SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.3.x"
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.2.x"
 
-# Tag: 3.3.0b1
-SRCREV = "b17a7a34da5be5c1e06fd139d94fca7d56b855cb"
+# Tag: 2.2.1
+SRCREV = "fc12e8f72a58c10734ce41ad2c39e6dcd927af97"
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
@@ -19,7 +19,10 @@ DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 
-LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=99143e34cf23a99976a299da9fa93bcf"
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=80ba3790b689991e47685da401fd3375"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
 
 DEPENDS += "xz"
+RDEPENDS_${PN} += "liblzma"

--- a/tests/acceptance/test_update.py
+++ b/tests/acceptance/test_update.py
@@ -100,7 +100,9 @@ class Helpers:
     def get_install_flag():
         with settings(warn_only=True):
             output = run("mender --help 2>&1")
-            if re.search("^\s*-install(\s|$)", output, flags=re.MULTILINE):
+            if re.search(r"^\s*install(\s|$)", output, flags=re.MULTILINE):
+                return "install"
+            elif re.search(r"^\s*-install(\s|$)", output, flags=re.MULTILINE):
                 return "-install"
             else:
                 return "-rootfs"


### PR DESCRIPTION
Changelog: Add mender 2.2.1 recipe
Changelog: Add mender-artifact 3.3.1 recipe
Changelog: Remove mender 2.2.0b1 recipe
Changelog: Remove mender-artifact 3.3.0b1 recipe

Same as #1081 and #1078.