### PR TITLE
mender-maybe-setup.bbclass: move mender overrides to DISTROOVERRIDES

### DIFF
--- a/meta-mender-core/classes/mender-maybe-setup.bbclass
+++ b/meta-mender-core/classes/mender-maybe-setup.bbclass
@@ -16,7 +16,7 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED_append = " ${MENDER_FEATURES_DISABLE}"
 python() {
     # Add all possible Mender features here. This list is here to have an
     # authoritative list of all distro features that Mender provides.
-    # Each one will also define the same string in OVERRIDES.
+    # Each one will also define the same string in DISTROOVERRIDES.
     mender_features = {
 
         # For GRUB, use BIOS for booting, instead of the default, UEFI.
@@ -84,7 +84,7 @@ python() {
             if feature not in mender_features:
                 bb.fatal("%s from MENDER_FEATURES_ENABLE or DISTRO_FEATURES is not a valid Mender feature."
                          % feature)
-            d.setVar('OVERRIDES_append', ':%s' % feature)
+            d.setVar('DISTROOVERRIDES_append', ':%s' % feature)
 
             # Verify that all 'mender-' features are added using MENDER_FEATURES
             # variables. This is important because we base some decisions on


### PR DESCRIPTION
Instead of being appended to OVERRIDES, mender specific overrides
should be appended to DISTROOVERRIDES. This ensures mender overrides
not break the order in OVERRIDES, for instance, the 'forcevariable'
override should always be the last in OVERRIDES.

Changelog: None
Signed-off-by: Ming Liu <liu.ming50@gmail.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
