### PR TITLE
master: Release Mender 3.1.0

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.3.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.3.0.bb
@@ -1,0 +1,6 @@
+require mender-binary-delta.inc
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_1.0.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_1.0.0.bb
@@ -1,0 +1,6 @@
+require mender-monitor.inc
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
@@ -23,7 +23,9 @@ def mender_monitor_srcrev_from_src_uri(d, src_uri):
         # Now extract the git sha from the filename
         m = re.match(r".*/mender-monitor-([0-9a-f]+)\.tar\.gz", filename)
         if m is None:
-            bb.error("Cannot extract git sha from filename: %s" % filename)
+            # No match probably means that the tarball is a tagged version, in
+            # which case this recipe is not to be used but still needs to parse
+            return ""
         return m.group(1)
 
 SRCREV = "${@mender_monitor_srcrev_from_src_uri(d, '${SRC_URI}')}"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.6.1.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_3.6.1.bb
@@ -1,0 +1,30 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=3.6.x"
+
+# Tag: 3.6.1
+SRCREV = "af2a3e3fb0069df3297dfea78e258c4b4d9dbd4d"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-artifact/LIC_FILES_CHKSUM.sha256;md5=0da2ded6556051c5d2fd88ca8339efd4"
+
+DEPENDS += "xz"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_3.1.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_3.1.0.bb
@@ -1,0 +1,31 @@
+require mender-client.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=3.1.x"
+
+# Tag: 3.1.0
+SRCREV = "4c077c92f313aac92bf3bb492ef479b3447ddc08"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender/LIC_FILES_CHKSUM.sha256;md5=69a48b331ae876b6775139310ec72f1b"
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & OpenSSL"
+
+DEPENDS += "xz openssl"
+RDEPENDS_${PN} += "liblzma openssl"

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_1.0.2.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_1.0.2.bb
@@ -1,0 +1,28 @@
+require mender-configure.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-configure-module;protocol=https;branch=1.0.x"
+
+# Tag: 1.0.2
+SRCREV = "7f091d3d414950011d98056ba4357dd26b5c1f53"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LIC_FILES_CHKSUM = "file://${S}/LIC_FILES_CHKSUM.sha256;md5=dbe7fef3ae7b158261d81f13228969e6"
+LICENSE = "Apache-2.0"


### PR DESCRIPTION
Porting #1476 to master.

    Port to master: remove DEFAULT_PREFERENCE = "-1" for mender-client
    recipe.