### PR TITLE
MEN-4242: mender-shell: generate and install mender-shell.conf

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -109,6 +109,7 @@ PACKAGECONFIG[grub] = ",,,grub-editenv grub-mender-grubenv"
 # because otherwise the Yocto QA checks will complain.
 PACKAGECONFIG[modules] = ",,,bash"
 PACKAGECONFIG[dbus] = ",,glib-2.0,glib-2.0"
+PACKAGECONFIG[inventory-network-scripts] = ",,,"
 
 # NOTE: Splits the mender.conf file by default into a transient and a persistent config. Needs to be
 # explicitly disabled if this is not to apply.


### PR DESCRIPTION
Changelog: mender-shell: generate and install mender-shell.conf with
required fields. `ServerURL` can be configured setting yocto variable
`MENDER_SERVER_URL`, same as used by mender-client recipe. If a
`mender-shell.conf` file is found in the `SRC_URI`, the contents will be
merged.

Note: includes test from https://github.com/mendersoftware/mender-image-tests/pull/33

In addition:
* mender-client: fix QA Issue: invalid PACKAGECONFIG: inventory-network-scripts
Changelog: Title