### PR TITLE
RFC: mender-artifact: Reinclude version 2.4.1.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.4.1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_2.4.1.bb
@@ -1,0 +1,23 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=2.4.x"
+
+# Tag: 2.4.1
+SRCREV = "574bb9802cdf5f9b4c96d460925e55089c39d009"
+
+# Enable this in Betas, not in finals.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=8ce3d9108b58e4a185a5f812536f03a5"


### PR DESCRIPTION
Without this it is not possible to migrate from Mender 1.7

Signed-off-by: Drew Moseley <drew@moseleynet.net>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Re-add the latest v2 mender-artifact recipe.  This is required to allow migrating 1.7 based configurations.