### PR TITLE
Add the MENDER_CONNECT_SHELL to meta-mender-core, defaults to /bin/sh

### DIFF
--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -18,6 +18,7 @@ DEPENDS_append = " glib-2.0"
 RDEPENDS_${PN} = "glib-2.0"
 
 MENDER_SERVER_URL ?= "https://docker.mender.io"
+MENDER_CONNECT_SHELL ??= "/bin/sh"
 MENDER_CONNECT_USER ??= "nobody"
 SYSTEMD_AUTO_ENABLE ?= "enable"
 SYSTEMD_SERVICE_${PN} = "mender-connect.service"
@@ -50,6 +51,9 @@ python do_prepare_mender_connect_conf() {
     if "ServerURL" not in mender_connect_conf:
         mender_connect_conf["ServerURL"] = d.getVar("MENDER_SERVER_URL")
 
+    if "Shell" not in mender_connect_conf:
+        mender_connect_conf["Shell"] = d.getVar("MENDER_CONNECT_SHELL")
+
     if "User" not in mender_connect_conf:
         mender_connect_conf["User"] = d.getVar("MENDER_CONNECT_USER")
 
@@ -61,6 +65,7 @@ python do_prepare_mender_connect_conf() {
 addtask do_prepare_mender_connect_conf after do_compile before do_install
 do_prepare_mender_connect_conf[vardeps] = " \
     MENDER_SERVER_URL \
+    MENDER_CONNECT_SHELL \
     MENDER_CONNECT_USER \
 "
 

--- a/meta-mender-demo/recipes-mender/mender-connect/mender-connect_%.bbappend
+++ b/meta-mender-demo/recipes-mender/mender-connect/mender-connect_%.bbappend
@@ -1,1 +1,2 @@
 MENDER_CONNECT_USER ?= "root"
+MENDER_CONNECT_SHELL ?= "/bin/bash"


### PR DESCRIPTION
Set it to /bin/bash in the meta-mender-demo layer

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
