### PR TITLE
Switch to a more relaxed license checksum checker for the Git recipe.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.4.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.4.0.bb
@@ -19,6 +19,10 @@ SRCREV = "b2c230e73b0e7c90d23ce03caedaec42728fa3f3"
 
 ################################################################################
 
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=d1fedd6e15ea779ce58fafea700f0c37"
 

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -52,29 +52,16 @@ PV = "${@mender_version_from_preferred_version(d, '${SRCPV}')}"
 SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=${MENDER_ARTIFACT_BRANCH}"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
-# dependencies) are included in the LICENSE variable below.
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 def mender_license(branch):
-    if branch == "3.1.x" or branch == "3.2.x":
-        return {
-                   "md5": "f3d4710343f1b959e4fa6b728ce12264",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
-        }
-    elif branch == "3.3.x":
-        return {
-                   "md5": "99143e34cf23a99976a299da9fa93bcf",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
-        }
-    elif branch == "3.4.x":
-        return {
-                   "md5": "d1fedd6e15ea779ce58fafea700f0c37",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
-        }
-    else:
-        return {
-                   "md5": "0813d261553528b7275c19312036befb",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
-        }
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_ARTIFACT_BRANCH'))['md5']}"
+    # Only one currently. If the sub licenses change we may introduce more.
+    return {
+               "md5": "0813d261553528b7275c19312036befb",
+               "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
+    }
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
 LICENSE = "${@mender_license(d.getVar('MENDER_ARTIFACT_BRANCH'))['license']}"
 
 # Downprioritize this recipe in version selections.

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.1.bb
@@ -20,7 +20,9 @@ SRCREV = "c008bca66eda3993ab29d8b567bbe696e3e04866"
 ################################################################################
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
-# dependencies) are included in the LICENSE variable below.
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=3e7426c258f60f9876ae3746f54c49d4"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.1.bb
@@ -20,7 +20,9 @@ SRCREV = "ffef645f932dd2fd7545705288f6e6df14417966"
 ################################################################################
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
-# dependencies) are included in the LICENSE variable below.
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=5649992d13a6fda40abfac7730a62b07"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL"
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -52,49 +52,24 @@ def mender_version_from_preferred_version(d, srcpv):
 SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=${MENDER_BRANCH}"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
-# dependencies) are included in the LICENSE variable below.
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 def mender_license(branch):
-    if branch == "1.7.x":
+    import re
+    if branch.startswith("1."):
         return {
-                   "md5": "5632b9f17043c6f5f532501778595c78",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
-    elif branch.startswith("1."):
+    elif re.match(r"2\.[0-3]\.x", branch) is not None:
         return {
-                   "md5": "debbe5e440f2e65465e86b25fc7c9fcc",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
-        }
-    elif branch == "2.0.x":
-        return {
-                   "md5": "ccb00e21c31df7189b2bd237ed86e7c2",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
-        }
-    elif branch == "2.1.x":
-        return {
-                   "md5": "1c872e33af7af0e7ee99e17f38dbcffc",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
-        }
-    elif branch == "2.2.x":
-        return {
-                   "md5": "80ba3790b689991e47685da401fd3375",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
-        }
-    elif branch == "2.3.x":
-        return {
-                   "md5": "3e7426c258f60f9876ae3746f54c49d4",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
-        }
-    elif branch == "2.4.x":
-        return {
-                   "md5": "5649992d13a6fda40abfac7730a62b07",
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL",
         }
     else:
         return {
-                   "md5": "76d17470649a8fdd1a679a9c56a35c15",
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL",
         }
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=${@mender_license(d.getVar('MENDER_BRANCH'))['md5']}"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
 LICENSE = "${@mender_license(d.getVar('MENDER_BRANCH'))['license']}"
 
 # Downprioritize this recipe in version selections.

--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -7,8 +7,12 @@ SRC_URI = "git://github.com/mendersoftware/mender-shell.git;protocol=https;branc
 SRCREV = "${AUTOREV}"
 PV = "0.1+git${SRCPV}"
 
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
-LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LIC_FILES_CHKSUM.sha256;md5=98fb11e1874b0aef96c1bac976ca6aa3"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
 
 inherit go-mod
 inherit go-ptest


### PR DESCRIPTION
This doesn't actually cover all license we use, so it should not be
used for production recipes, but should be acceptable for the Git
recipes.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
