### PR TITLE
MEN-4273 (dunfell): Copy self-signed certificate to ca-certificates

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -93,7 +93,8 @@ INSANE_SKIP_${PN}-ptest = "ldflags textrel"
 
 GO_IMPORT = "github.com/mendersoftware/mender"
 
-PACKAGECONFIG ?= "${@mender_feature_is_enabled("mender-client-install", "inventory-network-scripts", "", d)}"
+_MENDER_PACKAGECONFIG_DEFAULT = "${@mender_feature_is_enabled("mender-client-install", "dbus inventory-network-scripts", "", d)}"
+PACKAGECONFIG ?= "${_MENDER_PACKAGECONFIG_DEFAULT}"
 
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-client-install', ' mender-client-install', '', d)}"
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', ' u-boot', '', d)}"
@@ -106,11 +107,15 @@ PACKAGECONFIG[grub] = ",,,grub-editenv grub-mender-grubenv"
 # a very large requirement, which we will not mandate. Bash however, we require,
 # because otherwise the Yocto QA checks will complain.
 PACKAGECONFIG[modules] = ",,,bash"
+PACKAGECONFIG[dbus] = ",,glib-2.0,glib-2.0"
 
 # NOTE: Splits the mender.conf file by default into a transient and a persistent config. Needs to be
 # explicitly disabled if this is not to apply.
 PACKAGECONFIG[split-mender-config] = ",,,"
 PACKAGECONFIG_append = " split-mender-config"
+
+_MENDER_TAGS = "${@bb.utils.contains('PACKAGECONFIG', 'dbus', '', 'nodbus', d)}"
+EXTRA_OEMAKE_append = " TAGS='${_MENDER_TAGS}'"
 
 do_compile() {
     GOPATH="${B}:${S}"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -29,6 +29,7 @@ inherit systemd
 
 SYSTEMD_SERVICE_${PN} = "${MENDER_CLIENT}.service"
 FILES_${PN} += "\
+    ${datadir}/dbus-1/system.d/io.mender.AuthenticationManager.conf \
     ${datadir}/mender/identity \
     ${datadir}/mender/identity/mender-device-identity \
     ${datadir}/mender/inventory \
@@ -246,6 +247,7 @@ do_install() {
         install-inventory-local-scripts \
         ${@bb.utils.contains('PACKAGECONFIG', 'inventory-network-scripts', 'install-inventory-network-scripts', '', d)} \
         install-systemd \
+        ${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'install-dbus', '', d)} \
         ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'install-modules', '', d)}
 
     #install our prepared configuration

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -22,6 +22,8 @@ MENDER_RETRY_POLL_INTERVAL_SECONDS ?= "300"
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
+localdatadir = "${prefix}/local/share"
+
 inherit go
 inherit go-ptest
 inherit pkgconfig
@@ -47,6 +49,7 @@ FILES_${PN} += "\
     ${sysconfdir}/mender.conf \
     ${sysconfdir}/udev/mount.blacklist.d/mender \
     ${systemd_unitdir}/system/${MENDER_CLIENT}.service \
+    ${localdatadir}/ca-certificates/mender/server.crt \
     /data/mender/device_type \
     /data/mender/mender.conf \
 "
@@ -185,7 +188,6 @@ python do_prepare_mender_conf() {
     conf_maybe_add("RetryPollIntervalSeconds", "MENDER_RETRY_POLL_INTERVAL_SECONDS", getvar=True, integer=True)
     conf_maybe_add("RootfsPartA", "MENDER_ROOTFS_PART_A", getvar=True, integer=False)
     conf_maybe_add("RootfsPartB", "MENDER_ROOTFS_PART_B", getvar=True, integer=False)
-    conf_maybe_add("ServerCertificate", "MENDER_CERT_LOCATION", getvar=True, integer=False)
     conf_maybe_add("ServerURL", "MENDER_SERVER_URL", getvar=True, integer=False)
     conf_maybe_add("UpdatePollIntervalSeconds", "MENDER_UPDATE_POLL_INTERVAL_SECONDS", getvar=True, integer=True)
 
@@ -264,6 +266,8 @@ do_install() {
     if [ -f ${WORKDIR}/server.crt ]; then
         install -m 0755 -d $(dirname ${D}${MENDER_CERT_LOCATION})
         install -m 0444 ${WORKDIR}/server.crt ${D}${MENDER_CERT_LOCATION}
+        install -m 0755 -d ${D}${localdatadir}/ca-certificates/mender
+        install -m 0444 ${WORKDIR}/server.crt ${D}${localdatadir}/ca-certificates/mender/server.crt
     fi
 
     install -d ${D}/${localstatedir}/lib/mender
@@ -327,4 +331,9 @@ do_install_append_mender-persist-systemd-machine-id() {
     ln -sf ../mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/
     install -d -m 755 ${D}${bindir}
     install -m 755 ${WORKDIR}/mender-client-set-systemd-machine-id.sh ${D}${bindir}/
+}
+
+# Required if a self-signed certificate was added, but harmless in any case, so run unconditionally
+pkg_postinst_${PN} () {
+    SYSROOT="$D" $D${sbindir}/update-ca-certificates
 }

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.2.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.2.1.bb
@@ -27,6 +27,9 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
 DEPENDS += "xz"
 RDEPENDS_${PN} += "liblzma"
 
+# Not supported in versions < 2.5.0.
+_MENDER_PACKAGECONFIG_DEFAULT_remove = "dbus"
+
 # MEN-2948: systemd service is still named mender.service in 2.2.x
 MENDER_CLIENT = "mender"
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.3.1.bb
@@ -29,6 +29,9 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8"
 DEPENDS += "xz"
 RDEPENDS_${PN} += "liblzma"
 
+# Not supported in versions < 2.5.0.
+_MENDER_PACKAGECONFIG_DEFAULT_remove = "dbus"
+
 do_install() {
     oe_runmake \
         -C ${B}/src/${GO_IMPORT} \

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.4.1.bb
@@ -29,6 +29,9 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & Op
 DEPENDS += "xz openssl"
 RDEPENDS_${PN} += "liblzma openssl"
 
+# Not supported in versions < 2.5.0.
+_MENDER_PACKAGECONFIG_DEFAULT_remove = "dbus"
+
 do_install() {
     oe_runmake \
         -C ${B}/src/${GO_IMPORT} \

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1165,7 +1165,9 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             ['PACKAGECONFIG_remove = "dbus"'],
         )
 
-        env = get_bitbake_variables(request, "mender-client")
+        env = get_bitbake_variables(
+            request, "mender-client", prepared_test_build=prepared_test_build
+        )
 
         # Get dynamic section info from binary.
         output = subprocess.check_output(

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1150,3 +1150,30 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         assert (
             b"mender-inventory-geo" not in output
         ), "mender-inventory-network-scripts unexpectedly a part of the image"
+
+    @pytest.mark.min_mender_version("1.0.0")
+    def test_build_nodbus(self, request, prepared_test_build, bitbake_path):
+        """Test that we can remove dbus from PACKAGECONFIG, and that this causes the
+        library dependency to be gone. The opposite is not tested, since we
+        assume failure to link to the library will be caught in other tests that
+        test DBus functionality."""
+
+        build_image(
+            prepared_test_build["build_dir"],
+            prepared_test_build["bitbake_corebase"],
+            "mender-client",
+            ['PACKAGECONFIG_remove = "dbus"'],
+        )
+
+        env = get_bitbake_variables(request, "mender-client")
+
+        # Get dynamic section info from binary.
+        output = subprocess.check_output(
+            [env["READELF"], "-d", os.path.join(env["D"], "usr/bin/mender")]
+        ).decode()
+
+        # Verify the output is sane.
+        assert "libc" in output
+
+        # Actual test.
+        assert "libglib" not in output

--- a/tests/meta-mender-ci/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/tests/meta-mender-ci/recipes-mender/mender-client/mender-client_%.bbappend
@@ -1,0 +1,7 @@
+# Add these empty functions to prevent ptest from running for the acceptance
+# tests. They add significant running time to each test, and it is enough to
+# test them once in the main build.
+do_compile_ptest_base() {
+}
+do_install_ptest_base() {
+}


### PR DESCRIPTION
In addition, I ported the minumum commits to fix mender-client build in `dunfell`.

Changelog: mender-client: The self-signed Mender server certificate, if
present, is copied to ca-certificates in addition to
`MENDER_CERT_LOCATION` to be trusted by other services running in the
device.
