### PR TITLE
Inherit go-ptest in Mender golang recipes

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
@@ -2,6 +2,7 @@ DESCRIPTION = "Mender image artifact library"
 GO_IMPORT = "github.com/mendersoftware/mender-artifact"
 
 inherit go
+inherit go-ptest
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -23,6 +23,7 @@ S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 inherit go
+inherit go-ptest
 inherit pkgconfig
 inherit systemd
 

--- a/tests/meta-mender-ci/recipes-testing/mender-coverage-client/gobinarycoverage.bb
+++ b/tests/meta-mender-ci/recipes-testing/mender-coverage-client/gobinarycoverage.bb
@@ -2,6 +2,7 @@ DESCRIPTION = "Mender image artifact library"
 GO_IMPORT = "github.com/mendersoftware/gobinarycoverage"
 
 inherit go
+inherit go-ptest
 
 SRC_URI = "git://${GO_IMPORT};protocol=git"
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
The ptest part of go class was separated to go-ptest class some time
before zeus. See poky commit 70a862a.

https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=70a862a367beea2c92ec0fb1bcaba41b942c78ac

By the looks of it, since then we have not been running unit tests on
our mender-client and mender-artifact recipes builds.