### PR TITLE
[tests/acceptance] Remove --no-pull and update image-tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,3 @@
 	path = tests/acceptance/image-tests
 	url = https://github.com/mendersoftware/mender-image-tests
 	branch = master
-	ignore = all

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -59,12 +59,6 @@ def pytest_addoption(parser):
         help="Do not use a temporary build directory. Faster, but may mess with your build directory.",
     )
     parser.addoption(
-        "--no-pull",
-        action="store_true",
-        default=False,
-        help="Do not pull submodules. Handy if debugging something locally.",
-    )
-    parser.addoption(
         "--board-type",
         action="store",
         default="qemu",
@@ -108,10 +102,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    if not config.getoption("--no-pull"):
-        print("Automatically pulling submodules. Use --no-pull to disable")
-        subprocess.check_call("git submodule update --init --remote", shell=True)
-
     # ugly hack to access cli parameters inside common.py functions
     global configuration
 


### PR DESCRIPTION
From now on, the integration pipeline will not be cloning separately
mender-image-tests and then hacking meta-mender to use such clone, but
just use whatever is submodule'd here.

This commit updates the submodule to latest, removes the --no-pull
functionality, and removes the ignore of the submodule to make
developers aware.

See related PR https://github.com/mendersoftware/mender-qa/pull/432