### PR TITLE
Fix `EFI_PROVIDER` being set incorrectly when using certain layers.

### DIFF
--- a/meta-mender-core/classes/mender-setup-grub.inc
+++ b/meta-mender-core/classes/mender-setup-grub.inc
@@ -11,10 +11,9 @@ PREFERRED_RPROVIDER_virtual/grub-bootconf ?= "grub-mender-grubenv"
 
 # Set EFI_PROVIDER.  Not all MACHINE configs use it but notably
 # intel-corei7-64 does and without this we use the default of systemd-boot.
-EFI_PROVIDER ?= "${_MENDER_EFI_PROVIDER_DEFAULT}"
-_MENDER_EFI_PROVIDER_DEFAULT = ""
-_MENDER_EFI_PROVIDER_DEFAULT_mender-grub = "grub-efi"
-_MENDER_EFI_PROVIDER_DEFAULT_mender-grub_mender-bios = ""
+EFI_PROVIDER ?= ""
+EFI_PROVIDER_mender-grub = "grub-efi"
+EFI_PROVIDER_mender-grub_mender-bios = ""
 
 python() {
     if d.getVar('MENDER_GRUB_STORAGE_DEVICE'):


### PR DESCRIPTION
Use stronger `EFI_PROVIDER` assignment if related classes are set.
Since a default has already been set in some layers, and `?=`
assignments work in a first-one-counts fashion, our values do not
propogate if we use `?=`.

The original motivation and discussion for this fix is here:
https://hub.mender.io/t/simple-configuration-dunfell/2991/28

Changelog: Title

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
