### PR TITLE
Add new D-Bus policy file for io.mender.Proxy object

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -31,6 +31,7 @@ SYSTEMD_SERVICE_${PN} = "${MENDER_CLIENT}.service"
 FILES_${PN} += "\
     ${datadir}/dbus-1/system.d/io.mender.AuthenticationManager.conf \
     ${datadir}/dbus-1/system.d/io.mender.UpdateManager.conf \
+    ${datadir}/dbus-1/system.d/io.mender.Proxy.conf \
     ${datadir}/mender/identity \
     ${datadir}/mender/identity/mender-device-identity \
     ${datadir}/mender/inventory \

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1200,7 +1200,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             b"mender-inventory-geo" not in output
         ), "mender-inventory-network-scripts unexpectedly a part of the image"
 
-    @pytest.mark.min_mender_version("2.7.0")
+    @pytest.mark.min_mender_version("3.2.0")
     def test_mender_dbus_interface_file(
         self, request, prepared_test_build, bitbake_image
     ):
@@ -1212,6 +1212,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         EXPECTED_FILES = [
             "io.mender.Authentication1.xml",
             "io.mender.Update1.xml",
+            "io.mender.Proxy1.xml",
         ]
 
         # clean up the mender-client


### PR DESCRIPTION
Part of MEN-5166.

The spec file is implicitly installed in dbus-1/interface by the
Makefile

Changelog: None