### PR TITLE
[test_build] Mark min version 2.5.0 for test_certificate_split

### DIFF
--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -80,7 +80,7 @@ class TestBuild:
             shell=True,
         )
 
-    @pytest.mark.min_mender_version("2.6.0")
+    @pytest.mark.min_mender_version("2.5.0")
     def test_certificate_split(self, request, bitbake_image):
         """Test that the certificate added in the mender-server-certificate
         recipe is split correctly."""


### PR DESCRIPTION
Instead of 2.6.0. It seems like it was a confusion wrt Mender (product)
and mender (client) version.

Amends commit 62efe5017e2d3cdf9d29f2f68779b9f6df4daf59.