### PR TITLE
MEN-4032: Add glib-2.0 dependency for mender-client

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -1,7 +1,7 @@
 require mender-client.inc
 
-DEPENDS = "xz openssl"
-RDEPENDS_${PN} = "liblzma openssl"
+DEPENDS = "xz openssl glib-2.0"
+RDEPENDS_${PN} = "liblzma openssl glib-2.0"
 
 # The revision listed below is not really important, it's just a way to avoid
 # network probing during parsing if we are not gonna build the git version


### PR DESCRIPTION
It will go into the feature branch together with https://github.com/mendersoftware/mender/pull/625

This is provisional, we will have a better approach (and a proper Changelog tag) with [MEN-4014](https://tracker.mender.io/browse/MEN-4014)