### PR TITLE
Upgrade to grub-mender-grubenv tools with new names.

### DIFF
--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,4 +1,4 @@
-GRUB_MENDER_GRUBENV_REV = "f39c2c7ec7c9c24aae0108a9b04a0e6e61a3e96b"
+GRUB_MENDER_GRUBENV_REV = "1a7db967495bbe8be53b7a69dcb42822f39d9a74"
 GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
@@ -6,4 +6,4 @@ SRCREV = "${GRUB_MENDER_GRUBENV_REV}"
 PV = "1.3.0+git${SRCREV}"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"

--- a/meta-mender-core/recipes-mender/mender-client/files/mender-client-set-systemd-machine-id.sh
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-client-set-systemd-machine-id.sh
@@ -6,12 +6,20 @@
 
 set -eu
 
-CURRENT_BOOTLOADER_ID=$(fw_printenv mender_systemd_machine_id 2>/dev/null | cut -d= -f2)
+if [ -x /usr/bin/grub-mender-grubenv-set ]; then
+    BOOTENV_PRINT=grub-mender-grubenv-print
+    BOOTENV_SET=grub-mender-grubenv-set
+else
+    BOOTENV_PRINT=fw_printenv
+    BOOTENV_SET=fw_setenv
+fi
+
+CURRENT_BOOTLOADER_ID=$($BOOTENV_PRINT mender_systemd_machine_id 2>/dev/null | cut -d= -f2)
 CURRENT_SYSTEMD_ID=$(cat /etc/machine-id)
 
 rc=0
 if [ -z "${CURRENT_BOOTLOADER_ID}" ] && [ ! -z "${CURRENT_SYSTEMD_ID}" ]; then
-    fw_setenv "mender_systemd_machine_id" "${CURRENT_SYSTEMD_ID}"
+    $BOOTENV_SET "mender_systemd_machine_id" "${CURRENT_SYSTEMD_ID}"
     rc=$?
 elif [ "${CURRENT_BOOTLOADER_ID}" != "${CURRENT_SYSTEMD_ID}" ]; then
     echo "Error; bootloader and systemd disagree on machine-id." >&2

--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -170,6 +170,7 @@ class TestDeltaUpdateModule:
         prepared_test_build,
         bitbake_variables,
         bitbake_image,
+        bitbake_path,
         connection,
         http_server,
         board_type,

--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -14,6 +14,7 @@
 #    limitations under the License.
 
 import distutils.spawn
+from distutils.version import LooseVersion
 import os
 import re
 import shutil
@@ -23,6 +24,7 @@ import pytest
 
 from utils.common import (
     build_image,
+    get_bitbake_variables,
     latest_build_artifact,
     reboot,
     run_after_connect,
@@ -198,6 +200,14 @@ class TestDeltaUpdateModule:
             use_s3,
             s3_address,
         )
+
+        binary_delta_vars = get_bitbake_variables(
+            request, "mender-binary-delta", prepared_test_build
+        )
+        if LooseVersion(binary_delta_vars["PV"]) < LooseVersion("1.3.0"):
+            pytest.skip(
+                "This version of mender-binary-delta does not support grub-mender-grubenv-print and friends."
+            )
 
         with make_tempdir() as tmpdir:
             # Copy previous build


### PR DESCRIPTION
Changelog: grub-mender-grubenv: User space tools, "fw_printenv" and
"fw_setenv" have been renamed to "grub-mender-grubenv-print" and
"grub-mender-grubenv-set", respectively. This has been done in order
to avoid conflict with U-Boot's user space tools, which have the same
names.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
