### PR TITLE
Zeus update v2020.10.2

### DIFF
--- a/meta-mender-commercial/conf/layer.conf
+++ b/meta-mender-commercial/conf/layer.conf
@@ -15,5 +15,6 @@ BBFILE_PRIORITY_mender-commercial = "6"
 LAYERSERIES_COMPAT_mender-commercial = "zeus"
 LAYERDEPENDS_mender-commercial = "mender"
 
-# See https://tracker.mender.io/browse/MEN-3513.
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"
+# See https://tracker.mender.io/browse/MEN-3513 and
+# https://tracker.mender.io/browse/MEN-3912
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -28,6 +28,7 @@ do_version_check() {
         bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
     fi
 }
+do_version_check[noexec] = "${@'1' if d.getVar('MENDER_DEVMODE') else '0'}"
 addtask do_version_check after do_patch before do_install
 
 do_configure() {

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -22,8 +22,6 @@ FILES_${PN} = " \
 INSANE_SKIP_${PN} = "already-stripped"
 
 do_version_check() {
-    cp ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${WORKDIR}/
-
     if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
         bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
     fi
@@ -44,7 +42,7 @@ EOF
 
 do_install() {
     install -d -m 755 ${D}${datadir}/mender/modules/v3
-    install -m 755 ${WORKDIR}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
+    install -m 755 ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
 
     install -d -m 755 ${D}${sysconfdir}/mender
     install -m 644 ${WORKDIR}/mender-binary-delta.conf ${D}${sysconfdir}/mender/mender-binary-delta.conf

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -22,11 +22,12 @@ FILES_${PN} = " \
 INSANE_SKIP_${PN} = "already-stripped"
 
 do_version_check() {
-    if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
-        bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+    if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
+        if ! strings ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
+            bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+        fi
     fi
 }
-do_version_check[noexec] = "${@'1' if d.getVar('MENDER_DEVMODE') else '0'}"
 addtask do_version_check after do_patch before do_install
 
 do_configure() {

--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
@@ -122,7 +122,7 @@ tools/env/fw_printenv -l fw_printenv.lock > "$TMP_DIR/compiled-environment.txt" 
 rm -rf fw_printenv.lock
 if [ $ret -ne 0 ]; then
     if [ $ret -eq 134 -o $ret -eq 139 ]; then
-        echo "Detected SIGABRT or SIGSEGV. This may be an indication that your u-boot-fw-utils package is lacking an important patch. See https://docs.mender.io/troubleshooting/yocto-project-build#do_mender_uboot_auto_configure-fails-when-executing-toolsenvfw_p"
+        echo "Detected SIGABRT or SIGSEGV. This may be an indication that your u-boot-fw-utils package is lacking an important patch. See https://docs.mender.io/troubleshoot/yocto-project-build#do_mender_uboot_auto_configure-fails-when-executing-tools-env-fw"
     fi
     exit $ret
 fi

--- a/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
+++ b/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
@@ -11,7 +11,7 @@ do_install() {
     install -d -m 755 ${D}/${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb
 
     for dtb_path in ${KERNEL_DEVICETREE}; do
-        install -m 0644 ${DEPLOY_DIR_IMAGE}/$dtb_path ${D}/${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb/$dtb_base_name.$dtb_ext
+        install -m 0644 ${DEPLOY_DIR_IMAGE}/$(basename $dtb_path) ${D}/${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb/
     done
 }
 do_install[depends] = "virtual/kernel:do_deploy"

--- a/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
+++ b/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
@@ -3,5 +3,6 @@ require recipes-extended/images/core-image-full-cmdline.bb
 IMAGE_FEATURES_append = " read-only-rootfs"
 
 # See https://tracker.mender.io/browse/MEN-3513 and
-# https://tracker.mender.io/browse/MEN-3781.
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"
+# https://tracker.mender.io/browse/MEN-3781 and
+# https://tracker.mender.io/browse/MEN-3912.
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -941,12 +941,16 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         other = TestBuild.BuildDependsProvides.parse(output)
 
         # MEN-2956: Mender-Artifact now writes rootfs-image-checksum by default.
-        # Hence, the checksum should be present in all these test cases.
+        # MEN-3482: The new key for the rootfs image checksum is rootfs-image.checksum
         assert (
-            "rootfs_image_checksum" in other.provides
+            "rootfs-image.checksum" in other.provides
+            or "rootfs_image_checksum" in other.provides
         ), "Empty rootfs_image_checksum in the built rootfs-image artifact, this should be added by default by `mender-artifact write rootfs-image`"
         # Then remove it, not to mess up the expected test output
-        del other.provides["rootfs_image_checksum"]
+        if "rootfs-image.checksum" in other.provides.keys():
+            del other.provides["rootfs-image.checksum"]
+        if "rootfs_image_checksum" in other.provides.keys():
+            del other.provides["rootfs_image_checksum"]
 
         # MEN-3076: Mender-Artifacts writes software version by default
         # older versions did not, thus we remove the key before asserting the content

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -948,6 +948,11 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         # Then remove it, not to mess up the expected test output
         del other.provides["rootfs_image_checksum"]
 
+        # MEN-3076: Mender-Artifacts writes software version by default
+        # older versions did not, thus we remove the key before asserting the content
+        if "rootfs-image.version" in other.provides.keys():
+            del other.provides["rootfs-image.version"]
+
         assert dependsprovides.__dict__ == other.__dict__
 
     @pytest.mark.only_with_image("sdimg", "uefiimg", "gptimg", "biosimg")

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -862,7 +862,8 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
                         if depends_groups:
                             d.depends_groups = depends_groups
 
-                if "Provides:" in line:
+                # Precede with two spaces to avoid matching "Clears Provides:".
+                if "  Provides:" in line:
                     k = i + 1
                     tmp = {}
                     # Parse all provides on the following lines
@@ -881,7 +882,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
                     tmp = {}
                     # Parse all depends on the following lines
                     while True:
-                        if "Metadata:" in lines[k]:
+                        if "Metadata:" in lines[k] or "Clears Provides:" in lines[k]:
                             break
                         l = [s.strip() for s in lines[k].split(": ")]
                         assert len(l) == 2, "Line should only contain a key value pair"

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -921,7 +921,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
     @pytest.mark.min_mender_version("2.3.0")
     @pytest.mark.parametrize("dependsprovides", test_cases)
     def test_build_artifact_depends_and_provides(
-        self, prepared_test_build, bitbake_image, dependsprovides
+        self, prepared_test_build, bitbake_image, bitbake_path, dependsprovides
     ):
         """Test whether a build with enabled Artifact Provides and Depends does
         indeed add the parameters to the built Artifact"""


### PR DESCRIPTION
Bringing all relevant changes from [dunfell-v2020.10](https://docs.mender.io/development/release-information/release-notes-changelog#meta-mender-dunfell-v2020-10) into `zeus`, notably skipping the "Yocto check layer" changes (#1097 and #1037).