### PR TITLE
mender-monitor_git: define unique PV based on SRCREV

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
@@ -1,6 +1,30 @@
 require mender-monitor.inc
 
-def mender_monitor_version_from_preferred_version(d):
+def mender_monitor_srcrev_from_src_uri(d, src_uri):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is not None and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, SRCREV won't be used for defining PV
+        return ""
+    else:
+        # Extract SRCREV from the tarball filename
+        import glob
+        import re
+        # Remove "file://" prefix
+        src_uri_glob = src_uri.split()[0][len("file://"):]
+        # Get the filename
+        filenames = glob.glob(src_uri_glob)
+        if len(filenames) != 1:
+            bb.error("Expected exactly one file, found: %s" % filenames)
+        filename = filenames[0]
+        # Now extract the git sha from the filename
+        m = re.match(r".*/mender-monitor-([0-9a-f]+)\.tar\.gz", filename)
+        if m is None:
+            bb.error("Cannot extract git sha from filename: %s" % filename)
+        return m.group(1)
+
+SRCREV = "${@mender_monitor_srcrev_from_src_uri(d, '${SRC_URI}')}"
+
+def mender_monitor_version_from_preferred_version(d, srcrev):
     pref_version = d.getVar("PREFERRED_VERSION")
     if pref_version is not None and pref_version.find("-build") >= 0:
         # If "-build" is in the version, use the version as is. This means that
@@ -8,9 +32,10 @@ def mender_monitor_version_from_preferred_version(d):
         # final tags, which will need their own recipe.
         return pref_version
     else:
-        # Else return the default "master-git".
-        return "master-git"
-PV = "${@mender_monitor_version_from_preferred_version(d)}"
+        # Else return "master-git${SRCREV}".
+        return "master-git%s" % srcrev
+
+PV = "${@mender_monitor_version_from_preferred_version(d, '${SRCREV}')}"
 
 # Skip version check
 MENDER_DEVMODE = "true"


### PR DESCRIPTION
This will force yocto to rebuild from source every time that the
filename of the tarball changes.

Now the PV for the git recipe will be master-git${SRCREV}

This change aligns this recipe with other Mender components that are
build from source, though in this case SRCREV is extracted from the
filename and not from an actual Git repository.