### PR TITLE
test: bump min mender version

### DIFF
--- a/tests/acceptance/test_snapshot.py
+++ b/tests/acceptance/test_snapshot.py
@@ -196,7 +196,7 @@ class TestSnapshot:
             except:
                 pass
 
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_version("2.5.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     # Make sure we run both with and without terminal. Many signal bugs lurk in
     # different corners of the console code.


### PR DESCRIPTION
The fix for the sudo bug is on the released Mender-Artifact 3.4.x branch, but is
not yet released, meaning that it is not in the 3.4.0 tag in Mender-Artifact:

https://github.com/mendersoftware/mender-artifact/commits/3.4.0

Therefore, this will only be in master and be released with Mender release 2.6.0
