### PR TITLE
warrior: [tests/acceptance] Remove --no-pull and update image-tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,4 +2,3 @@
 	path = tests/acceptance/image-tests
 	url = https://github.com/mendersoftware/mender-image-tests
 	branch = master
-	ignore = all

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -87,10 +87,6 @@ def pytest_configure(config):
     env.connection_attempts = 10
     env.timeout = 30
 
-    if not config.getoption("--no-pull"):
-        print("Automatically pulling submodules. Use --no-pull to disable")
-        subprocess.check_call("git submodule update --init --remote", shell=True)
-
 
 def current_hosts():
     # Workaround for being inside/outside execute().


### PR DESCRIPTION
Back-porting #1137 to warrior.

For warrior, using a commit before the refactoring (Python 2 compat)
instead of latest. We don't expect to update the submodule further.