### PR TITLE
Fix FTBFS due to host contamination with secure boot enabled

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
+++ b/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
@@ -29,6 +29,7 @@ CONFFILES_${PN}_remove = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '${EFI_BOOT_PATH}/grubenv', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '${EFI_BOOT_PATH}/boot-menu.inc', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '${EFI_BOOT_PATH}/efi-secure-boot.inc', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '${EFI_BOOT_PATH}/password.inc', '', d)} \
 "
 
 # Allow the cfg and signature files to be installed by grub-mender-grubenv
@@ -36,7 +37,7 @@ python do_cleanconfigs_class-target() {
     if bb.utils.contains('DISTRO_FEATURES', 'mender-grub', True, False, d) and \
         bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', True, False, d):
             ext = d.getVar("SB_FILE_EXT")
-            for basename in ("grub.cfg", "grubenv", "boot-menu.inc", "efi-secure-boot.inc"):
+            for basename in ("grub.cfg", "grubenv", "boot-menu.inc", "efi-secure-boot.inc", "password.inc"):
                 filebase = d.getVar("D") + d.getVar("MENDER_BOOT_PART_MOUNT_LOCATION") + "/EFI/BOOT/" + basename
                 if os.path.exists(filebase):
                     os.remove(filebase)


### PR DESCRIPTION
meta-secure-core defines `password.inc` which triggers an error if I want to use secure boot:

```
meta-secure-core defines password.inc which triggers an error:
Path ./package/boot/efi/EFI/BOOT/password.inc.p7b is owned by uid 1000,
gid 1000, which doesn't match any user/group on target. This may be due
to host contamination.
```

Removing `password.inc` file fixes this.

Please, review. Thanks.