### PR TITLE
[dependabot] Fix parse error in dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     package-ecosystem: gitsubmodule
     schedule:
       interval: weekly
+    target_branch: "master"
   - commit-message:
       prefix: "Changelog:All"
     directory: /


### PR DESCRIPTION
By explicitly marking the first entry with target_branch master, so that
dependabot does not detect the rest as duplicates of this one.