### PR TITLE
Make mender-connect dependent on mender-client.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
@@ -1,13 +1,6 @@
 require mender-client_git.inc
 
-def mender_version_of_this_recipe(d, srcpv):
-    version = mender_version_from_preferred_version(d, srcpv)
-    if version.startswith("1."):
-        # Pre-2.0. We don't want to match this.
-        return "non-matching-version-" + version
-    else:
-        return version
-PV = "${@mender_version_of_this_recipe(d, '${SRCPV}')}"
+PV = "${@mender_version_from_preferred_version(d, '${SRCPV}')}"
 
 # MEN-2948: systemd service for the client is now named mender-client.service,
 # but it was called mender.service in 2.2 and earlier.

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -17,6 +17,9 @@ def mender_autorev_if_git_version(d):
         return "f6ffa190892202263fdb75975059fbb201adab6a"
 SRCREV ?= '${@mender_autorev_if_git_version(d)}'
 
+# Force the version of master packages to compare very highly to other versions.
+PKGV = "${@'999+master+git${SRCPV}' if '${PV}'.startswith('master') else '${PV}'}"
+
 def mender_branch_from_preferred_version(d):
     import re
     version = d.getVar("PREFERRED_VERSION")

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -15,7 +15,7 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"
 
 DEPENDS_append = " glib-2.0"
-RDEPENDS_${PN} = "glib-2.0"
+RDEPENDS_${PN} = "glib-2.0 mender-client (>= 2.5)"
 
 MENDER_SERVER_URL ?= "https://docker.mender.io"
 MENDER_CONNECT_SHELL ??= "/bin/sh"

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -16,8 +16,5 @@ MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT ?= "608"
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_FEATURES += "splash"
 
-# Install Mender add-ons
-IMAGE_INSTALL_append = " mender-connect"
-
 LAYERSERIES_COMPAT_mender-demo = "dunfell"
 LAYERDEPENDS_mender-demo = "mender"

--- a/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -8,3 +8,16 @@ RDEPENDS_${PN}_append_mender-client-install = "${@bb.utils.contains_any('MENDER_
 # way. Therefore we need LSB support so that the dynamic linker is found.
 # Specifically, this creates the symlink /lib64 -> /lib.
 RDEPENDS_${PN}_append_mender-client-install = " lsb-ld"
+
+def maybe_mender_connect(d):
+    pref = d.getVar('PREFERRED_VERSION_pn-mender-client')
+    if pref is None:
+        return " mender-connect"
+
+    if pref[0:3] in ["1.7", "2.0", "2.1", "2.2", "2.3", "2.4"]:
+        return ""
+    else:
+        return " mender-connect"
+
+# Install Mender add-ons, but only if the client is recent enough.
+RDEPENDS_${PN}_append_mender-image = "${@maybe_mender_connect(d)}"


### PR DESCRIPTION
Also make sure the demo layer only installs it if we are building a
recent enough client. `layer.conf` seems to have some restrictions on
inline Python, so move it to a recipe as a dependency instead.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

