### PR TITLE
[zeus] mender-shell + revert rootfs labels + tests updates

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -126,8 +126,8 @@ EOF
     fi
 
     cat >> "$wks" <<EOF
-part --source rawcopy --sourceparams="file=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${ARTIFACTIMG_FSTYPE}" --fstype=${ARTIFACTIMG_FSTYPE} --label primary --ondisk "$ondisk_dev" --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $part_type_params
-part --source rawcopy --sourceparams="file=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${ARTIFACTIMG_FSTYPE}" --fstype=${ARTIFACTIMG_FSTYPE} --label secondary --ondisk "$ondisk_dev" --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $part_type_params
+part --source rawcopy --sourceparams="file=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${ARTIFACTIMG_FSTYPE}" --ondisk "$ondisk_dev" --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $part_type_params
+part --source rawcopy --sourceparams="file=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${ARTIFACTIMG_FSTYPE}" --ondisk "$ondisk_dev" --align $alignment_kb --fixed-size ${MENDER_CALC_ROOTFS_SIZE}k $part_type_params
 EOF
 
     if [ "${MENDER_SWAP_PART_SIZE_MB}" -ne "0" ]; then

--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -7,8 +7,12 @@ SRC_URI = "git://github.com/mendersoftware/mender-shell.git;protocol=https;branc
 SRCREV = "${AUTOREV}"
 PV = "0.1+git${SRCPV}"
 
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
-LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LIC_FILES_CHKSUM.sha256;md5=98fb11e1874b0aef96c1bac976ca6aa3"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
 
 inherit go-mod
 inherit go-ptest

--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -17,6 +17,9 @@ LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=7fd64609fe1bce47db0e8f6e
 inherit go-mod
 inherit go-ptest
 
+DEPENDS_append = " pkgconfig-native glib-2.0"
+RDEPENDS_${PN} = "glib-2.0"
+
 GO_IMPORT = "github.com/mendersoftware/mender-shell"
 
 do_compile() {
@@ -40,6 +43,6 @@ inherit systemd
 
 SYSTEMD_AUTO_ENABLE ?= "enable"
 
-FILES_${PN}_append-mender-shell-systemd += "\
+FILES_${PN}_append += "\
     ${systemd_unitdir}/system/mender-shell.service \
 "

--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "Mender program for remote terminal access."
+DESCRIPTION = "Mender add-on for remote terminal access."
 HOMEPAGE = "https://mender.io"
 
 SRC_URI = "git://github.com/mendersoftware/mender-shell.git;protocol=https;branch=master"
@@ -14,16 +14,22 @@ PV = "0.1+git${SRCPV}"
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
 
-inherit go-mod
-inherit go-ptest
-
-DEPENDS_append = " pkgconfig-native glib-2.0"
+DEPENDS_append = " glib-2.0"
 RDEPENDS_${PN} = "glib-2.0"
+
+SYSTEMD_AUTO_ENABLE ?= "enable"
+
+inherit go
+inherit go-ptest
+inherit pkgconfig
+inherit systemd
 
 GO_IMPORT = "github.com/mendersoftware/mender-shell"
 
 do_compile() {
-    oe_runmake V=1
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1
 }
 
 do_install() {
@@ -38,10 +44,6 @@ do_install() {
         install-bin \
         install-systemd
 }
-
-inherit systemd
-
-SYSTEMD_AUTO_ENABLE ?= "enable"
 
 FILES_${PN}_append += "\
     ${systemd_unitdir}/system/mender-shell.service \

--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -1,0 +1,41 @@
+DESCRIPTION = "Mender program for remote terminal access."
+HOMEPAGE = "https://mender.io"
+
+SRC_URI = "git://github.com/mendersoftware/mender-shell.git;protocol=https;branch=master"
+
+# See: https://www.yoctoproject.org/docs/2.5.1/dev-manual/dev-manual.html#automatically-incrementing-a-binary-package-revision-number
+SRCREV = "${AUTOREV}"
+PV = "0.1+git${SRCPV}"
+
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LIC_FILES_CHKSUM.sha256;md5=98fb11e1874b0aef96c1bac976ca6aa3"
+
+inherit go-mod
+inherit go-ptest
+
+GO_IMPORT = "github.com/mendersoftware/mender-shell"
+
+do_compile() {
+    oe_runmake V=1
+}
+
+do_install() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1 \
+        prefix=${D} \
+        bindir=${bindir} \
+        datadir=${datadir} \
+        sysconfdir=${sysconfdir} \
+        systemd_unitdir=${systemd_unitdir} \
+        install-bin \
+        install-systemd
+}
+
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE ?= "enable"
+
+FILES_${PN}_append-mender-shell-systemd += "\
+    ${systemd_unitdir}/system/mender-shell.service \
+"

--- a/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
+++ b/meta-mender-core/recipes-mender/mender-shell/mender-shell.bb
@@ -18,6 +18,7 @@ DEPENDS_append = " glib-2.0"
 RDEPENDS_${PN} = "glib-2.0"
 
 MENDER_SERVER_URL ?= "https://docker.mender.io"
+MENDER_SHELL_USER ??= "nobody"
 SYSTEMD_AUTO_ENABLE ?= "enable"
 
 B = "${WORKDIR}/build"
@@ -45,8 +46,11 @@ python do_prepare_mender_shell_conf() {
         with open(src_conf) as fd:
             mender_shell_conf = json.load(fd)
 
-    if not "ServerURL" in mender_shell_conf:
+    if "ServerURL" not in mender_shell_conf:
         mender_shell_conf["ServerURL"] = d.getVar("MENDER_SERVER_URL")
+
+    if "User" not in mender_shell_conf:
+        mender_shell_conf["User"] = d.getVar("MENDER_SHELL_USER")
 
     dst_conf = os.path.join(d.getVar("B"), "mender-shell.conf")
     with open(dst_conf, "w") as fd:
@@ -56,6 +60,7 @@ python do_prepare_mender_shell_conf() {
 addtask do_prepare_mender_shell_conf after do_compile before do_install
 do_prepare_mender_shell_conf[vardeps] = " \
     MENDER_SERVER_URL \
+    MENDER_SHELL_USER \
 "
 
 do_install() {

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -16,5 +16,8 @@ MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT ?= "608"
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_FEATURES += "splash"
 
+# Install Mender add-ons
+IMAGE_INSTALL_append = " mender-shell"
+
 LAYERSERIES_COMPAT_mender-demo = "zeus"
 LAYERDEPENDS_mender-demo = "mender"

--- a/meta-mender-demo/recipes-mender/mender-shell/mender-shell.bbappend
+++ b/meta-mender-demo/recipes-mender/mender-shell/mender-shell.bbappend
@@ -1,0 +1,1 @@
+MENDER_SHELL_USER ?= "root"


### PR DESCRIPTION
As the title says:
* Bring mender-shell related commits (skipped from #1172 due to #1213).
* Revert rootfs label change (see #1219).
* And update tests (from #1232).

This should be all to finally tag/release `zeus`.