### PR TITLE
MEN-4550: Add acceptance test for DBus Update Control endpoint.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,20 +6,26 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits.yml'
   - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-license.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-python3-format.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
+variables:
+  LICENSE_HEADERS_IGNORE_FILES_REGEXP: '\./meta-mender-core/recipes-bsp/u-boot/files/.*\.py'
+
 trigger:mender-qa:
-  image: alpine
+  image: python:alpine
   stage: trigger
   before_script:
-    - apk add --no-cache git curl bash python3 py3-pip
+    - apk add --no-cache git curl bash
     - pip3 install pyyaml
     - git clone https://github.com/mendersoftware/integration.git integration
-    - git clone https://github.com/mendersoftware/mender-qa.git mender-qa
+    - wget -q https://raw.githubusercontent.com/mendersoftware/mender-qa/master/scripts/gitlab_trigger_client_publish
+    - chmod +x gitlab_trigger_client_publish
   script:
     - export WORKSPACE=$(pwd)
-    - mender-qa/scripts/gitlab_trigger_client_publish ${CI_COMMIT_REF_NAME} ${CI_PROJECT_NAME}
-  only:
-    - master
+    - ./gitlab_trigger_client_publish ${CI_COMMIT_REF_NAME} ${CI_PROJECT_NAME}
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master"'

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017 Northern.tech AS
+Copyright 2021 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,0 +1,7 @@
+b4acfcfa2a0ba1a8c82ec3965fbcee886cff8394ca4214e0ddac0a36beb1e05a  LICENSE
+b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  meta-mender-core/recipes-mender/mender-client-migrate-configuration/files/LICENSE
+b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  meta-mender-core/recipes-mender/mender-wait-for-timesync/files/LICENSE
+beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  meta-mender-core/recipes-core/lsb-ld/files/LICENSE
+ceb1b36ff073bd13d9806d4615b931707768ca9023805620acc32dd1cfc2f680  meta-mender-demo/recipes-mender/boot-script/files/LICENSE
+ceb1b36ff073bd13d9806d4615b931707768ca9023805620acc32dd1cfc2f680  meta-mender-demo/recipes-mender/mender-reboot-detector/files/LICENSE
+b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  meta-mender-demo/recipes-mender/example-state-scripts/files/LICENSE

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -20,7 +20,7 @@ FILES_${PN}_append_mender-systemd = " \
     ${systemd_system_unitdir}/mender-configure-apply-device-config.service \
 "
 
-SYSTEMD_SERVICE_${PN} = "mender-configure-apply-device-config.service"
+SYSTEMD_SERVICE_${PN}_mender-systemd = "mender-configure-apply-device-config.service"
 
 FILES_${PN}-demo = " \
     ${libdir}/mender-configure/apply-device-config.d/mender-demo-raspberrypi-led \

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -17,4 +17,4 @@ IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_FEATURES += "splash"
 
 LAYERSERIES_COMPAT_mender-demo = "dunfell"
-LAYERDEPENDS_mender-demo = "mender"
+LAYERDEPENDS_mender-demo = "mender openembedded-layer"

--- a/meta-mender-qemu/scripts/docker/ext4_manipulator.py
+++ b/meta-mender-qemu/scripts/docker/ext4_manipulator.py
@@ -1,3 +1,17 @@
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os
 import subprocess
 from pathlib import PurePath

--- a/meta-mender-qemu/scripts/docker/setup-mender-configuration.py
+++ b/meta-mender-qemu/scripts/docker/setup-mender-configuration.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
 
 import argparse
 import json

--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/tests/acceptance/mock_server.py
+++ b/tests/acceptance/mock_server.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import os
+import pytest
+import tempfile
+
+from utils.common import put_no_sftp
+
+# May appear excessive, but emulated QEMU is *really* slow to execute this.
+EXPIRATION_TIME = 60
+BOOT_EXPIRATION_TIME = 30
+
+MENDER_CONF = """{
+    "UpdatePollIntervalSeconds": 1,
+    "InventoryPollIntervalSeconds": 5,
+    "RetryPollIntervalSeconds": 1,
+    "UpdateControlMapExpirationTimeSeconds": %d,
+    "UpdateControlMapBootExpirationTimeSeconds": %d,
+    "ServerURL": "https://docker.mender.io:8443",
+    "DBus": {
+        "Enabled": true
+    }
+}
+""" % (
+    EXPIRATION_TIME,
+    BOOT_EXPIRATION_TIME,
+)
+
+
+@pytest.fixture(scope="function")
+def setup_mock_server(request, bitbake_variables, connection):
+    if bitbake_variables["MACHINE"] == "vexpress-qemu-flash":
+        pytest.skip(
+            "Mock server is not available on vexpress-qemu due to space constraints."
+        )
+
+    conffile = "/data/etc/mender/mender.conf"
+    conffile_bkp = f"{conffile}.backup"
+    bdir = os.path.dirname(conffile_bkp)
+    result = connection.run(
+        f"mkdir -p {bdir} && if [ -e {conffile} ]; then cp {conffile} {conffile_bkp}; fi"
+    )
+
+    tf = tempfile.NamedTemporaryFile()
+    with open(tf.name, "w") as fd:
+        fd.write(MENDER_CONF)
+
+    put_no_sftp(tf.name, connection, remote=conffile)
+
+    hostsfile = "/data/etc/hosts"
+    hostsfile_bkp = f"{hostsfile}.backup"
+    connection.run(
+        f"cp {hostsfile} {hostsfile_bkp} && echo 127.0.0.1 docker.mender.io >> {hostsfile}"
+    )
+
+    def fin():
+        connection.run(
+            f"if [ -e {conffile_bkp} ]; then dd if={conffile_bkp} of=$(realpath {conffile}); fi"
+        )
+        connection.run(
+            f"if [ -e {hostsfile_bkp} ]; then dd if={hostsfile_bkp} of=$(realpath {hostsfile}); fi"
+        )
+
+    request.addfinalizer(fin)
+
+
+def prepare_deployment_response(
+    connection,
+    artifact_file,
+    device_type,
+    deployment_id="test-deployment",
+    artifact_name="test-artifact",
+):
+    with tempfile.NamedTemporaryFile() as fd:
+        fd.write(
+            b"""{
+  "id": "%s",
+  "artifact": {
+    "source": {
+      "uri": "https://docker.mender.io:8443/data/%s",
+      "expire": "2099-01-01T00:00:00.000+0000"
+    },
+        "device_types_compatible": ["%s"],
+    "artifact_name": "%s"
+  }
+}"""
+            % (
+                deployment_id.encode(),
+                os.path.basename(artifact_file).encode(),
+                device_type.encode(),
+                artifact_name.encode(),
+            )
+        )
+        fd.flush()
+
+        put_no_sftp(
+            artifact_file,
+            connection,
+            remote=os.path.join("/data", os.path.basename(artifact_file)),
+        )
+        put_no_sftp(
+            fd.name,
+            connection,
+            remote="/data/mender-mock-server-deployment-header.json",
+        )
+
+
+def cleanup_deployment_response(connection):
+    connection.run("rm -f /data/mender-mock-server-deployment-header.json")

--- a/tests/acceptance/requirements_py3.txt
+++ b/tests/acceptance/requirements_py3.txt
@@ -1,6 +1,6 @@
 attrs==21.2.0
 bcrypt==3.2.0
-certifi==2020.12.5
+certifi==2021.5.30
 cffi==1.14.5
 chardet==4.0.0
 cryptography==3.4.7
@@ -27,4 +27,4 @@ requests==2.25.1
 six==1.16.0
 toml==0.10.2
 ubi-reader==0.7.0
-urllib3==1.26.4
+urllib3==1.26.5

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/tests/acceptance/test_ubimg.py
+++ b/tests/acceptance/test_ubimg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Mender Software AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -1,0 +1,461 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import json
+import os
+import pytest
+import subprocess
+import sys
+import tempfile
+import time
+
+from multiprocessing import Process
+
+from mock_server import (
+    cleanup_deployment_response,
+    prepare_deployment_response,
+    setup_mock_server,
+    EXPIRATION_TIME,
+    BOOT_EXPIRATION_TIME,
+)
+from utils.common import get_no_sftp
+
+# Map UIDs. Randomly chosen, but used throughout for consistency.
+MUID = "3702f9f0-b318-11eb-a7b6-c7aece07181e"
+MUID2 = "3702f9f0-b318-11eb-a7b6-c7aece07181f"
+
+BETWEEN_EXPIRATIONS = max(EXPIRATION_TIME, BOOT_EXPIRATION_TIME) - 5
+FAIL_TIME = EXPIRATION_TIME + BOOT_EXPIRATION_TIME
+
+
+def start_and_ready_mender_client(connection, second_connection):
+    def dbus_monitor():
+        second_connection.run(
+            "dbus-monitor --system \"type='signal',interface='io.mender.Authentication1'\" > /tmp/dbus-monitor.log"
+        )
+
+    p = Process(target=dbus_monitor, daemon=True)
+    p.start()
+    time.sleep(0.5)
+    try:
+        connection.run("systemctl start mender-client")
+
+        timeout = 120
+        now = time.time()
+        while time.time() - now < timeout:
+            time.sleep(1)
+            output = connection.run("cat /tmp/dbus-monitor.log")
+            if "JwtTokenStateChange" in output.stdout.strip():
+                break
+        else:
+            assert (
+                False
+            ), "Mender client did not broadcast JwtTokenStateChange as expected."
+    finally:
+        p.terminate()
+        connection.run("rm -f cat /tmp/dbus-monitor.log")
+
+
+class TestUpdateControl:
+    test_update_control_maps_cases = [
+        {"name": "Empty map", "case": {"maps": [{"id": MUID,}], "success": True,},},
+        {
+            "name": "Fail in ArtifactInstall_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactInstall_Enter": {"action": "fail",},},
+                    }
+                ],
+                "success": False,
+                "last_successful_state": "Download",
+            },
+        },
+        {
+            "name": "Fail in ArtifactReboot_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactReboot_Enter": {"action": "fail",},},
+                    }
+                ],
+                "success": False,
+                "last_successful_state": "ArtifactInstall",
+            },
+        },
+        {
+            "name": "Fail in ArtifactCommit_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactCommit_Enter": {"action": "fail",},},
+                    }
+                ],
+                "success": False,
+                "last_successful_state": "ArtifactVerifyReboot",
+            },
+        },
+        {
+            "name": "Pause in ArtifactInstall_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactInstall_Enter": {"action": "pause",},},
+                    }
+                ],
+                "success": True,
+                "state_before_pause": "Download",
+                "continue_map": {
+                    "id": MUID,
+                    "states": {"ArtifactInstall_Enter": {"action": "continue",},},
+                },
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+        {
+            "name": "Pause in ArtifactReboot_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactReboot_Enter": {"action": "pause",},},
+                    }
+                ],
+                "success": True,
+                "state_before_pause": "ArtifactInstall",
+                "continue_map": {
+                    "id": MUID,
+                    "states": {"ArtifactReboot_Enter": {"action": "continue",},},
+                },
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+        {
+            "name": "Pause in ArtifactCommit_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactCommit_Enter": {"action": "pause",},},
+                    }
+                ],
+                "success": True,
+                "state_before_pause": "ArtifactVerifyReboot",
+                "continue_map": {
+                    "id": MUID,
+                    "states": {"ArtifactCommit_Enter": {"action": "continue",},},
+                },
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+        {
+            "name": "Expire in ArtifactInstall_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {
+                            "ArtifactInstall_Enter": {
+                                "action": "pause",
+                                "on_map_expire": "continue",
+                            },
+                        },
+                    }
+                ],
+                "take_at_least": EXPIRATION_TIME,
+                "success": True,
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+        {
+            "name": "Reboot and expire in ArtifactInstall_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {
+                            "ArtifactInstall_Enter": {
+                                "action": "pause",
+                                "on_map_expire": "continue",
+                            },
+                        },
+                    }
+                ],
+                "restart_client": True,
+                "fail_after": BETWEEN_EXPIRATIONS,
+                "success": True,
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+        {
+            "name": "Continue, then fail in ArtifactInstall_Enter",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {
+                            "ArtifactInstall_Enter": {
+                                "action": "continue",
+                                "on_action_executed": "fail",
+                            },
+                        },
+                    }
+                ],
+                "second_deployment": True,
+                "success": False,
+                "last_successful_state": "Download",
+            },
+        },
+        {
+            "name": "continue with higher priority",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactInstall_Enter": {"action": "fail",},},
+                    },
+                    {
+                        "id": MUID2,
+                        "states": {"ArtifactInstall_Enter": {"action": "continue",},},
+                        "priority": 1,
+                    },
+                ],
+                # "continue" has lowest precedence, even if the priority is
+                # higher.
+                "success": False,
+                "last_successful_state": "Download",
+            },
+        },
+        {
+            "name": "force_continue with higher priority",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactInstall_Enter": {"action": "pause",},},
+                    },
+                    {
+                        "id": MUID2,
+                        "states": {
+                            "ArtifactInstall_Enter": {"action": "force_continue",},
+                        },
+                        "priority": 1,
+                    },
+                ],
+                "success": True,
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+        {
+            "name": "force_continue with lower priority",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {"ArtifactCommit_Enter": {"action": "fail",},},
+                    },
+                    {
+                        "id": MUID2,
+                        "states": {
+                            "ArtifactCommit_Enter": {"action": "force_continue",},
+                        },
+                        "priority": -1,
+                    },
+                ],
+                "success": False,
+                "last_successful_state": "ArtifactVerifyReboot",
+            },
+        },
+        {
+            "name": "Expired and purged map",
+            "case": {
+                "maps": [
+                    {
+                        "id": MUID,
+                        "states": {
+                            # Install a map which succeeds, but sets up for failure afterwards.
+                            "ArtifactInstall_Enter": {
+                                "action": "continue",
+                                "on_action_executed": "fail",
+                            },
+                            # Then expire the map.
+                            "ArtifactCommit_Enter": {
+                                "action": "pause",
+                                "on_map_expire": "continue",
+                            },
+                        },
+                    }
+                ],
+                # The second deployment should succeed despite the "fail" above,
+                # because expired maps are purged between deployments.
+                "second_deployment": True,
+                "take_at_least": EXPIRATION_TIME,
+                "success": True,
+                "last_successful_state": "ArtifactCommit",
+            },
+        },
+    ]
+
+    @pytest.mark.min_mender_version("2.7.0")
+    @pytest.mark.parametrize(
+        "case_name,case",
+        [(case["name"], case["case"]) for case in test_update_control_maps_cases],
+    )
+    def test_update_control_maps(
+        self,
+        case_name,
+        case,
+        setup_board,
+        connection,
+        second_connection,
+        setup_mock_server,
+        bitbake_variables,
+        bitbake_path,
+    ):
+        def set_update_control_map(m, warn=False):
+            output = connection.run(
+                "dbus-send --system --dest=io.mender.UpdateManager --print-reply /io/mender/UpdateManager io.mender.Update1.SetUpdateControlMap string:'%s'"
+                % json.dumps(m),
+                warn=warn,
+            )
+            assert "int32 %d" % (EXPIRATION_TIME / 2) in output.stdout
+
+        try:
+            start_and_ready_mender_client(connection, second_connection)
+
+            for m in case["maps"]:
+                set_update_control_map(m)
+
+            if case.get("restart_client"):
+                # Restart client after map insertion in order to trigger the
+                # boot expiration mechanism.
+                connection.run("systemctl restart mender-client")
+
+            def make_and_deploy_artifact():
+                with tempfile.NamedTemporaryFile(suffix=".mender") as artifact_file:
+                    artifact_name = os.path.basename(artifact_file.name)[:-7]
+
+                    subprocess.check_call(
+                        [
+                            "mender-artifact",
+                            "write",
+                            "module-image",
+                            "-t",
+                            bitbake_variables["MENDER_DEVICE_TYPE"],
+                            "-T",
+                            "logger-update-module",
+                            "-n",
+                            artifact_name,
+                            "-o",
+                            artifact_file.name,
+                        ]
+                    )
+                    prepare_deployment_response(
+                        connection,
+                        artifact_file.name,
+                        bitbake_variables["MENDER_DEVICE_TYPE"],
+                        artifact_name=artifact_name,
+                    )
+
+            now = time.time()
+
+            make_and_deploy_artifact()
+
+            log = []
+            pause_state_observed = 0
+            continue_map_inserted = False
+            second_deployment_done = False
+            PAUSE_STATE_OBSERVE_COUNT = 2
+            while time.time() - now <= case.get("fail_after", FAIL_TIME):
+                output = connection.run(
+                    "cat /data/logger-update-module.log 2>/dev/null || true"
+                ).stdout.strip()
+                log = [line.split()[1] for line in output.split("\n") if len(line) > 0]
+
+                # Check for the state before the pause state, and verify it's
+                # the last state (meaning the client is currently waiting before
+                # the next state).
+                if (
+                    not continue_map_inserted
+                    and case.get("state_before_pause")
+                    and len(log) > 0
+                    and log[-1] == case["state_before_pause"]
+                ):
+                    pause_state_observed += 1
+                    # Verify that it stays in paused mode.
+                    if pause_state_observed >= PAUSE_STATE_OBSERVE_COUNT:
+                        # Now insert the map to unblock the pause.
+                        set_update_control_map(case["continue_map"])
+                        continue_map_inserted = True
+
+                # Cleanup is the last state of a deployment
+                if "Cleanup" in log:
+                    if case.get("second_deployment") and not second_deployment_done:
+                        # When making two deployments, we assume the first one
+                        # is successful.
+                        assert "ArtifactFailure" not in log
+
+                        connection.run("rm -f /data/logger-update-module.log")
+                        make_and_deploy_artifact()
+                        second_deployment_done = True
+                    else:
+                        break
+
+                time.sleep(5)
+            else:
+                pytest.fail("Could not find Cleanup in log, did deployment not finish?")
+
+            if case.get("take_at_least"):
+                assert (
+                    time.time() - now >= case["take_at_least"]
+                ), "Deployment finished before it was supposed to!"
+
+            if case["success"]:
+                assert "ArtifactFailure" not in log
+            else:
+                assert "ArtifactFailure" in log
+                assert (
+                    log[log.index("ArtifactFailure") - 1]
+                    == case["last_successful_state"]
+                )
+
+            if case.get("state_before_pause"):
+                assert (
+                    pause_state_observed >= PAUSE_STATE_OBSERVE_COUNT
+                ), "Looks like the client did not pause!"
+
+        finally:
+            cleanup_deployment_response(connection)
+            # Reset update control maps.
+            set_update_control_map({"id": MUID}, warn=True)
+            set_update_control_map({"id": MUID2}, warn=True)
+            connection.run("systemctl stop mender-client")
+            connection.run("rm -f /data/logger-update-module.log")
+
+    @pytest.mark.min_mender_version("2.7.0")
+    def test_invalid_update_control_map(
+        self, setup_board, connection, second_connection, setup_mock_server
+    ):
+        start_and_ready_mender_client(connection, second_connection)
+
+        status = connection.run(
+            """dbus-send --system --dest=io.mender.UpdateManager --print-reply /io/mender/UpdateManager io.mender.Update1.SetUpdateControlMap string:'{"not-a":"valid-map"}'""",
+            warn=True,
+        )
+        assert status.return_code != 0

--- a/tests/meta-mender-ci/conf/layer.conf
+++ b/tests/meta-mender-ci/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_meta-mender-ci = "10"
 LAYERSERIES_COMPAT_meta-mender-ci = "dunfell"
 
 IMAGE_FEATURES_append = " read-only-rootfs"
-IMAGE_INSTALL_append = " lsb-test ${MENDER_MOCK_SERVER}"
+IMAGE_INSTALL_append = " lsb-test ${MENDER_MOCK_SERVER} logger-update-module"
 
 MENDER_MOCK_SERVER = "mender-mock-server"
 # There isn't enough space to install this on vexpress-qemu-flash.

--- a/tests/meta-mender-ci/recipes-testing/logger-update-module/logger-update-module.bb
+++ b/tests/meta-mender-ci/recipes-testing/logger-update-module/logger-update-module.bb
@@ -1,0 +1,30 @@
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LICENSE = "Apache-2.0"
+
+FILES_${PN} = "${datadir}/mender/modules/v3/logger-update-module"
+
+do_compile() {
+    cat > ${B}/logger-update-module <<'EOF'
+#!/bin/sh
+case "$1" in
+    NeedsArtifactReboot)
+        echo "Yes"
+
+        # Don't log this one, it is not related to state flow.
+        ;;
+    SupportsRollback)
+        echo "No"
+
+        # Don't log this one, it is not related to state flow.
+        ;;
+    *)
+        echo "$(date +%s)" "$@" >> /data/logger-update-module.log
+        ;;
+esac
+EOF
+}
+
+do_install() {
+    install -m 755 -d ${D}${datadir}/mender/modules/v3
+    install -m 755 ${B}/logger-update-module ${D}${datadir}/mender/modules/v3/logger-update-module
+}

--- a/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
+++ b/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
@@ -13,7 +13,9 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import os.path
+import os
+import re
+import shutil
 import ssl
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -26,45 +28,111 @@ JWT_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkNjA2ZjYxNC03NWFkLT
 
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
+        self.read_body()
+
         if self.path == "/api/devices/v1/deployments/device/deployments/next":
             return self.do_GET_or_POST_deployments_next()
-        self.send_response(404)
-        self.end_headers()
+        elif self.path.startswith("/data/"):
+            with open(self.path, "rb") as body:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(os.fstat(body.fileno()).st_size))
+                self.end_headers()
+
+                shutil.copyfileobj(body, self.wfile)
+        else:
+            self.send_empty_response(404)
 
     def do_POST(self):
+        self.read_body()
+
         if self.path == "/api/devices/v1/authentication/auth_requests":
             return self.do_POST_auth_requests()
         elif self.path == "/api/devices/v1/deployments/device/deployments/next":
             return self.do_GET_or_POST_deployments_next()
-        self.send_response(404)
-        self.end_headers()
+        self.send_empty_response(404)
 
     def do_PATCH(self):
+        self.read_body()
+
         if self.path == "/api/devices/v1/inventory/device/attributes":
             return self.do_PATCH_or_PUT_device_attributes()
-        self.send_response(404)
-        self.end_headers()
+        self.send_empty_response(404)
 
     def do_PUT(self):
+        self.read_body()
+
         if self.path == "/api/devices/v1/inventory/device/attributes":
             return self.do_PATCH_or_PUT_device_attributes()
-        self.send_response(404)
-        self.end_headers()
+        elif (
+            re.match(
+                "/api/devices/v1/deployments/device/deployments/[^/]*/status", self.path
+            )
+            is not None
+        ):
+            self.send_empty_response(204)
+        else:
+            self.send_empty_response(404)
 
     def do_POST_auth_requests(self):
         self.send_response(200)
-        self.send_header("Content-type", "application/jwt")
+        self.send_header("Content-Type", "application/jwt")
+        self.send_header("Content-Length", len(JWT_TOKEN.encode("utf-8")))
         self.end_headers()
         self.wfile.write(JWT_TOKEN.encode("utf-8"))
 
     def do_PATCH_or_PUT_device_attributes(self):
         self.send_response(200)
-        self.send_header("Content-type", "application/json")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", 0)
         self.end_headers()
 
     def do_GET_or_POST_deployments_next(self):
-        self.send_response(204)
+        if os.path.exists("/data/mender-mock-server-deployment-header.json"):
+            with open("/data/mender-mock-server-deployment-header.json", "rb") as body:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", os.fstat(body.fileno()).st_size)
+                self.end_headers()
+
+                shutil.copyfileobj(body, self.wfile)
+
+            # Only serve the request once.
+            os.remove("/data/mender-mock-server-deployment-header.json")
+
+        else:
+            self.send_empty_response(204)
+
+    def send_empty_response(self, status_code):
+        self.send_response(status_code)
+        self.send_header("Content-Length", "0")
         self.end_headers()
+
+    def read_body(self):
+        if self.headers.get(
+            "Transfer-Encoding"
+        ) is not None and "chunked" in self.headers.get("Transfer-Encoding"):
+            size = self.rfile.readline().strip()
+            size = int(size, 16)
+        elif self.headers.get("Content-Length") is not None:
+            size = int(self.headers.get("Content-Length"))
+        else:
+            return ""
+
+        data = self.rfile.read(size)
+
+        if self.headers.get(
+            "Transfer-Encoding"
+        ) is not None and "chunked" in self.headers.get("Transfer-Encoding"):
+            # We only support one chunk.
+            lineend = self.rfile.readline().strip()
+            assert lineend == b""
+            size = self.rfile.readline().strip()
+            assert size == b"0"
+            lineend = self.rfile.readline().strip()
+            assert lineend == b""
+
+        return data
 
 
 def main():

--- a/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
+++ b/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2021 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/tests/meta-mender-ci/recipes-testing/mender-mock-server/mender-mock-server_1.0.bb
+++ b/tests/meta-mender-ci/recipes-testing/mender-mock-server/mender-mock-server_1.0.bb
@@ -17,6 +17,7 @@ SYSTEMD_SERVICE_${PN} = "mender-mock-server.service"
 
 FILES_${PN} += "\
     ${prefix}/local/bin/mender-mock-server.py \
+    /data/mender-mock-server.py \
     ${prefix}/local/bin/private.key \
     ${systemd_unitdir}/system/mender-mock-server.service \
 "
@@ -28,4 +29,8 @@ do_install() {
 
     install -d ${D}/${systemd_unitdir}/system
     install -m 644 ${WORKDIR}/mender-mock-server.service ${D}${systemd_unitdir}/system/mender-mock-server.service
+
+    install -m 755 -d ${D}/data
+    mv ${D}${prefix}/local/bin/mender-mock-server.py ${D}/data/mender-mock-server.py
+    ln -s /data/mender-mock-server.py ${D}${prefix}/local/bin/mender-mock-server.py
 }

--- a/tests/meta-mender-ci/recipes-testing/mender-mock-server/mender-mock-server_1.0.bb
+++ b/tests/meta-mender-ci/recipes-testing/mender-mock-server/mender-mock-server_1.0.bb
@@ -5,7 +5,7 @@ SRC_URI = " \
 "
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = " \
-    file://mender-mock-server.py;beginline=2;endline=14;md5=96cdd6947ab31ed6536dcfd6a67688ef \
+    file://mender-mock-server.py;beginline=2;endline=14;md5=457f0d2d149c4d7f13339726a05c8b83 \
 "
 S = "${WORKDIR}"
 


### PR DESCRIPTION
`mender-mock-server.py` has to be substantially extended for the calls
to work correctly. We have to consume the body of requests for
subsequent calls to work, and we need to be able to handle chunked
bodies. We also make it possible to schedule a deployment with it.

In addition we add a logger-update-module which we can use to track
exactly which states the Update Module is going through.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
