### PR TITLE
rename: min_mender_version -> min_mender_client_version

### DIFF
--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -29,7 +29,7 @@ from helpers import Helpers
 
 
 @pytest.mark.commercial
-@pytest.mark.min_mender_version("2.1.0")
+@pytest.mark.min_mender_client_version("2.1.0")
 class TestDeltaUpdateModule:
     @pytest.mark.only_with_image("ext4")
     def test_build_and_run_module(

--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -450,13 +450,13 @@ def prepared_test_build(prepared_test_build_base):
 
 
 @pytest.fixture(autouse=True)
-def min_mender_version(request, bitbake_variables):
-    version_mark = request.node.get_closest_marker("min_mender_version")
+def min_mender_client_version(request, bitbake_variables):
+    version_mark = request.node.get_closest_marker("min_mender_client_version")
     if version_mark is None:
         pytest.fail(
             (
-                '%s must be marked with @pytest.mark.min_mender_version("<VERSION>") to '
-                + "indicate lowest Mender version for which the test will work."
+                '%s must be marked with @pytest.mark.min_mender_client_version("<VERSION>") to '
+                + "indicate lowest Mender client version for which the test will work."
             )
             % str(request.node)
         )

--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -462,7 +462,7 @@ def min_mender_client_version(request, bitbake_variables):
         )
 
     test_version = version_mark.args[0]
-    if not version_is_minimum(bitbake_variables, "mender", test_version):
+    if not version_is_minimum(bitbake_variables, "mender-client", test_version):
         pytest.skip("Test requires Mender client %s or newer" % test_version)
 
 

--- a/tests/acceptance/pytest.ini
+++ b/tests/acceptance/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts = -s
 markers =
-    min_mender_version: indicate lowest Mender version for which the test will run
+    min_mender_client_version: indicate lowest Mender version for which the test will run
     min_yocto_version: indicate lowest Yocto version for which the test will run
     only_for_machine: execute only for the given machine
     only_with_image: execute only if one of the given images is enabled

--- a/tests/acceptance/test_bootimg.py
+++ b/tests/acceptance/test_bootimg.py
@@ -24,7 +24,7 @@ from common import (
 
 
 class TestBootImg:
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_bootimg_creation(
         self, bitbake_variables, prepared_test_build, bitbake_image
     ):

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -60,7 +60,7 @@ def extract_partition(img, number):
 
 
 class TestBuild:
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_default_server_certificate(self):
         """Test that the md5sum we have on record matches the server certificate.
         This makes sure the warning about this certificate is correct."""
@@ -80,7 +80,7 @@ class TestBuild:
         )
 
     @pytest.mark.only_with_image("sdimg")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_bootloader_embed(self, prepared_test_build, bitbake_image):
         """Test that MENDER_IMAGE_BOOTLOADER_FILE causes the bootloader to be embedded
         correctly in the resulting sdimg."""
@@ -137,7 +137,7 @@ class TestBuild:
         os.close(embedded)
 
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_image_rootfs_extra_space(
         self, prepared_test_build, bitbake_variables, bitbake_image
     ):
@@ -161,7 +161,7 @@ class TestBuild:
         )
 
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_tenant_token(self, prepared_test_build, bitbake_image):
         """Test setting a custom tenant-token"""
 
@@ -197,7 +197,7 @@ class TestBuild:
             os.remove("mender.conf")
 
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
-    @pytest.mark.min_mender_version("1.1.0")
+    @pytest.mark.min_mender_client_version("1.1.0")
     def test_artifact_signing_keys(
         self, prepared_test_build, bitbake_variables, bitbake_path, bitbake_image
     ):
@@ -248,7 +248,7 @@ class TestBuild:
             os.remove("artifact-verify-key.pem")
 
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
-    @pytest.mark.min_mender_version("1.2.0")
+    @pytest.mark.min_mender_client_version("1.2.0")
     def test_state_scripts(
         self,
         prepared_test_build,
@@ -382,7 +382,7 @@ class TestBuild:
                 target="-c clean example-state-scripts",
             )
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     # The extra None elements are to check for no preferred version,
     # e.g. latest.
     @pytest.mark.parametrize(
@@ -442,7 +442,7 @@ class TestBuild:
             )
             run_verbose("%s && bitbake %s" % (init_env_cmd, recipe))
 
-    @pytest.mark.min_mender_version("1.1.0")
+    @pytest.mark.min_mender_client_version("1.1.0")
     def test_multiple_device_types_compatible(
         self, prepared_test_build, bitbake_path, bitbake_variables, bitbake_image
     ):
@@ -472,7 +472,7 @@ class TestBuild:
             assert data["device_types_compatible"] == ["machine1", "machine2"]
 
     @pytest.mark.only_for_machine("vexpress-qemu-flash")
-    @pytest.mark.min_mender_version("1.3.0")
+    @pytest.mark.min_mender_client_version("1.3.0")
     @pytest.mark.parametrize(
         "test_case_name,test_case",
         [
@@ -571,7 +571,7 @@ class TestBuild:
             assert test_case["expected"][key] == variables[key]
 
     @pytest.mark.only_with_image("sdimg", "uefiimg")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_boot_partition_population(
         self, prepared_test_build, bitbake_path, bitbake_image
     ):
@@ -644,7 +644,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             os.remove("img1.fs")
 
     @pytest.mark.only_with_image("sdimg", "uefiimg")
-    @pytest.mark.min_mender_version("2.0.0")
+    @pytest.mark.min_mender_client_version("2.0.0")
     def test_module_install(
         self, prepared_test_build, bitbake_path, latest_rootfs, bitbake_image
     ):
@@ -695,7 +695,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             assert "modules" in entries
 
     @pytest.mark.only_with_image("sdimg", "uefiimg", "gptimg", "biosimg")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_correct_partition_types(self, latest_part_image):
         """Test that all the partitions in the image have the correct type."""
 
@@ -930,7 +930,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         ),
     ]
 
-    @pytest.mark.min_mender_version("2.3.0")
+    @pytest.mark.min_mender_client_version("2.3.0")
     @pytest.mark.parametrize("dependsprovides", test_cases)
     def test_build_artifact_depends_and_provides(
         self, prepared_test_build, bitbake_image, bitbake_path, dependsprovides
@@ -972,7 +972,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         assert dependsprovides.__dict__ == other.__dict__
 
     @pytest.mark.only_with_image("sdimg", "uefiimg", "gptimg", "biosimg")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_extra_parts(self, latest_part_image, prepared_test_build, bitbake_image):
         sdimg = latest_part_image.endswith(".sdimg")
         uefiimg = latest_part_image.endswith(".uefiimg")

--- a/tests/acceptance/test_dataimg.py
+++ b/tests/acceptance/test_dataimg.py
@@ -22,7 +22,7 @@ from common import build_image, latest_build_artifact, make_tempdir
 
 
 class TestDataImg:
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_dataimg_creation(
         self, bitbake_variables, prepared_test_build, bitbake_image
     ):

--- a/tests/acceptance/test_inventory.py
+++ b/tests/acceptance/test_inventory.py
@@ -22,7 +22,7 @@ from common import put_no_sftp
 
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestInventory:
-    @pytest.mark.min_mender_version("1.6.0")
+    @pytest.mark.min_mender_client_version("1.6.0")
     def test_rootfs_type(self, bitbake_variables, connection):
         """Test that rootfs is returned correctly by the inventory script."""
 
@@ -31,7 +31,7 @@ class TestInventory:
         ).stdout.strip()
         assert output == "rootfs_type=%s" % bitbake_variables["ARTIFACTIMG_FSTYPE"]
 
-    @pytest.mark.min_mender_version("1.6.0")
+    @pytest.mark.min_mender_client_version("1.6.0")
     def test_bootloader_integration(self, bitbake_variables, connection):
         """Test that the bootloader integration type matches what we would
         expect from the build."""
@@ -57,7 +57,7 @@ class TestInventory:
                 "Unknown platform combination. Please add a test case for this combination."
             )
 
-    @pytest.mark.min_mender_version("2.0.0")
+    @pytest.mark.min_mender_client_version("2.0.0")
     def test_inventory_os(self, bitbake_variables, connection):
         """Test that "os" inventory attribute is reported correctly by the
         inventory script."""

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -86,7 +86,7 @@ def versioned_mender_image(
 
 @pytest.mark.only_with_image("mender")
 class TestMenderArtifact:
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_order(self, versioned_mender_image):
         """Test that order of components inside update is correct."""
 
@@ -155,7 +155,7 @@ class TestMenderArtifact:
 
         assert meta_data_found
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_files_list_integrity(self, versioned_mender_image):
         """Test that the list of files in the manifest is the same as the actual
         file list."""
@@ -187,7 +187,7 @@ class TestMenderArtifact:
 
         assert sorted(manifest_list) == sorted(tar_list)
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_files_checksum_integrity(self, versioned_mender_image):
         """Test that the checksum of each file is correct."""
 
@@ -232,7 +232,7 @@ class TestMenderArtifact:
 
             assert hasher.hexdigest() == recorded_hash, "%s doesn't match" % file
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_artifacts_validation(self, versioned_mender_image, bitbake_path):
         """Test that the mender-artifact tool validates the update successfully."""
 
@@ -240,7 +240,7 @@ class TestMenderArtifact:
 
         subprocess.check_call(["mender-artifact", "validate", mender_image])
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_artifacts_rootfs_size(
         self, versioned_mender_image, bitbake_path, bitbake_variables
     ):

--- a/tests/acceptance/test_os_integration.py
+++ b/tests/acceptance/test_os_integration.py
@@ -19,7 +19,7 @@ import pytest
 
 
 class TestOsIntegration:
-    @pytest.mark.min_mender_version("2.2.1")
+    @pytest.mark.min_mender_client_version("2.2.1")
     def test_syslogger(self, setup_board, connection):
         """Test that we log to syslog, and that we don't if we specify --no-syslog."""
 

--- a/tests/acceptance/test_snapshot.py
+++ b/tests/acceptance/test_snapshot.py
@@ -24,7 +24,7 @@ from common import determine_active_passive_part, get_ssh_common_args
 
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestSnapshot:
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_client_version("2.2.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     @pytest.mark.parametrize("compression", [("", ">"), ("-C gzip", "| gunzip -c >")])
     def test_basic_snapshot(self, compression, bitbake_variables, connection):
@@ -50,7 +50,7 @@ class TestSnapshot:
         finally:
             connection.run("umount /mnt || true")
 
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_client_version("2.2.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     def test_snapshot_device_file(self, bitbake_variables, connection):
         try:
@@ -75,7 +75,7 @@ class TestSnapshot:
         finally:
             connection.run("umount /mnt || true")
 
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_client_version("2.2.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     def test_snapshot_inactive(self, bitbake_variables, connection):
         try:
@@ -100,7 +100,7 @@ class TestSnapshot:
         finally:
             connection.run("rm -f /data/snapshot-test")
 
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_client_version("2.2.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     def test_snapshot_avoid_deadlock(self, connection):
         loop = None
@@ -147,7 +147,7 @@ class TestSnapshot:
                 connection.run("losetup -d %s" % loop)
             connection.run("rm -f /data/tmp-file-system")
 
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_client_version("2.2.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     # Make sure we run both with and without terminal. Many signal bugs lurk in
     # different corners of the console code.
@@ -196,7 +196,7 @@ class TestSnapshot:
             except:
                 pass
 
-    @pytest.mark.min_mender_version("2.2.0")
+    @pytest.mark.min_mender_client_version("2.2.0")
     @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     # Make sure we run both with and without terminal. Many signal bugs lurk in
     # different corners of the console code.

--- a/tests/acceptance/test_ubimg.py
+++ b/tests/acceptance/test_ubimg.py
@@ -186,7 +186,7 @@ def ubimg_without_uboot_env(request, latest_ubimg, prepared_test_build, bitbake_
 
 
 @pytest.mark.only_with_image("ubimg")
-@pytest.mark.min_mender_version("1.2.0")
+@pytest.mark.min_mender_client_version("1.2.0")
 class TestUbimg:
     def test_total_size(self, bitbake_variables, ubimg_without_uboot_env):
         """Test that the size of the ubimg and its volumes are correct."""

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -255,7 +255,7 @@ class TestUbootAutomation:
 
             return configs_to_test
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_uboot_compile(self, bitbake_variables):
         """Test that our automatic patching of U-Boot still successfully builds
         the expected number of boards."""
@@ -379,7 +379,7 @@ class TestUbootAutomation:
             shutil.rmtree("/dev/shm/test_uboot_compile", ignore_errors=True)
 
     @pytest.mark.only_with_image("sdimg")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_older_uboot_build(self, prepared_test_build, bitbake_image):
         """Test that we can provide our own custom U-Boot provider."""
 
@@ -441,7 +441,7 @@ class TestUbootAutomation:
         except subprocess.CalledProcessError:
             pass
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_save_mender_auto_configured_patch(
         self, prepared_test_build, bitbake_image
     ):
@@ -525,7 +525,7 @@ class TestUbootAutomation:
     # can't be tested because of the limitations listed in
     # do_check_mender_defines.
     @pytest.mark.only_with_distro_feature("mender-ubi")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_incorrect_Kconfig_setting(self, prepared_test_build, bitbake_image):
         """First produce a patch using the auto-patcher, then disable
         auto-patching and apply the patch with a slight modification that makes


### PR DESCRIPTION
There is enough confusion with discerning Mender releases from Mender client
release versions already.

Let us try and keep them at a minimum by explicilty noting that we are referring
to the client release.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
