### PR TITLE
Fixes for test_update_control_maps_cleanup

### DIFF
--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -482,14 +482,16 @@ class TestUpdateControl:
             "name": "Cleanup after success",
             "case": {
                 "pause_map": {
+                    "priority": 0,
                     "states": {"ArtifactCommit_Enter": {"action": "pause",},},
                 },
                 "pause_state": "ArtifactVerifyReboot",
                 "continue_map": {
                     "id": MUID,
+                    "priority": 10,
                     "states": {
                         "ArtifactInstall_Enter": {"action": "fail",},
-                        "ArtifactCommit_Enter": {"action": "continue",},
+                        "ArtifactCommit_Enter": {"action": "force_continue",},
                     },
                 },
                 "expect_failure": False,
@@ -499,11 +501,13 @@ class TestUpdateControl:
             "name": "Cleanup after failure",
             "case": {
                 "pause_map": {
+                    "priority": 0,
                     "states": {"ArtifactCommit_Enter": {"action": "pause",},},
                 },
                 "pause_state": "ArtifactVerifyReboot",
                 "continue_map": {
                     "id": MUID,
+                    "priority": 10,
                     "states": {
                         "ArtifactInstall_Enter": {"action": "fail",},
                         "ArtifactCommit_Enter": {"action": "fail",},

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -450,6 +450,10 @@ class TestUpdateControl:
                     pause_state_observed >= PAUSE_STATE_OBSERVE_COUNT
                 ), "Looks like the client did not pause!"
 
+        except:
+            connection.run("journalctl -u mender-client | cat")
+            raise
+
         finally:
             cleanup_deployment_response(connection)
             # Reset update control maps.
@@ -579,7 +583,13 @@ class TestUpdateControl:
             log = wait_for_state("Cleanup")
             assert "ArtifactFailure" not in log
 
+        except:
+            connection.run("journalctl -u mender-client | cat")
+            raise
+
         finally:
             cleanup_deployment_response(connection)
+            # Reset update control maps.
+            set_update_control_map(connection, {"id": MUID}, warn=True)
             connection.run("systemctl stop mender-client")
             connection.run("rm -f /data/logger-update-module.log")

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -574,6 +574,7 @@ class TestUpdateControl:
 
             # Second deployment shall succeed
             connection.run("rm -f /data/logger-update-module.log")
+            cleanup_deployment_response(connection)
             make_and_deploy_artifact(
                 connection,
                 bitbake_variables["MENDER_DEVICE_TYPE"],

--- a/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
+++ b/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
@@ -97,9 +97,6 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
                 shutil.copyfileobj(body, self.wfile)
 
-            # Only serve the request once.
-            os.remove("/data/mender-mock-server-deployment-header.json")
-
         else:
             self.send_empty_response(204)
 


### PR DESCRIPTION
* test_update_control.py: Print mender logs on erros
    
    And add missing cleanup in test_update_control_maps_cleanup

* mender-mock-server.py: Serve /deployments/next until user cleans-up

* test_update_control.py: Fix test_update_control_maps_cleanup
    
    Now that the client will be refreshing the map from /deployments/next,
    the test needs to use different priorities for the two maps. Also, for
    the case of "continue", the test shall use "force_continue".
