### PR TITLE
[rocko] Fix lockfile error due to using system lock directory.

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_configure.sh
@@ -108,7 +108,9 @@ fake-env.txt 0 $BOOTENV_SIZE
 fake-env.txt 0 $BOOTENV_SIZE
 EOF
 # Save compiled U-Boot environment
-tools/env/fw_printenv > "$TMP_DIR/compiled-environment.txt"
+mkdir -p fw_printenv.lock
+tools/env/fw_printenv -l fw_printenv.lock > "$TMP_DIR/compiled-environment.txt"
+rm -rf fw_printenv.lock
 
 # cmd/.version.o.cmd is automatically built by the build system and contains all
 # dependencies for the given source file. We use this to go through all the


### PR DESCRIPTION
Cherry-picking 7879f6ac3f24e94c3ab0ec227f71e5d85e8a372f to rocko. See [community request at Mender Hub](https://hub.mender.io/t/do-mender-uboot-auto-configure-fails-due-to-multiple-users-running-the-build/2722).