### PR TITLE
Dependabot updates + Misc clean-ups

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -44,7 +44,6 @@ FILES_${PN} += "\
     ${datadir}/mender/modules/v3/rpm \
     ${datadir}/mender/modules/v3/script \
     ${datadir}/mender/modules/v3/single-file \
-    ${sysconfdir}/mender.conf \
     ${sysconfdir}/udev/mount.blacklist.d/mender \
     ${systemd_unitdir}/system/${MENDER_CLIENT}.service \
     /data/mender/device_type \

--- a/meta-mender-qemu/docker/qemux86-64/Dockerfile
+++ b/meta-mender-qemu/docker/qemux86-64/Dockerfile
@@ -18,7 +18,7 @@
 # -e TENANT_TOKEN=<token>
 #       Use token as tenant token for client.
 
-FROM alpine:3.12.2
+FROM alpine:3.12.3
 
 # Install packages
 RUN apk update && apk upgrade && \

--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -1,7 +1,6 @@
 pytest==6.2.1
 fabric==2.5.0
 pytest-html==3.1.1
-pytest-xdist==2.1.0
 paramiko==2.7.2
 python-lzo==1.12
 ubi-reader==0.7.0

--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -8,5 +8,5 @@ ubi-reader==0.7.0
 filelock==3.0.12
 psutil==5.8.0
 pycrypto==2.6.1
-requests==2.25.0
+requests==2.25.1
 PyYAML==5.3.1

--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -1,4 +1,4 @@
-pytest==6.2.0
+pytest==6.2.1
 fabric==2.5.0
 pytest-html==3.1.1
 pytest-xdist==2.1.0

--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -6,7 +6,7 @@ paramiko==2.7.2
 python-lzo==1.12
 ubi-reader==0.7.0
 filelock==3.0.12
-psutil==5.7.2
+psutil==5.8.0
 pycrypto==2.6.1
 requests==2.25.0
 PyYAML==5.3.1

--- a/tests/meta-mender-ci/conf/distro/poky-mender-ci.conf
+++ b/tests/meta-mender-ci/conf/distro/poky-mender-ci.conf
@@ -1,7 +1,3 @@
-#@TYPE: Distribution
-#@NAME: Poky Mender CI
-#@DESCRIPTION: Distribution based on Poky with some enhancements for Mender Continuous Integration
-
 require conf/distro/poky.conf
 
 DISTRO = "poky-mender-ci"
@@ -10,6 +6,3 @@ DISTRO_NAME = "Poky (Yocto Project Reference Distro) with Mender CI enhancements
 
 # disable features that are not needed for QA
 DISTRO_FEATURES_remove = "alsa bluetooth irda x11 3g nfc bluez5 opengl wayland pulseaudio"
-
-# use opkg
-PACKAGE_CLASSES = "package_ipk"


### PR DESCRIPTION
#1240, #1241, #1242, #1244 and:

* [tests/acceptance] Remove pytest-xdist from requirements
(makes #1243 N.A.)
* [mender-client.inc] Remove nonexisting file from FILES
* [meta-mender-ci] Remove override of PACKAGE_CLASSES