### PR TITLE
mender-shell: align recipe with other Mender go recipes

### DIFF
--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Mender program for remote terminal access."
+DESCRIPTION = "Mender add-on for remote terminal access."
 HOMEPAGE = "https://mender.io"
 
 SRC_URI = "git://github.com/mendersoftware/mender-shell.git;protocol=https;branch=master"
@@ -14,16 +14,22 @@ PV = "0.1+git${SRCPV}"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
 
-inherit go-mod
-inherit go-ptest
-
-DEPENDS_append = " pkgconfig-native glib-2.0"
+DEPENDS_append = " glib-2.0"
 RDEPENDS_${PN} = "glib-2.0"
+
+SYSTEMD_AUTO_ENABLE ?= "enable"
+
+inherit go
+inherit go-ptest
+inherit pkgconfig
+inherit systemd
 
 GO_IMPORT = "github.com/mendersoftware/mender-shell"
 
 do_compile() {
-    oe_runmake V=1
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1
 }
 
 do_install() {
@@ -38,10 +44,6 @@ do_install() {
         install-bin \
         install-systemd
 }
-
-inherit systemd
-
-SYSTEMD_AUTO_ENABLE ?= "enable"
 
 FILES_${PN}_append += "\
     ${systemd_unitdir}/system/mender-shell.service \


### PR DESCRIPTION
Namely:
* inherit go instead of go-mod
* inherit pkgconfig instead of manually specifying dependency
* fix do_compile function
* reorder declarations
* use term "add-on" in description