### PR TITLE
fix grub chownboot task ordering

### DIFF
--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -90,7 +90,7 @@ do_install() {
 python() {
     if bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', True, False, d):
         bb.build.addtask('do_sign', 'do_deploy do_package', 'do_install', d)
-        bb.build.addtask('do_chownboot', 'do_package', 'do_sign', d)
+        bb.build.addtask('do_chownboot', 'do_deploy do_package', 'do_sign', d)
 }
 
 python do_sign() {


### PR DESCRIPTION
this is already on the `master` branch, just merging into `dunfell`

----

grub-efi has cleanconfigs added as such:

    addtask cleanconfigs after do_sign do_chownboot before deploy do_package

but chownboot was being ordered *after* deploy. cleanconfigs deleting grub.cfg after deploy was causing psuedo to freakout and abort.
cleanconfigs should be sandwiched inbetween do_sign and do_deploy.

grub-mender-grubenv now explicitly adds do_chownboot before do_deploy

Changelog: Title

Signed-off-by: corey cothrum <contact@coreycothrum.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
