### PR TITLE
Add meta-oe as dependency to mender-demo

### DIFF
--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -17,4 +17,4 @@ IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_FEATURES += "splash"
 
 LAYERSERIES_COMPAT_mender-demo = "dunfell"
-LAYERDEPENDS_mender-demo = "mender"
+LAYERDEPENDS_mender-demo = "mender openembedded-layer"


### PR DESCRIPTION
`jq` is a dependency for mender configure in the demos.
It doesn't exit in poky only in meta-oe.

"meta-oe" is called the "openembedded-layer".

Trying to build without meta-oe produces this error:

```
ERROR: Nothing RPROVIDES 'jq' (but
/home/user/demo_notes/beaglebone-yocto/build/../sources/meta-mender/meta-mender-core/recipes-mender/mender-configure/mender-configure_1.0.0.bb
RDEPENDS on or otherwise requires it)
```

This commits makes it more explicit on how to fix the issue:

```
ERROR: Layer 'mender-demo' depends on layer 'openembedded-layer', but this layer is not enabled in your configuration
```

Changelog: Title

Signed-off-by: Alan <alan.martinovic@gmail.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
