### PR TITLE
Robustness improvements for test_update_control.py

### DIFF
--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -22,11 +22,7 @@ from multiprocessing import Process
 
 from mock_server import setup_mock_server
 
-MENDER_STATE_FILES = (
-    "/var/lib/mender/mender-agent.pem",
-    "/var/lib/mender/mender-store",
-    "/var/lib/mender/mender-store-lock",
-)
+from utils.common import cleanup_mender_state
 
 
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
@@ -78,7 +74,7 @@ class TestDBus:
 
         finally:
             connection.run("systemctl stop mender-client")
-            connection.run("rm -f %s" % " ".join(MENDER_STATE_FILES))
+            cleanup_mender_state(connection)
 
     @pytest.mark.min_mender_version("2.5.0")
     def test_dbus_get_jwt_token(self, bitbake_variables, connection, setup_mock_server):
@@ -107,7 +103,7 @@ class TestDBus:
             assert f'string "{self.JWT_TOKEN}' in output
         finally:
             connection.run("systemctl stop mender-client")
-            connection.run("rm -f %s" % " ".join(MENDER_STATE_FILES))
+            cleanup_mender_state(connection)
 
     @pytest.mark.min_mender_version("2.5.0")
     def test_dbus_fetch_jwt_token(
@@ -178,4 +174,4 @@ class TestDBus:
                 connection.run("rm -f /tmp/dbus-monitor.log")
 
         finally:
-            connection.run("rm -f %s" % " ".join(MENDER_STATE_FILES))
+            cleanup_mender_state(connection)

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -30,7 +30,7 @@ from mock_server import (
     EXPIRATION_TIME,
     BOOT_EXPIRATION_TIME,
 )
-from utils.common import get_no_sftp, put_no_sftp
+from utils.common import put_no_sftp, cleanup_mender_state
 
 # Map UIDs. Randomly chosen, but used throughout for consistency.
 MUID = "3702f9f0-b318-11eb-a7b6-c7aece07181e"
@@ -498,6 +498,7 @@ class TestUpdateControl:
             # Reset update control maps.
             clear_update_control_maps(connection)
             connection.run("systemctl stop mender-client")
+            cleanup_mender_state(connection)
             connection.run("rm -f /data/logger-update-module.log")
 
     @pytest.mark.min_mender_version("2.7.0")
@@ -514,6 +515,7 @@ class TestUpdateControl:
             assert status.return_code != 0
         finally:
             connection.run("systemctl stop mender-client")
+            cleanup_mender_state(connection)
 
     test_update_control_maps_cleanup_cases = [
         {
@@ -615,6 +617,7 @@ class TestUpdateControl:
             cleanup_deployment_response(connection)
             clear_update_control_maps(connection)
             connection.run("systemctl stop mender-client")
+            cleanup_mender_state(connection)
             connection.run("rm -f /data/logger-update-module.log")
 
     @pytest.mark.min_mender_version("2.7.0")
@@ -712,4 +715,5 @@ done
             # Reset update control maps.
             clear_update_control_maps(connection)
             connection.run("systemctl stop mender-client")
+            cleanup_mender_state(connection)
             connection.run("rm -f /data/logger-update-module.log")

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -491,6 +491,7 @@ class TestUpdateControl:
 
         except:
             connection.run("journalctl -u mender-client | cat")
+            connection.run("journalctl -u mender-mock-server | cat")
             raise
 
         finally:
@@ -611,6 +612,7 @@ class TestUpdateControl:
 
         except:
             connection.run("journalctl -u mender-client | cat")
+            connection.run("journalctl -u mender-mock-server | cat")
             raise
 
         finally:
@@ -707,6 +709,7 @@ done
 
         except:
             connection.run("journalctl -u mender-client | cat")
+            connection.run("journalctl -u mender-mock-server | cat")
             raise
 
         finally:

--- a/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
+++ b/tests/meta-mender-ci/recipes-testing/mender-mock-server/files/mender-mock-server.py
@@ -140,13 +140,17 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         if self.headers.get(
             "Transfer-Encoding"
         ) is not None and "chunked" in self.headers.get("Transfer-Encoding"):
-            # We only support one chunk.
-            lineend = self.rfile.readline().strip()
-            assert lineend == b""
-            size = self.rfile.readline().strip()
-            assert size == b"0"
-            lineend = self.rfile.readline().strip()
-            assert lineend == b""
+            # Read remaining chunks
+            while size > 0:
+                lineend = self.rfile.readline().strip()
+                assert lineend == b""
+                size = self.rfile.readline().strip()
+                size = int(size, 16)
+                if size > 0:
+                    data += self.rfile.read(size)
+                else:
+                    lineend = self.rfile.readline().strip()
+                    assert lineend == b""
 
         return data.decode()
 


### PR DESCRIPTION
* test_update_control.py: Clean up Mender state between test cases
    
    Using the helper from mender-images, inspired by the same clean-up done
    for test_dbus.py
    
    Update also the git submodule at the same time

* mender-mock-server.py: Support for multiple chunks chunked transfer
    
    Print the mock server logs on test failures too.
    
    Used Mozilla dev docs for reference. See:
    https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding#chun
ked_encoding
