### PR TITLE
MEN-4030: Add DBus busconfig file

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -29,6 +29,7 @@ inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "${MENDER_CLIENT}.service"
 FILES_${PN} += "\
+    ${datadir}/dbus-1/system.d/io.mender.AuthenticationManager.conf \
     ${datadir}/mender/identity \
     ${datadir}/mender/identity/mender-device-identity \
     ${datadir}/mender/inventory \
@@ -245,6 +246,7 @@ do_install() {
         install-identity-scripts \
         install-inventory-scripts \
         install-systemd \
+        ${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'install-dbus', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'install-modules', '', d)}
 
     #install our prepared configuration

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -91,7 +91,7 @@ def mender_license(branch):
         }
     else:
         return {
-                   "md5": "5649992d13a6fda40abfac7730a62b07",
+                   "md5": "3c9c9b85566a003c928f5a2dd93aa21e",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL",
         }
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1102,3 +1102,11 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
 
         # Actual test.
         assert "libglib" not in output
+
+        # Make sure busconfig files are also gone.
+        assert not os.path.exists(
+            os.path.join(env["D"], "usr/share/dbus-1/system.d/io.mender.conf")
+        )
+        assert not os.path.exists(
+            os.path.join(env["D"], "etc/dbus-1/system.d/io.mender.conf")
+        )


### PR DESCRIPTION
```
commit 27b4ae73fddf7ae89f543756d09136a30a0368ba
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 5 11:06:20 2020

    Update mender-image-tests in order to test DBus files.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit dee4d841beeeb6815f4cb3dfe4c9e1b53c3e25c8
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 5 11:05:42 2020

    Update mender-client checksum after adding godbus test dependency.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 3b94af210b622d0cd771f57c334758c0dc62f9ff
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Nov 5 08:14:25 2020

    MEN-4030: Test that busconfig files are gone when dbus is off.
    
    Changelog: None
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 7ca4da99b16c435d57d54c31dd87363c99af20b2
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Wed Nov 4 18:14:18 2020

    MEN-4030: mender-client: Add DBus busconfig files.
    
    Changelog: Title
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```