### PR TITLE
devicetree: Strip containing folders (mostly for freescale)

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0002-Generic-boot-code-for-Mender.patch
@@ -120,7 +120,7 @@ new file mode 100644
 index 0000000000..0605f6a9fa
 --- /dev/null
 +++ b/include/env_mender.h
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,156 @@
 +/*
 +  Copyright 2017 Northern.tech AS
 +
@@ -205,8 +205,7 @@ index 0000000000..0605f6a9fa
 +    "fi; "                                                              \
 +    "if test \"${mender_systemd_machine_id}\" != \"\"; "                \
 +    "then "                                                             \
-+    "setenv bootargs systemd.machine_id=${mender_systemd_machine_id} "  \
-+    "${bootargs}; "                                                     \
++    "setenv bootargs \"systemd.machine_id=${mender_systemd_machine_id} ${bootargs}\"; " \
 +    "fi; "                                                              \
 +    "setenv mender_kernel_root " MENDER_STORAGE_DEVICE_BASE "${mender_boot_part}; "    \
 +    "if test ${mender_boot_part} = " __stringify(MENDER_ROOTFS_PART_A_NUMBER) "; "     \

--- a/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
+++ b/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
@@ -11,7 +11,7 @@ do_install() {
     install -d -m 755 ${D}/${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb
 
     for dtb_path in ${KERNEL_DEVICETREE}; do
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/$dtb_path ${D}/${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb/$dtb_base_name.$dtb_ext
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/$(basename $dtb_path) ${D}/${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb/
     done
 }
 do_install[depends] = "virtual/kernel:do_deploy"


### PR DESCRIPTION
Some BSPs store the DTBs in a subfolder and we need to account for
that in the KERNEL_DEVICETREE variable processing.

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
