### PR TITLE
MEN-4811: Conditionally install D-Bus interface files

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -274,12 +274,19 @@ do_install() {
     # install dbus files
     if grep -q install-dbus ${B}/src/${GO_IMPORT}/Makefile; then
         if ${@bb.utils.contains('PACKAGECONFIG', 'dbus', 'true', 'false', d)}; then
+            # install the D-Bus policy file
             oe_runmake \
                 -C ${B}/src/${GO_IMPORT} \
                 V=1 \
                 prefix=${D} \
                 datadir=${datadir} \
                 install-dbus
+
+            # install the D-Bus interface file(s)
+            if [ -f ${B}/src/${GO_IMPORT}/Documentation/io.mender.Authentication1.xml ]; then
+                install -d ${D}${datadir}/dbus-1/interface
+                install -m 0644 ${B}/src/${GO_IMPORT}/Documentation/io.mender.*.xml ${D}${datadir}/dbus-1/interface
+            fi
         fi
     fi
 
@@ -318,12 +325,6 @@ do_install() {
     install -d ${D}${sysconfdir}/udev/mount.blacklist.d
     echo ${MENDER_ROOTFS_PART_A} > ${D}${sysconfdir}/udev/mount.blacklist.d/mender
     echo ${MENDER_ROOTFS_PART_B} >> ${D}${sysconfdir}/udev/mount.blacklist.d/mender
-
-    # install the D-Bus interface file
-    if [ -f ${B}/src/${GO_IMPORT}/Documentation/io.mender.Authentication1.xml ]; then
-        install -d ${D}${datadir}/dbus-1/interface
-        install -m 0644 ${B}/src/${GO_IMPORT}/Documentation/io.mender.*.xml ${D}${datadir}/dbus-1/interface
-    fi
 }
 
 do_install_append_class-target_mender-image_mender-systemd() {

--- a/meta-mender-qemu/recipes-mender/mender-client/mender-client_git.bbappend
+++ b/meta-mender-qemu/recipes-mender/mender-client/mender-client_git.bbappend
@@ -1,1 +1,0 @@
-require mender-client-test-files.inc


### PR DESCRIPTION
    MEN-4811: Conditionally install D-Bus interface files
    
    The interface files, shipped in mender-client-dev package, shall be
    present only when PACKAGECONFIG contains "dbus".
    
    Fixed also how the test was getting `deploy_dir_rpm`. If obtained from
    bitbake variables, the dir will point to the base build dir (and not the
    prepared one for this test!).

    Changelog: Fix: mender-client-dev package contains D-Bus interface files
    only when "dbus" is enabled in PACKAGECONFIG.

In addition:
* meta-mender-qemu: Remove mender-client_git.bbappend
* Testing https://github.com/mendersoftware/mender-image-tests/pull/55 (technically unrelated, though)