### PR TITLE
Add recipes for Mender 2.6.2 and 2.7.1.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.5.2.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.5.2.bb
@@ -1,0 +1,30 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.5.x"
+
+# Tag: 3.5.2
+SRCREV = "24d27630258eb10ddb94636e0a1fcd003ede7f40"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=323a5656903d7707e13bbf9306a1e491"
+
+DEPENDS += "xz"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.5.2.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.5.2.bb
@@ -1,0 +1,31 @@
+require mender-client.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.5.x"
+
+# Tag: 2.5.2
+SRCREV = "e527207299cc6d5940fb1051516ab9fbf7f4c9bc"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=94f3ba4eba45eae14396f3499fcb5383"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL"
+
+DEPENDS += "xz openssl"
+RDEPENDS_${PN} += "liblzma openssl"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_2.6.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_2.6.1.bb
@@ -1,0 +1,31 @@
+require mender-client.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=2.6.x"
+
+# Tag: 2.6.1
+SRCREV = "ec5271500259b6f0adfb5c6505523c2c389cd2dd"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=69a48b331ae876b6775139310ec72f1b"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL"
+
+DEPENDS += "xz openssl"
+RDEPENDS_${PN} += "liblzma openssl"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.0.2.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.0.2.bb
@@ -1,0 +1,28 @@
+require mender-connect.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=1.0.x"
+
+# Tag: 1.0.2
+SRCREV = "bf966d20f497fccee0968c45e5060516c4da9556"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LIC_FILES_CHKSUM.sha256;md5=496bbc1daf381b64e77838a406aef285"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.1.1.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.1.1.bb
@@ -1,0 +1,28 @@
+require mender-connect.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=1.1.x"
+
+# Tag: 1.1.1
+SRCREV = "a65c431f19b8dd03b207441e78bc2b6f35a91b85"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LIC_FILES_CHKSUM.sha256;md5=fa1436147d867cccbbc08ed73f77f9b6"


### PR DESCRIPTION
Changelog: Add mender-artifact-3.5.2 recipe.
Changelog: Add mender-client-2.5.2 recipe.
Changelog: Add mender-client-2.6.1 recipe.
Changelog: Add mender-connect-1.0.2 recipe.
Changelog: Add mender-connect-1.1.1 recipe.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit b647b4beb5235cf468cecb3424f54b0653491b53)
