### PR TITLE
[test_delta_update_module::perform_update] Set min_mender_version

### DIFF
--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -158,6 +158,8 @@ class TestDeltaUpdateModule:
 
     # Not testable on QEMU/ARM combination currently. See MEN-4297.
     @pytest.mark.not_for_machine("vexpress-qemu")
+    # mender-binary-delta 1.2.0 requires mender-artifact 3.5.0
+    @pytest.mark.min_mender_version("2.5.0")
     @pytest.mark.only_with_image("ext4")
     def test_perform_update(
         self,


### PR DESCRIPTION
To version 2.5.0: latest mender-binary-delta 1.2.0 requires
mender-artifact 3.5.0, which corresponds to mender 2.5.0.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
(cherry picked from commit d2edbd4be2e0e7a8a5dcee0c5c4f074695540333)
