### PR TITLE
dataimg: create symlink to dataimg in IMGDEPLOYDIR

### DIFF
--- a/meta-mender-core/classes/mender-dataimg.bbclass
+++ b/meta-mender-core/classes/mender-dataimg.bbclass
@@ -22,6 +22,7 @@ IMAGE_CMD_dataimg() {
 IMAGE_CMD_dataimg_mender-image-ubi() {
     mkfs.ubifs -o "${WORKDIR}/data.ubifs" -r "${IMAGE_ROOTFS}/data" ${MKUBIFS_ARGS}
     install -m 0644 "${WORKDIR}/data.ubifs" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
+    ln -sfn "${IMAGE_NAME}.dataimg" "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.dataimg"
 }
 
 # We need the data contents intact.


### PR DESCRIPTION
Fixes do_image_ubimg task ubinize error "error 2 (No such file or directory)" since the
referenced "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.dataimg" does not exist if the
symlink is not created.
