### PR TITLE
Revert "MEN-4106: add rpm to the deb requirements to run acceptance tests"

### DIFF
--- a/tests/acceptance/requirements_deb.txt
+++ b/tests/acceptance/requirements_deb.txt
@@ -47,7 +47,6 @@ qemu-kvm
 qemu-system-arm
 qemu-system-x86
 qemu-utils
-rpm
 s3cmd
 screen
 sudo


### PR DESCRIPTION
Changelog: none

This reverts commit fcabd7d771abf72621a4ce9e55cd54246ce3736f.

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>
