### PR TITLE
MEN-4737 Monitoring wrapper alignment

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
@@ -1,12 +1,18 @@
 LICENSE = "CLOSED"
 LICENSE_FLAGS = "commercial"
 
+inherit systemd
+
 RDEPENDS_${PN} = "bash mender-client (>= 2.5)"
 
 FILES_${PN} = " \
     ${bindir}/mender-monitord \
     ${sysconfdir}/mender-monitor \
     ${datadir}/mender-monitor \
+"
+
+FILES_${PN}_append_mender-systemd = " \
+    ${systemd_system_unitdir}/mender-monitor.service \
 "
 
 S ?= "${WORKDIR}/${PN}"
@@ -18,9 +24,19 @@ do_version_check() {
 }
 addtask do_version_check after do_unpack before do_install
 
+SYSTEMD_SERVICE_${PN}_mender-systemd = "mender-monitor.service"
+
 do_install() {
     oe_runmake \
         -C ${S} \
         DESTDIR=${D} \
         install
 }
+
+do_install_append_mender-systemd() {
+    oe_runmake \
+        -C ${S} \
+        DESTDIR=${D} \
+        install-systemd
+}
+


### PR DESCRIPTION
MEN-4737 Monitoring wrapper alignment

Goes with https://github.com/mendersoftware/monitor-client/pull/17
* include service file
* add a correct link to the mender-monitord

ChangeLog:title
Signed-off-by: Peter Grzybowski <peter@northern.tech>
