### PR TITLE
Warrior update v2020.10.2

### DIFF
--- a/meta-mender-commercial/conf/layer.conf
+++ b/meta-mender-commercial/conf/layer.conf
@@ -15,5 +15,6 @@ BBFILE_PRIORITY_mender-commercial = "6"
 LAYERSERIES_COMPAT_mender-commercial = "warrior"
 LAYERDEPENDS_mender-commercial = "mender"
 
-# See https://tracker.mender.io/browse/MEN-3513.
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"
+# See https://tracker.mender.io/browse/MEN-3513 and
+# https://tracker.mender.io/browse/MEN-3912
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"

--- a/meta-mender-commercial/conf/layer.conf
+++ b/meta-mender-commercial/conf/layer.conf
@@ -14,3 +14,6 @@ BBFILE_PRIORITY_mender-commercial = "6"
 
 LAYERSERIES_COMPAT_mender-commercial = "warrior"
 LAYERDEPENDS_mender-commercial = "mender"
+
+# See https://tracker.mender.io/browse/MEN-3513.
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -28,6 +28,7 @@ do_version_check() {
         bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
     fi
 }
+do_version_check[noexec] = "${@'1' if d.getVar('MENDER_DEVMODE') else '0'}"
 addtask do_version_check after do_patch before do_install
 
 do_configure() {

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -22,8 +22,6 @@ FILES_${PN} = " \
 INSANE_SKIP_${PN} = "already-stripped"
 
 do_version_check() {
-    cp ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${WORKDIR}/
-
     if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
         bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
     fi
@@ -44,7 +42,7 @@ EOF
 
 do_install() {
     install -d -m 755 ${D}${datadir}/mender/modules/v3
-    install -m 755 ${WORKDIR}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
+    install -m 755 ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta ${D}${datadir}/mender/modules/v3/mender-binary-delta
 
     install -d -m 755 ${D}${sysconfdir}/mender
     install -m 644 ${WORKDIR}/mender-binary-delta.conf ${D}${sysconfdir}/mender/mender-binary-delta.conf

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -22,11 +22,12 @@ FILES_${PN} = " \
 INSANE_SKIP_${PN} = "already-stripped"
 
 do_version_check() {
-    if ! strings ${WORKDIR}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
-        bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+    if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
+        if ! strings ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta | fgrep -q "${PN} ${PV}"; then
+            bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/${SUB_FOLDER}/mender-binary-delta | grep '${PN} [a-f0-9]')"
+        fi
     fi
 }
-do_version_check[noexec] = "${@'1' if d.getVar('MENDER_DEVMODE') else '0'}"
 addtask do_version_check after do_patch before do_install
 
 do_configure() {

--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
@@ -122,7 +122,7 @@ tools/env/fw_printenv -l fw_printenv.lock > "$TMP_DIR/compiled-environment.txt" 
 rm -rf fw_printenv.lock
 if [ $ret -ne 0 ]; then
     if [ $ret -eq 134 -o $ret -eq 139 ]; then
-        echo "Detected SIGABRT or SIGSEGV. This may be an indication that your u-boot-fw-utils package is lacking an important patch. See https://docs.mender.io/troubleshooting/yocto-project-build#do_mender_uboot_auto_configure-fails-when-executing-toolsenvfw_p"
+        echo "Detected SIGABRT or SIGSEGV. This may be an indication that your u-boot-fw-utils package is lacking an important patch. See https://docs.mender.io/troubleshoot/yocto-project-build#do_mender_uboot_auto_configure-fails-when-executing-tools-env-fw"
     fi
     exit $ret
 fi

--- a/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
+++ b/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
@@ -3,5 +3,6 @@ require recipes-extended/images/core-image-full-cmdline.bb
 IMAGE_FEATURES_append = " read-only-rootfs"
 
 # See https://tracker.mender.io/browse/MEN-3513 and
-# https://tracker.mender.io/browse/MEN-3781.
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"
+# https://tracker.mender.io/browse/MEN-3781 and
+# https://tracker.mender.io/browse/MEN-3912.
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"

--- a/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
+++ b/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb
@@ -1,3 +1,7 @@
 require recipes-extended/images/core-image-full-cmdline.bb
 
 IMAGE_FEATURES_append = " read-only-rootfs"
+
+# See https://tracker.mender.io/browse/MEN-3513 and
+# https://tracker.mender.io/browse/MEN-3781.
+EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit', '', d)}"


### PR DESCRIPTION
Bringing all relevant changes from [dunfell-v2020.10](https://docs.mender.io/development/release-information/release-notes-changelog#meta-mender-dunfell-v2020-10) into `warrior`, notably skipping the "Yocto check layer" changes (#1097 and #1037).

Added commits 401c6d8b4562af7ae79fd53d0ad778b0b797d895 and e4d8ddb58be1291165b3a798b0d576ee4cbb1f2f, which were missed in previous updates for unknown reason.

See also #1120.