### PR TITLE
[dependabot] Extend submodule update to maintained branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,32 @@ updates:
     package-ecosystem: gitsubmodule
     schedule:
       interval: weekly
+  - commit-message:
+      prefix: "Changelog:All"
+    directory: /
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: weekly
+    target_branch: "zeus"
+  - commit-message:
+      prefix: "Changelog:All"
+    directory: /
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: weekly
+    target_branch: "dunfell"
+  - commit-message:
+      prefix: "Changelog:All"
+    directory: /
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: weekly
+    target_branch: "gatesgarth"
+  - commit-message:
+      prefix: "Changelog:All"
+    directory: /
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: weekly
+    target_branch: "hardknott"
 


### PR DESCRIPTION
Trigger submodule update from zeus on, including future yocto branches.
Note that warrior is out as it uses Python 2 and, as per today, can not
be further updated.