### PR TITLE
mender-client: Update LICENSE to include OpenSSL

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.0.bb
@@ -22,7 +22,7 @@ SRCREV = "fecb925fab76b1bad4b9ad654f1485136dde6f82"
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=5649992d13a6fda40abfac7730a62b07"
-LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL"
 
 DEPENDS += "xz openssl"
 RDEPENDS_${PN} += "liblzma openssl"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -84,10 +84,15 @@ def mender_license(branch):
                    "md5": "3e7426c258f60f9876ae3746f54c49d4",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
+    elif branch == "2.4.x":
+        return {
+                   "md5": "5649992d13a6fda40abfac7730a62b07",
+                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL",
+        }
     else:
         return {
                    "md5": "5649992d13a6fda40abfac7730a62b07",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"
 LICENSE = "${@mender_license(d.getVar('MENDER_BRANCH'))['license']}"


### PR DESCRIPTION
For 2.4.0 recipe, 2.4.x builds, and master builds.