### PR TITLE
mender-binary-delta: do_version_check() fixes

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -24,11 +24,12 @@ FILES_${PN} = " \
 INSANE_SKIP_${PN} = "already-stripped"
 
 do_version_check() {
-    if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
-        bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+    if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
+        if ! strings ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
+            bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+        fi
     fi
 }
-do_version_check[noexec] = "${@'1' if d.getVar('MENDER_DEVMODE') else '0'}"
 addtask do_version_check after do_patch before do_install
 
 do_configure() {

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -24,8 +24,6 @@ FILES_${PN} = " \
 INSANE_SKIP_${PN} = "already-stripped"
 
 do_version_check() {
-    cp ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${WORKDIR}/
-
     if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
         bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
     fi
@@ -46,7 +44,7 @@ EOF
 
 do_install() {
     install -d -m 755 ${D}${datadir}/mender/modules/v3
-    install -m 755 ${WORKDIR}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
+    install -m 755 ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
 
     install -d -m 755 ${D}${sysconfdir}/mender
     install -m 644 ${WORKDIR}/mender-binary-delta.conf ${D}${sysconfdir}/mender/mender-binary-delta.conf


### PR DESCRIPTION
```
commit f08e4c8819da6446fc3ec90802f9b57b61bed251
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 12 13:02:01 2020

    mender-binary-delta: Fix broken do_version_check.
    
    For unknown reasons, the "noexec" flag is not actually possible to
    turn off, not even with "0" nor "". The only way to disable it is to
    remove it, which kind of defeats the purpose of having it. Luckily
    it's easy to work around, so just do the variable check in code
    instead.
    
    The reason this has passed in our CI is that it is not covered by the
    sstate cache, so if it had a hit then this problem would not reveal
    itself.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 14113b2f3d8a4a2688ea9879f565caca2dade015
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Oct 9 14:09:47 2020

    mender-binary-delta: Fix do_version_check having side effects.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

```