### PR TITLE
MEN-4033: Acceptance test test_dbus_non_root_access

### DIFF
--- a/tests/meta-mender-ci/conf/layer.conf
+++ b/tests/meta-mender-ci/conf/layer.conf
@@ -19,3 +19,8 @@ MENDER_MOCK_SERVER = "mender-mock-server"
 MENDER_MOCK_SERVER_vexpress-qemu-flash = ""
 
 LAYERDEPENDS_meta-mender-ci_append = " mender"
+
+IMAGE_CLASSES += "extrausers"
+EXTRA_USERS_PARAMS = "\
+    useradd -p '' mender-ci-tester; \
+"


### PR DESCRIPTION
 Install a non-root user in meta-mender-ci and use it in the new test to
verify that AccessDenied is returned when accessing Mender D-Bus API.

