### PR TITLE
Add a feature for the inventory-geo-script in the Mender-client

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -93,7 +93,7 @@ INSANE_SKIP_${PN}-ptest = "ldflags textrel"
 
 GO_IMPORT = "github.com/mendersoftware/mender"
 
-PACKAGECONFIG ?= "${@mender_feature_is_enabled("mender-client-install", "modules", "", d)}"
+PACKAGECONFIG ?= "${@mender_feature_is_enabled("mender-client-install", "modules inventory-network-scripts", "", d)}"
 
 PACKAGECONFIG_append = "${@bb.utils.contains('MENDER_FEATURES', 'mender-client-install', ' mender-client-install', '', d)}"
 PACKAGECONFIG_append = "${@bb.utils.contains('MENDER_FEATURES', 'mender-uboot', ' u-boot', '', d)}"
@@ -238,7 +238,8 @@ do_install() {
         systemd_unitdir=${systemd_unitdir} \
         install-bin \
         install-identity-scripts \
-        install-inventory-scripts \
+        install-inventory-local-scripts \
+        ${@bb.utils.contains('PACKAGECONFIG', 'inventory-network-scripts', 'install-inventory-network-scripts', '', d)} \
         install-systemd \
         ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'install-modules', '', d)}
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.1.bb
@@ -26,3 +26,61 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
 
 DEPENDS += "xz"
 RDEPENDS_${PN} += "liblzma"
+
+do_install() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1 \
+        prefix=${D} \
+        bindir=${bindir} \
+        datadir=${datadir} \
+        sysconfdir=${sysconfdir} \
+        systemd_unitdir=${systemd_unitdir} \
+        install-bin \
+        install-identity-scripts \
+        install-inventory-scripts \
+        install-systemd \
+        ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'install-modules', '', d)}
+
+    #install our prepared configuration
+    install -d ${D}/${sysconfdir}/mender
+    install -d ${D}/data/mender
+    if [ -f ${B}/transient_mender.conf ]; then
+        install -m 0600 ${B}/transient_mender.conf ${D}/${sysconfdir}/mender/mender.conf
+    fi
+    if [ -f ${B}/persistent_mender.conf ]; then
+        install -m 0600 ${B}/persistent_mender.conf ${D}/data/mender/mender.conf
+    fi
+
+    #install server certificate
+    if [ -f ${WORKDIR}/server.crt ]; then
+        install -m 0755 -d $(dirname ${D}${MENDER_CERT_LOCATION})
+        install -m 0444 ${WORKDIR}/server.crt ${D}${MENDER_CERT_LOCATION}
+    fi
+
+    install -d ${D}/${localstatedir}/lib/mender
+
+    # install artifact verification key, if any.
+    if [ -e ${WORKDIR}/artifact-verify-key.pem ]; then
+        if [ -n "${MENDER_ARTIFACT_VERIFY_KEY}" ]; then
+            bbfatal "You can not specify both MENDER_ARTIFACT_VERIFY_KEY and have artifact-verify-key.pem in SRC_URI."
+        fi
+        install -m 0444 ${WORKDIR}/artifact-verify-key.pem ${D}${sysconfdir}/mender
+    elif [ -n "${MENDER_ARTIFACT_VERIFY_KEY}" ]; then
+        install -m 0444 "${MENDER_ARTIFACT_VERIFY_KEY}" ${D}${sysconfdir}/mender/artifact-verify-key.pem
+    fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'mender-image', 'true', 'false', d)}; then
+        # symlink /var/lib/mender to /data/mender
+        rm -rf ${D}/${localstatedir}/lib/mender
+        ln -s /data/mender ${D}/${localstatedir}/lib/mender
+
+        install -m 755 -d ${D}/data/mender
+        install -m 444 ${B}/device_type ${D}/data/mender/
+    fi
+
+    # Setup blacklist to ensure udev does not automatically mount Mender managed partitions
+    install -d ${D}${sysconfdir}/udev/mount.blacklist.d
+    echo ${MENDER_ROOTFS_PART_A} > ${D}${sysconfdir}/udev/mount.blacklist.d/mender
+    echo ${MENDER_ROOTFS_PART_B} >> ${D}${sysconfdir}/udev/mount.blacklist.d/mender
+}

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.1.bb
@@ -26,3 +26,61 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & Op
 
 DEPENDS += "xz openssl"
 RDEPENDS_${PN} += "liblzma openssl"
+
+do_install() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1 \
+        prefix=${D} \
+        bindir=${bindir} \
+        datadir=${datadir} \
+        sysconfdir=${sysconfdir} \
+        systemd_unitdir=${systemd_unitdir} \
+        install-bin \
+        install-identity-scripts \
+        install-inventory-scripts \
+        install-systemd \
+        ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'install-modules', '', d)}
+
+    #install our prepared configuration
+    install -d ${D}/${sysconfdir}/mender
+    install -d ${D}/data/mender
+    if [ -f ${B}/transient_mender.conf ]; then
+        install -m 0600 ${B}/transient_mender.conf ${D}/${sysconfdir}/mender/mender.conf
+    fi
+    if [ -f ${B}/persistent_mender.conf ]; then
+        install -m 0600 ${B}/persistent_mender.conf ${D}/data/mender/mender.conf
+    fi
+
+    #install server certificate
+    if [ -f ${WORKDIR}/server.crt ]; then
+        install -m 0755 -d $(dirname ${D}${MENDER_CERT_LOCATION})
+        install -m 0444 ${WORKDIR}/server.crt ${D}${MENDER_CERT_LOCATION}
+    fi
+
+    install -d ${D}/${localstatedir}/lib/mender
+
+    # install artifact verification key, if any.
+    if [ -e ${WORKDIR}/artifact-verify-key.pem ]; then
+        if [ -n "${MENDER_ARTIFACT_VERIFY_KEY}" ]; then
+            bbfatal "You can not specify both MENDER_ARTIFACT_VERIFY_KEY and have artifact-verify-key.pem in SRC_URI."
+        fi
+        install -m 0444 ${WORKDIR}/artifact-verify-key.pem ${D}${sysconfdir}/mender
+    elif [ -n "${MENDER_ARTIFACT_VERIFY_KEY}" ]; then
+        install -m 0444 "${MENDER_ARTIFACT_VERIFY_KEY}" ${D}${sysconfdir}/mender/artifact-verify-key.pem
+    fi
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'mender-image', 'true', 'false', d)}; then
+        # symlink /var/lib/mender to /data/mender
+        rm -rf ${D}/${localstatedir}/lib/mender
+        ln -s /data/mender ${D}/${localstatedir}/lib/mender
+
+        install -m 755 -d ${D}/data/mender
+        install -m 444 ${B}/device_type ${D}/data/mender/
+    fi
+
+    # Setup blacklist to ensure udev does not automatically mount Mender managed partitions
+    install -d ${D}${sysconfdir}/udev/mount.blacklist.d
+    echo ${MENDER_ROOTFS_PART_A} > ${D}${sysconfdir}/udev/mount.blacklist.d/mender
+    echo ${MENDER_ROOTFS_PART_B} >> ${D}${sysconfdir}/udev/mount.blacklist.d/mender
+}

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -31,6 +31,7 @@ from common import (
     get_local_conf_orig_path,
     make_tempdir,
     version_is_minimum,
+    reset_build_conf,
 )
 
 
@@ -1079,3 +1080,61 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         assert re.search(test2_re, fstab, flags=re.MULTILINE) is not None
         assert re.search(test3_re, fstab, flags=re.MULTILINE) is not None
         assert re.search(test4_re, fstab, flags=re.MULTILINE) is not None
+
+    @pytest.mark.min_mender_version("2.5.0")
+    @pytest.mark.only_with_image("ext4")
+    def test_mender_inventory_network_scripts(self, prepared_test_build, bitbake_image):
+        """
+        Test the 'inventory-network-scripts' build feature configuration through
+        'PACKAGECONFIG' is working as expected.
+
+        This verifies that the 'inventory-network-scripts' option is a part
+        build, and also that the inventory scripts are not included when
+        removed.
+
+
+        The test only runs for sdimg, as the build image should not really matter here.
+        """
+
+        #
+        # Feature enabled
+        #
+        reset_build_conf(prepared_test_build["build_dir"])
+        build_image(
+            prepared_test_build["build_dir"],
+            prepared_test_build["bitbake_corebase"],
+            bitbake_image,
+            ['PACKAGECONFIG_append_pn-mender-client = " inventory-network-scripts"'],
+        )
+        rootfs = latest_build_artifact(
+            prepared_test_build["build_dir"], "core-image*.ext4"
+        )
+        assert len(rootfs) > 0, "rootfs not generated"
+
+        output = subprocess.check_output(
+            ["debugfs", "-R", "ls /usr/share/mender/inventory", rootfs]
+        )
+        assert (
+            b"mender-inventory-geo" in output,
+        ), "mender-inventory-network-scripts seems not to be a part of the image, like they should"
+
+        #
+        # Feature disabled
+        #
+        reset_build_conf(prepared_test_build["build_dir"])
+        build_image(
+            prepared_test_build["build_dir"],
+            prepared_test_build["bitbake_corebase"],
+            bitbake_image,
+            ['PACKAGECONFIG_remove_pn-mender-client = " inventory-network-scripts"'],
+        )
+        rootfs = latest_build_artifact(
+            prepared_test_build["build_dir"], "core-image*.ext4"
+        )
+        assert len(rootfs) > 0, "ext4 not generated"
+        output = subprocess.check_output(
+            ["debugfs", "-R", "ls /usr/share/mender/inventory", rootfs]
+        )
+        assert (
+            b"mender-inventory-geo" not in output,
+        ), "mender-inventory-network-scripts unexpectedly a part of the image"


### PR DESCRIPTION
This adds a feature: 'mender-inventory-geo-script' which installs the
inventory-geo script as an inventory script when the Mender-client is installed.

By default, this is a sub-feature of the following features to go along with the
current setup which installs the script by default:

* mender-full
* mender-full-ubi
* mender-full-bios

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

