### PR TITLE
mender-connect: Correct ShellCommand key in config file

### DIFF
--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
@@ -40,8 +40,8 @@ python do_prepare_mender_connect_conf() {
     if "ServerURL" not in mender_connect_conf:
         mender_connect_conf["ServerURL"] = d.getVar("MENDER_SERVER_URL")
 
-    if "Shell" not in mender_connect_conf:
-        mender_connect_conf["Shell"] = d.getVar("MENDER_CONNECT_SHELL")
+    if "ShellCommand" not in mender_connect_conf:
+        mender_connect_conf["ShellCommand"] = d.getVar("MENDER_CONNECT_SHELL")
 
     if "User" not in mender_connect_conf:
         mender_connect_conf["User"] = d.getVar("MENDER_CONNECT_USER")


### PR DESCRIPTION
Typo introduced at bda27970.

Changelog: Title