### PR TITLE
Amend shell syntax conditional dbus + revert skip test

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -268,7 +268,7 @@ do_install() {
 
     # install dbus files
     if grep -q install-dbus ${B}/src/${GO_IMPORT}/Makefile; then
-        if ${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'true', '', d)}; then
+        if ${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'true', 'false', d)}; then
             oe_runmake \
                 -C ${B}/src/${GO_IMPORT} \
                 V=1 \

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1092,7 +1092,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         assert re.search(test3_re, fstab, flags=re.MULTILINE) is not None
         assert re.search(test4_re, fstab, flags=re.MULTILINE) is not None
 
-    @pytest.mark.min_mender_version("2.5.0")
+    @pytest.mark.min_mender_version("1.0.0")
     def test_build_nodbus(self, request, prepared_test_build, bitbake_path):
         """Test that we can remove dbus from PACKAGECONFIG, and that this causes the
         library dependency to be gone. The opposite is not tested, since we


### PR DESCRIPTION
Amend of #1236:

```
Fix shell script parse error when no dbus in PACKAGECONFIG

Error introduced at 4f8b02a, and it only shows when building with
preferred version master (grep succeed) and removing dbus from
PACKAGECONFIG.
```

And  and revert of #1237:
```
Revert "[tests/acceptance] test_build_nodbus: set min mender 2.5.0"

This reverts commit 76a2d441692d741701b7cd4ac60ae2d7db0a4c71.

This commit was not needed in the first place, the error that motivated
it was miss-understood. See previous commit fixing the shell syntax.
```