### PR TITLE
MEN-4807: mender-monitor integration (external flow)

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
@@ -18,11 +18,14 @@ FILES_${PN}_append_mender-systemd = " \
     ${systemd_system_unitdir}/mender-monitor.service \
 "
 
-S ?= "${WORKDIR}/${PN}"
+S = "${WORKDIR}/mender-monitor"
 
 do_version_check() {
     if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
-        bbfatal "Not yet released. This recipe can only be used with MENDER_DEVMODE"
+        tarball_version=$(cat ${S}/.version)
+        if [ "${tarball_version}" != "${PV}" ]; then
+            bbfatal "Version '${PV}' not found in .version file from the tarball. Is it the correct version? Found '${tarball_version}'"
+        fi
     fi
 }
 addtask do_version_check after do_unpack before do_install

--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
@@ -1,9 +1,16 @@
 require mender-monitor.inc
 
-PV = "master-git"
-
-# Source directly the repo, override name
-S = "${WORKDIR}/monitor-client"
+def mender_monitor_version_from_preferred_version(d):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is not None and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, use the version as is. This means that
+        # we can build tags with "-build" in them from this recipe, but not
+        # final tags, which will need their own recipe.
+        return pref_version
+    else:
+        # Else return the default "master-git".
+        return "master-git"
+PV = "${@mender_monitor_version_from_preferred_version(d)}"
 
 # Skip version check
 MENDER_DEVMODE = "true"

--- a/tests/acceptance/commercial/test_monitor_addon.py
+++ b/tests/acceptance/commercial/test_monitor_addon.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import subprocess
+
+import pytest
+
+from utils.common import (
+    build_image,
+    latest_build_artifact,
+)
+
+
+@pytest.mark.commercial
+@pytest.mark.min_mender_version("3.1.0")
+class TestDeltaUpdateModule:
+    @pytest.mark.only_with_image("ext4")
+    def test_build_addon(
+        self, request, bitbake_variables, prepared_test_build, bitbake_image
+    ):
+        build_image(
+            prepared_test_build["build_dir"],
+            prepared_test_build["bitbake_corebase"],
+            bitbake_image,
+            ['IMAGE_INSTALL_append = " mender-monitor"'],
+            [
+                'BBLAYERS_append = " %s/../meta-mender-commercial"'
+                % bitbake_variables["LAYERDIR_MENDER"]
+            ],
+        )
+        image = latest_build_artifact(
+            request, prepared_test_build["build_dir"], "core-image*.ext4"
+        )
+
+        for expected_node in [
+            "/usr/bin/mender-monitorctl",
+            "/usr/bin/mender-monitord",
+            "/etc/mender-monitor/monitor.d/log.sh",
+            "/etc/mender-monitor/monitor.d/service.sh",
+            "/usr/share/mender-monitor/mender-monitorctl",
+            "/usr/share/mender-monitor/mender-monitord",
+            "/usr/share/mender-monitor/ctl.sh",
+            "/usr/share/mender-monitor/daemon.sh",
+            "/usr/share/mender-monitor/common/common.sh",
+            "/usr/share/mender-monitor/config/config.sh",
+            "/usr/share/mender-monitor/lib/monitor-lib.sh",
+            "/usr/share/mender-monitor/lib/service-lib.sh",
+            "/var/lib/mender-monitor",
+        ]:
+            output = subprocess.check_output(
+                ["debugfs", "-R", "stat %s" % expected_node, image]
+            ).decode()
+
+            # The nodes are either files or symlinks
+            assert "Type: regular" in output or "Type: symlink" in output


### PR DESCRIPTION
* Add version check in mender-monitor.inc
* Add logic to accept build tags in mender-monitor_git.bb
* Unify `S` in git and inc recipe: both will use the tarball
* Add test test_monitor_addon.py to check contents