### PR TITLE
mender-client: Ensure growfs works on GPT and does not resize if a li…

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/files/mender-client-resize-data-part.sh.in
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-client-resize-data-part.sh.in
@@ -26,7 +26,10 @@ data_part_end=$(expr ${data_part_start} + ${data_part_size})
 # because of 'set -e'. Silence this error
 free_space=$(expr ${total_disk_size} - ${data_part_end} || true)
 
-if [ ${free_space} -eq 0 ]; then
+# If there is less than 8196 blocks = 4 MiB free unused space, we consider
+# the disk as already resized. After resizing, some disk space may still
+# have been left unused.
+if [ ${free_space} -lt 8196 ]; then
     echo "Disk has already been resized."
     exit 0
 fi

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -1,7 +1,7 @@
 DESCRIPTION = "Mender tool for doing OTA software updates."
 HOMEPAGE = "https://mender.io"
 
-RDEPENDS_${PN}_append_mender-growfs-data_mender-systemd = " parted"
+RDEPENDS_${PN}_append_mender-growfs-data_mender-systemd = " parted util-linux-fdisk"
 
 def cert_location_if_server_crt_in(src_uri, d):
     for src in src_uri.split():


### PR DESCRIPTION
…ttle space is left unused

Related issue: MEN-4176

Add redepends on util-linux-fdisk as busybox fdisk does not seem to support GPT filesystems.

Added a grace amount of free space that is allowed, such that mender does not end up in a state
where it will run fdisk and parted on every boot.
Cases have been seen where some small part of the disk is left unused after resizing.

Changelog: Title
Signed-off-by: Kasper Føns <kf@chora.dk>