### PR TITLE
[tests/acceptance] common.py: minor improvements

### DIFF
--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -236,15 +236,9 @@ def get_ssh_common_args(conn):
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.
 def put_no_sftp(file, conn, remote="."):
     cmd = "scp %s" % get_ssh_common_args(conn)
-
-    try:
-        conn.local(
-            "%s -P %s %s %s@%s:%s"
-            % (cmd, conn.port, file, conn.user, conn.host, remote)
-        )
-    except Exception as e:
-        print("exception while putting file: ", e)
-        raise e
+    conn.local(
+        "%s -P %s %s %s@%s:%s" % (cmd, conn.port, file, conn.user, conn.host, remote)
+    )
 
 
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.

--- a/tests/acceptance/common.py
+++ b/tests/acceptance/common.py
@@ -235,7 +235,7 @@ def get_ssh_common_args(conn):
 
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.
 def put_no_sftp(file, conn, remote="."):
-    cmd = "scp -C %s" % get_ssh_common_args(conn)
+    cmd = "scp %s" % get_ssh_common_args(conn)
 
     try:
         conn.local(
@@ -249,7 +249,7 @@ def put_no_sftp(file, conn, remote="."):
 
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.
 def get_no_sftp(file, conn, local="."):
-    cmd = "scp -C %s" % get_ssh_common_args(conn)
+    cmd = "scp %s" % get_ssh_common_args(conn)
     conn.local(
         "%s -P %s %s@%s:%s %s" % (cmd, conn.port, conn.user, conn.host, file, local)
     )


### PR DESCRIPTION
* [tests/acceptance] common.py: Remove scp compression
We run tests only on virtual devices, so the compression overhead does
not pay off compared to the transmission time.

* [tests/acceptance] common.py: Remove try/catch in put_no_sftp
It added no value to the function. Also now both put/get functions are
aligned.