### PR TITLE
m-configure: Adapt to new configuration scripts and systemd integration.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -1,13 +1,33 @@
 DESCRIPTION = "Mender add-on for device configuration."
 HOMEPAGE = "https://mender.io"
 
+inherit systemd
+
+PACKAGES_append = " ${PN}-demo ${PN}-scripts"
+
 RDEPENDS_${PN} = "dbus curl mender-client (>= 2.5)"
+RDEPENDS_${PN}-demo = "${PN} jq"
+RDEPENDS_${PN}-scripts = "${PN} jq"
 
 FILES_${PN} = " \
     ${datadir}/mender/modules/v3/mender-configure \
     ${datadir}/mender/inventory/mender-inventory-mender-configure \
     /var/lib/mender-configure \
     /data/mender-configure \
+"
+
+FILES_${PN}_append_mender-systemd = " \
+    ${systemd_system_unitdir}/mender-configure-apply-device-config.service \
+"
+
+SYSTEMD_SERVICE_${PN} = "mender-configure-apply-device-config.service"
+
+FILES_${PN}-demo = " \
+    ${libdir}/mender-configure/apply-device-config.d/mender-demo-raspberrypi-led \
+"
+
+FILES_${PN}-scripts = " \
+    ${libdir}/mender-configure/apply-device-config.d/timezone \
 "
 
 S = "${WORKDIR}/git"
@@ -17,9 +37,18 @@ do_install() {
     oe_runmake \
         -C ${S} \
         DESTDIR=${D} \
-        install
+        install-bin \
+        install-demo \
+        install-scripts
 
     install -d -m 755 ${D}/data/mender-configure
     install -d -m 755 ${D}/var/lib/
     ln -s /data/mender-configure ${D}/var/lib/mender-configure
+}
+
+do_install_append_mender-systemd() {
+    oe_runmake \
+        -C ${S} \
+        DESTDIR=${D} \
+        install-systemd
 }

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
@@ -62,7 +62,7 @@ def mender_configure_license(branch):
     return {
                "license": "Apache-2.0",
     }
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"
 LICENSE = "${@mender_configure_license(d.getVar('MENDER_CONFIGURE_BRANCH'))['license']}"
 
 # Downprioritize this recipe in version selections.

--- a/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -22,12 +22,12 @@ def maybe_mender_connect(d):
 def maybe_mender_configure(d):
     pref = d.getVar('PREFERRED_VERSION_pn-mender-client')
     if pref is None:
-        return " mender-configure"
+        return " mender-configure mender-configure-demo mender-configure-scripts"
 
     if pref[0:3] in ["1.7", "2.0", "2.1", "2.2", "2.3", "2.4", "2.5"]:
         return ""
     else:
-        return " mender-configure"
+        return " mender-configure mender-configure-demo mender-configure-scripts"
 
 # Install Mender add-ons, but only if the client is recent enough.
 RDEPENDS_${PN}_append_mender-image = "${@maybe_mender_connect(d)}${@maybe_mender_configure(d)}"

--- a/meta-mender-demo/recipes-mender/mender-configure/mender-configure_%.bbappend
+++ b/meta-mender-demo/recipes-mender/mender-configure/mender-configure_%.bbappend
@@ -1,16 +1,3 @@
-
-do_compile_append() {
-    cat > ${B}/apply-device-config << END
-#!/bin/sh
-exit 0
-END
-}
-
-do_install_append() {
-    install -d ${D}${libdir}/mender-configure
-    install -m 0755 -t ${D}${libdir}/mender-configure ${B}/apply-device-config
-}
-
-FILES_${PN} += " \
-    ${libdir}/mender-configure/apply-device-config \
-"
+# For demoing it's a better experience if the timezone data is actually
+# installed.
+RDEPENDS_${PN}-scripts_append = " tzdata"


### PR DESCRIPTION
Changelog: Add mender-configure-scripts package, which provides
timezone configuration out of the box.

Changelog: Add mender-configure-demo package, which provides led
manipulation on Raspberry Pi devices, for demo purposes.

Changelog: If the `mender-systemd` class is set (the default),
mender-configure now provides a service file for systemd which will
automatically apply the stored configuration on startup.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>