### PR TITLE
MEN-4030: Add DBus busconfig file

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -29,6 +29,7 @@ inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "${MENDER_CLIENT}.service"
 FILES_${PN} += "\
+    ${datadir}/dbus-1/system.d/io.mender.AuthenticationManager.conf \
     ${datadir}/mender/identity \
     ${datadir}/mender/identity/mender-device-identity \
     ${datadir}/mender/inventory \
@@ -245,6 +246,7 @@ do_install() {
         install-identity-scripts \
         install-inventory-scripts \
         install-systemd \
+        ${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'install-dbus', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'install-modules', '', d)}
 
     #install our prepared configuration

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -91,7 +91,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "5649992d13a6fda40abfac7730a62b07",
+                   "md5": "b88631a5f7973871d7dac12e01a42e85",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1102,3 +1102,11 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
 
         # Actual test.
         assert "libglib" not in output
+
+        # Make sure busconfig files are also gone.
+        assert not os.path.exists(
+            os.path.join(env["D"], "usr/share/dbus-1/system.d/io.mender.conf")
+        )
+        assert not os.path.exists(
+            os.path.join(env["D"], "etc/dbus-1/system.d/io.mender.conf")
+        )


### PR DESCRIPTION
```
commit 1729504e4ad4136b456e5e6d3b276fe6aca27a15
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 5 11:06:20 2020

    Update mender-image-tests in order to test DBus files.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 61d98f345746091c84313ce27ddca64b15c80fc3
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 5 11:05:42 2020

    Update mender-client checksum after adding godbus test dependency.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit a594eed3f8e4a81a14f66d4e5be817dd2401d926
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 5 08:14:25 2020

    MEN-4030: Test that busconfig files are gone when dbus is off.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit a71a79ab67fd5f21546e40f9043fe98c3a37f7b7
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Nov 4 18:14:18 2020

    MEN-4030: mender-client: Add DBus busconfig files.
    
    Changelog: Title
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```