### PR TITLE
Bump the timeout for the acceptance mock-server

### DIFF
--- a/tests/acceptance/mock_server.py
+++ b/tests/acceptance/mock_server.py
@@ -21,8 +21,8 @@ from utils.common import put_no_sftp
 import json
 
 # May appear excessive, but emulated QEMU is *really* slow to execute this.
-EXPIRATION_TIME = 60
-BOOT_EXPIRATION_TIME = 30
+EXPIRATION_TIME = 90
+BOOT_EXPIRATION_TIME = 45
 
 MENDER_CONF = """{
     "UpdatePollIntervalSeconds": 1,


### PR DESCRIPTION
This will make the tests take longer, but will result in fewer spurious errors.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

