### PR TITLE
mender-helpers: add support for VirtIO disk drives

### DIFF
--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -36,7 +36,7 @@ get_part_number_from_device() {
         /dev/mmcblk*p* )
             dev_base=$(echo $1 | cut -dk -f2 | cut -dp -f2)
             ;;
-        /dev/[sh]d[a-z][1-9])
+        /dev/[shv]d[a-z][1-9])
             dev_base=${1##*d[a-z]}
             ;;
         /dev/nvme[0-9]n[0-9]p[0-9])

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -17,7 +17,7 @@ MENDER_STORAGE_DEVICE_DEFAULT = "/dev/mmcblk0"
 MENDER_STORAGE_DEVICE_BASE ??= "${MENDER_STORAGE_DEVICE_BASE_DEFAULT}"
 def mender_linux_partition_base(dev):
     import re
-    if re.match("^/dev/[sh]d[a-z]", dev):
+    if re.match("^/dev/[shv]d[a-z]", dev):
         return dev
     else:
         return "%sp" % dev


### PR DESCRIPTION
Virtual disk devices are listed as /dev/vdX.

Update Regex to allow user setting a MENDER_STORAGE_DEVICE = "/dev/vda".

