### PR TITLE
u-boot-mender: Ignore case when checking variables in mender_Kconfig_…

### DIFF
--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
@@ -257,7 +257,7 @@ do_configure_prepend_mender-uboot() {
         key="$(echo "$line" | sed -e 's/=.*//')"
         if egrep "^($key=|# $key is not set\$)" ${B}/.config; then
             # We found the option. Check that it's correct.
-            if ! fgrep "$line" ${B}/.config; then
+            if ! fgrep -i "$line" ${B}/.config; then
                 wrong_entry="$(fgrep "$key" ${B}/.config)"
                 msg="$(printf "U-Boot configuration %s has setting:\n%s\nbut Mender expects:\n%s\nPlease fix U-Boot's configuration file." \
                     "${UBOOT_MACHINE}" \


### PR DESCRIPTION
…fragment

Fixes:

ERROR: u-boot-fslc-v2020.04+gitAUTOINC+88c58453be-r0 do_configure: U-Boot configuration  pico-dwarf-imx7d_defconfig pico-nymph-imx7d_defconfig pico-pi-imx7d_defconfig has setting:
CONFIG_ENV_OFFSET=0xC0000
but Mender expects:
CONFIG_ENV_OFFSET=0xc0000
Please fix U-Boot's configuration file.
...

So, let's ignore case during comparison by adding '-i' option to fgrep

Changelog: Title

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>