### PR TITLE
Temporarily down-prioritize mender-binary-delta 1.2.0 in version sel.

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.2.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.2.0.bb
@@ -2,4 +2,4 @@ require mender-binary-delta.inc
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-#DEFAULT_PREFERENCE = "-1"
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
It depends on mender-artifact 3.5, which has not been released yet.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
