### PR TITLE
Add another kernel module to QEMU, needed by TestFaultTolerance.

### DIFF
--- a/meta-mender-qemu/recipes-mender/mender-client/mender-client-test-files.inc
+++ b/meta-mender-qemu/recipes-mender/mender-client/mender-client-test-files.inc
@@ -11,7 +11,7 @@ DEPENDS_append_mender-image_qemuall = " softhsm opensc gnutls p11-kit libp11"
 RDEPENDS_${PN}_append_mender-image_qemuall = " softhsm opensc gnutls p11-kit libp11 gnutls-bin"
 
 # Needed for the TestFaultTolerance tests in the integration repository.
-RDEPENDS_${PN}_append_mender-image_qemuall = " kernel-module-xt-string"
+RDEPENDS_${PN}_append_mender-image_qemuall = " kernel-module-xt-string kernel-module-ts-bm"
 
 # Used as a rootfs-image replacement when testing update modules.
 FILES_${PN}_append_mender-image_qemuall = " ${sysconfdir}/mender/rootfs-image-v2.conf \


### PR DESCRIPTION
Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
