### PR TITLE
dunfell: mender-client: Split concatenated certificates in ca-certificates.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -48,7 +48,7 @@ FILES_${PN} += "\
     ${datadir}/mender/modules/v3/single-file \
     ${sysconfdir}/udev/mount.blacklist.d/mender \
     ${systemd_unitdir}/system/${MENDER_CLIENT}.service \
-    ${localdatadir}/ca-certificates/mender/server.crt \
+    ${localdatadir}/ca-certificates/mender/ \
     /data/mender/device_type \
     /data/mender/mender.conf \
 "
@@ -294,8 +294,27 @@ do_install() {
     if [ -f ${WORKDIR}/server.crt ]; then
         install -m 0755 -d $(dirname ${D}${MENDER_CERT_LOCATION})
         install -m 0444 ${WORKDIR}/server.crt ${D}${MENDER_CERT_LOCATION}
+
         install -m 0755 -d ${D}${localdatadir}/ca-certificates/mender
-        install -m 0444 ${WORKDIR}/server.crt ${D}${localdatadir}/ca-certificates/mender/server.crt
+
+        # MEN-4580: Multiple certificates in one file are necessary to split in
+        # order for `update-ca-certificates` to produce a hashed symlink to them,
+        # which is required by some programs, such as curl.
+        if [ $(fgrep 'BEGIN CERTIFICATE' ${WORKDIR}/server.crt | wc -l) -gt 1 ]; then
+            certnum=1
+            while read LINE; do
+                if [ -z "$cert" ] || echo "$LINE" | fgrep -q 'BEGIN CERTIFICATE'; then
+                    cert=${D}${localdatadir}/ca-certificates/mender/server-$certnum.crt
+                    rm -f $cert
+                    touch $cert
+                    chmod 0444 $cert
+                    certnum=$(expr $certnum + 1)
+                fi
+                echo "$LINE" >> $cert
+            done < ${WORKDIR}/server.crt
+        else
+            install -m 0444 ${WORKDIR}/server.crt ${D}${localdatadir}/ca-certificates/mender/server.crt
+        fi
     fi
 
     install -d ${D}/${localstatedir}/lib/mender

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -80,6 +80,29 @@ class TestBuild:
             shell=True,
         )
 
+    @pytest.mark.min_mender_version("1.0.0")
+    def test_certificate_split(self, request, bitbake_image):
+        """Test that the certificate added in the mender-server-certificate
+        recipe is split correctly."""
+
+        # Currently this is hardcoded to the md5 sums of the split demo
+        # certificate as of 2021-04-07. Please update if it is replaced.
+        md5sums = """02d20627f63664f9495cea2e54b28e1b  ./usr/local/share/ca-certificates/mender/server-1.crt
+b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/server-2.crt"""
+
+        rootfs = get_bitbake_variables(request, bitbake_image)["IMAGE_ROOTFS"]
+        output = (
+            subprocess.check_output(
+                "md5sum ./usr/local/share/ca-certificates/mender/*",
+                shell=True,
+                cwd=rootfs,
+            )
+            .decode()
+            .strip()
+        )
+
+        assert md5sums == output
+
     @pytest.mark.only_with_image("sdimg")
     @pytest.mark.min_mender_version("1.0.0")
     def test_bootloader_embed(self, request, prepared_test_build, bitbake_image):


### PR DESCRIPTION
MEN-4580: Multiple certificates in one file are necessary to split in
order for `update-ca-certificates` to produce a hashed symlink to
them, which is required by some programs, such as curl.

Changelog: Commit

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
