### PR TITLE
mender-configure: Add missing feature selector for mender-systemd.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -20,7 +20,7 @@ FILES_${PN}_append_mender-systemd = " \
     ${systemd_system_unitdir}/mender-configure-apply-device-config.service \
 "
 
-SYSTEMD_SERVICE_${PN} = "mender-configure-apply-device-config.service"
+SYSTEMD_SERVICE_${PN}_mender-systemd = "mender-configure-apply-device-config.service"
 
 FILES_${PN}-demo = " \
     ${libdir}/mender-configure/apply-device-config.d/mender-demo-raspberrypi-led \


### PR DESCRIPTION
Changelog: Fix build error when trying to build mender-configure
without systemd:
```
mender-configure-1.0.0-r0 do_package: SYSTEMD_SERVICE_mender-configure value mender-configure-apply-device-config.service does not exist.
```

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
