### PR TITLE
[requirements_py3.txt] Add cryptography

### DIFF
--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -9,3 +9,4 @@ psutil==5.8.0
 pycrypto==2.6.1
 requests==2.25.1
 PyYAML==5.4.1
+cryptography==3.3.2


### PR DESCRIPTION
And set it to the previous to last version, not introducing Rust
dependency. We'll update it in a different PR.