### PR TITLE
MEN-4712: monitor-client yocto integration (internal flow)

### DIFF
--- a/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb
+++ b/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb
@@ -1,0 +1,3 @@
+require recipes-extended/images/core-image-full-cmdline.bb
+
+IMAGE_INSTALL_append = " mender-monitor"

--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
@@ -1,0 +1,26 @@
+LICENSE = "CLOSED"
+LICENSE_FLAGS = "commercial"
+
+RDEPENDS_${PN} = "bash mender-client (>= 2.5)"
+
+FILES_${PN} = " \
+    ${bindir}/mender-monitord \
+    ${sysconfdir}/mender-monitor \
+    ${datadir}/mender-monitor \
+"
+
+S ?= "${WORKDIR}/${PN}"
+
+do_version_check() {
+    if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
+        bbfatal "Not yet released. This recipe can only be used with MENDER_DEVMODE"
+    fi
+}
+addtask do_version_check after do_unpack before do_install
+
+do_install() {
+    oe_runmake \
+        -C ${S} \
+        DESTDIR=${D} \
+        install
+}

--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
@@ -1,0 +1,12 @@
+require mender-monitor.inc
+
+PV = "master-git"
+
+# Source directly the repo, override name
+S = "${WORKDIR}/monitor-client"
+
+# Skip version check
+MENDER_DEVMODE = "true"
+
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
* MEN-4712: meta-mender-commercial: Add monitor-client git recipe
* MEN-4712: Add new image monitor-image-full-cmdline for internal testing

`Changelog: Title` in both