### PR TITLE
dunfell: Mender 2.6.0 release

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.2.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.2.0.bb
@@ -2,4 +2,4 @@ require mender-binary-delta.inc
 
 # Enable this in Betas, not in finals.
 # Downprioritize this recipe in version selections.
-DEFAULT_PREFERENCE = "-1"
+#DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.5.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.5.0.bb
@@ -1,0 +1,29 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.5.x"
+
+# Tag: 3.5.0
+SRCREV = "b36aaf7f828e347e2f692605997bb80d2a178bc7"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=323a5656903d7707e13bbf9306a1e491"
+
+DEPENDS += "xz"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.5.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.5.0.bb
@@ -1,0 +1,30 @@
+require mender-client.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.5.x"
+
+# Tag: 2.5.0
+SRCREV = "68ee8e6609eb131cf822d6623d3576ada36745f3"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=94f3ba4eba45eae14396f3499fcb5383"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL"
+
+DEPENDS += "xz openssl"
+RDEPENDS_${PN} += "liblzma openssl"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
@@ -1,0 +1,80 @@
+DESCRIPTION = "Mender add-on for remote terminal access."
+HOMEPAGE = "https://mender.io"
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=master"
+
+DEPENDS_append = " glib-2.0"
+RDEPENDS_${PN} = "glib-2.0 mender-client (>= 2.5)"
+
+MENDER_SERVER_URL ?= "https://docker.mender.io"
+MENDER_CONNECT_SHELL ??= "/bin/sh"
+MENDER_CONNECT_USER ??= "nobody"
+SYSTEMD_AUTO_ENABLE ?= "enable"
+SYSTEMD_SERVICE_${PN} = "mender-connect.service"
+
+B = "${WORKDIR}/build"
+
+inherit go
+inherit go-ptest
+inherit pkgconfig
+inherit systemd
+
+GO_IMPORT = "github.com/mendersoftware/mender-connect"
+
+do_compile() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1
+}
+
+python do_prepare_mender_connect_conf() {
+    import json
+
+    mender_connect_conf = {}
+    # If a mender-connect.conf has been provided in SRC_URI, merge contents
+    src_conf = os.path.join(d.getVar("WORKDIR"), "mender-connect.conf")
+    if os.path.exists(src_conf):
+        with open(src_conf) as fd:
+            mender_connect_conf = json.load(fd)
+
+    if "ServerURL" not in mender_connect_conf:
+        mender_connect_conf["ServerURL"] = d.getVar("MENDER_SERVER_URL")
+
+    if "Shell" not in mender_connect_conf:
+        mender_connect_conf["Shell"] = d.getVar("MENDER_CONNECT_SHELL")
+
+    if "User" not in mender_connect_conf:
+        mender_connect_conf["User"] = d.getVar("MENDER_CONNECT_USER")
+
+    dst_conf = os.path.join(d.getVar("B"), "mender-connect.conf")
+    with open(dst_conf, "w") as fd:
+        json.dump(mender_connect_conf, fd, indent=4, sort_keys=True)
+
+}
+addtask do_prepare_mender_connect_conf after do_compile before do_install
+do_prepare_mender_connect_conf[vardeps] = " \
+    MENDER_SERVER_URL \
+    MENDER_CONNECT_SHELL \
+    MENDER_CONNECT_USER \
+"
+
+do_install() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1 \
+        prefix=${D} \
+        bindir=${bindir} \
+        datadir=${datadir} \
+        sysconfdir=${sysconfdir} \
+        systemd_unitdir=${systemd_unitdir} \
+        install-bin \
+        install-systemd
+
+    # install configuration
+    mkdir -p  ${D}/${sysconfdir}/mender
+    install -m 0600 ${B}/mender-connect.conf ${D}/${sysconfdir}/mender/mender-connect.conf
+}
+
+FILES_${PN}_append += "\
+    ${systemd_unitdir}/system/mender-connect.service \
+"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.0.0.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.0.0.bb
@@ -1,0 +1,27 @@
+require mender-connect.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=1.0.x"
+
+# Tag: 1.0.0
+SRCREV = "ba20f26b20cffb72ca14ddb3f3e2347186689ace"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LIC_FILES_CHKSUM.sha256;md5=496bbc1daf381b64e77838a406aef285"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -1,91 +1,65 @@
-DESCRIPTION = "Mender add-on for remote terminal access."
-HOMEPAGE = "https://mender.io"
+require mender-connect.inc
 
-SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=master"
+# The revision listed below is not really important, it's just a way to avoid
+# network probing during parsing if we are not gonna build the git version
+# anyway. If git version is enabled, the AUTOREV will be chosen instead of the
+# SHA.
+def mender_connect_autorev_if_git_version(d):
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
+        return d.getVar("AUTOREV")
+    else:
+        return "ba20f26b20cffb72ca14ddb3f3e2347186689ace"
+SRCREV ?= '${@mender_connect_autorev_if_git_version(d)}'
 
-# See: https://www.yoctoproject.org/docs/2.5.1/dev-manual/dev-manual.html#automatically-incrementing-a-binary-package-revision-number
-SRCREV = "${AUTOREV}"
-PV = "0.1+git${SRCPV}"
+def mender_connect_branch_from_preferred_version(d):
+    import re
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is None:
+        version = ""
+    match = re.match(r"^[0-9]+\.[0-9]+\.", version)
+    if match is not None:
+        # If the preferred version is some kind of version, use the branch name
+        # for that one (1.0.x style).
+        return match.group(0) + "x"
+    else:
+        # Else return master as branch.
+        return "master"
+MENDER_CONNECT_BRANCH = "${@mender_connect_branch_from_preferred_version(d)}"
+
+def mender_connect_version_from_preferred_version(d, srcpv):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is not None and pref_version.find("-git") >= 0:
+        # If "-git" is in the version, remove it along with any suffix it has,
+        # and then readd it with commit SHA.
+        return "%s-git%s" % (pref_version[0:pref_version.index("-git")], srcpv)
+    elif pref_version is not None and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, use the version as is. This means that
+        # we can build tags with "-build" in them from this recipe, but not
+        # final tags, which will need their own recipe.
+        return pref_version
+    else:
+        # Else return the default "master-git".
+        return "master-git%s" % srcpv
+PV = "${@mender_connect_version_from_preferred_version(d, '${SRCPV}')}"
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=${MENDER_CONNECT_BRANCH}"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below. Note that for
 # releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
 # file.
-LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
-LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"
+def mender_connect_license(branch):
+    # Only one currently. If the sub licenses change we may introduce more.
+    return {
+               "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
+    }
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"
+LICENSE = "${@mender_connect_license(d.getVar('MENDER_CONNECT_BRANCH'))['license']}"
 
-DEPENDS_append = " glib-2.0"
-RDEPENDS_${PN} = "glib-2.0 mender-client (>= 2.5)"
-
-MENDER_SERVER_URL ?= "https://docker.mender.io"
-MENDER_CONNECT_SHELL ??= "/bin/sh"
-MENDER_CONNECT_USER ??= "nobody"
-SYSTEMD_AUTO_ENABLE ?= "enable"
-SYSTEMD_SERVICE_${PN} = "mender-connect.service"
-
-B = "${WORKDIR}/build"
-
-inherit go
-inherit go-ptest
-inherit pkgconfig
-inherit systemd
-
-GO_IMPORT = "github.com/mendersoftware/mender-connect"
-
-do_compile() {
-    oe_runmake \
-        -C ${B}/src/${GO_IMPORT} \
-        V=1
-}
-
-python do_prepare_mender_connect_conf() {
-    import json
-
-    mender_connect_conf = {}
-    # If a mender-connect.conf has been provided in SRC_URI, merge contents
-    src_conf = os.path.join(d.getVar("WORKDIR"), "mender-connect.conf")
-    if os.path.exists(src_conf):
-        with open(src_conf) as fd:
-            mender_connect_conf = json.load(fd)
-
-    if "ServerURL" not in mender_connect_conf:
-        mender_connect_conf["ServerURL"] = d.getVar("MENDER_SERVER_URL")
-
-    if "Shell" not in mender_connect_conf:
-        mender_connect_conf["Shell"] = d.getVar("MENDER_CONNECT_SHELL")
-
-    if "User" not in mender_connect_conf:
-        mender_connect_conf["User"] = d.getVar("MENDER_CONNECT_USER")
-
-    dst_conf = os.path.join(d.getVar("B"), "mender-connect.conf")
-    with open(dst_conf, "w") as fd:
-        json.dump(mender_connect_conf, fd, indent=4, sort_keys=True)
-
-}
-addtask do_prepare_mender_connect_conf after do_compile before do_install
-do_prepare_mender_connect_conf[vardeps] = " \
-    MENDER_SERVER_URL \
-    MENDER_CONNECT_SHELL \
-    MENDER_CONNECT_USER \
-"
-
-do_install() {
-    oe_runmake \
-        -C ${B}/src/${GO_IMPORT} \
-        V=1 \
-        prefix=${D} \
-        bindir=${bindir} \
-        datadir=${datadir} \
-        sysconfdir=${sysconfdir} \
-        systemd_unitdir=${systemd_unitdir} \
-        install-bin \
-        install-systemd
-
-    # install configuration
-    mkdir -p  ${D}/${sysconfdir}/mender
-    install -m 0600 ${B}/mender-connect.conf ${D}/${sysconfdir}/mender/mender-connect.conf
-}
-
-FILES_${PN}_append += "\
-    ${systemd_unitdir}/system/mender-connect.service \
-"
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
* Add recipe mender-connect 1.0.0
Moving most of the logic of the old git recipe into an inc file, and
reworking the new git recipe as for other mender recipes.
Changelog: Title

* Add mender-client and mender-artifact new recipes
Changelog: Add recipe mender-client 2.5.0
Changelog: Add recipe mender-artifact 3.5.0

* Revert "Temporarily down-prioritize mender-binary-delta 1.2.0 in version sel."
This reverts commit 446dcc1ba224edf6e9dbc2fcf58ed1c0b5953a80.