### PR TITLE
[tests/acceptance] Re-introduce min_mender_version fixture

### DIFF
--- a/tests/acceptance/fixtures.py
+++ b/tests/acceptance/fixtures.py
@@ -450,6 +450,27 @@ def prepared_test_build(prepared_test_build_base):
 
 
 @pytest.fixture(autouse=True)
+def min_mender_version(request, bitbake_variables):
+    """Backwards compatible version of min_mender_client_version for mender-convert
+
+    We can remove this fixture once mender-convert 2.2 goes EOL
+    """
+    version_mark = request.node.get_closest_marker("min_mender_version")
+    if version_mark is None:
+        pytest.fail(
+            (
+                '%s must be marked with @pytest.mark.min_mender_version("<VERSION>") to '
+                + "indicate lowest Mender client version for which the test will work."
+            )
+            % str(request.node)
+        )
+
+    test_version = version_mark.args[0]
+    if not version_is_minimum(bitbake_variables, "mender-client", test_version):
+        pytest.skip("Test requires Mender client %s or newer" % test_version)
+
+
+@pytest.fixture(autouse=True)
 def min_mender_client_version(request, bitbake_variables):
     version_mark = request.node.get_closest_marker("min_mender_client_version")
     if version_mark is None:

--- a/tests/acceptance/pytest.ini
+++ b/tests/acceptance/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 addopts = -s
 markers =
+    min_mender_version: (DEPRECATED) backwards compatible variant of min_mender_client_version
     min_mender_client_version: indicate lowest Mender version for which the test will run
     min_yocto_version: indicate lowest Yocto version for which the test will run
     only_for_machine: execute only for the given machine


### PR DESCRIPTION
For backwards compatibility in mender-convert stable release branch.