### PR TITLE
initramfs-module-install_%.bbappend: Fix Mender

### DIFF
--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -1,9 +1,5 @@
-FILESEXTRAPATHS_prepend_mender-grub := "${THISDIR}/files:"
-
-SRC_URI_append_mender-grub = " file://init-install-efi-mender.sh "
+require initramfs-module-install.inc
 
 do_install_append_mender-grub() {
-    # Overwrite the version of this file provided by upstream
-    sed -e 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh > init-install-efi-mender-altered.sh
     install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install-efi.sh
 }

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install.inc
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install.inc
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_prepend_mender-grub := "${THISDIR}/files:"
+
+SRC_URI_append_mender-grub = " file://init-install-efi-mender.sh "
+
+do_install_append_mender-grub() {
+    # Overwrite the version of this file provided by upstream
+    sed -e 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh > init-install-efi-mender-altered.sh
+}

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install_%.bbappend
@@ -1,0 +1,5 @@
+require initramfs-module-install.inc
+
+do_install_append_mender-grub() {
+    install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install.sh
+}


### PR DESCRIPTION
Fix Mender installation from a USB stick (hddimg) on machines with
BIOS by using the same installation script as for EFI.

Changelog: Fix Mender installation from a USB stick for BIOS

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
