### PR TITLE
add systemd-boot support

### DIFF
--- a/meta-mender-core/classes/mender-image-systemd-boot.bbclass
+++ b/meta-mender-core/classes/mender-image-systemd-boot.bbclass
@@ -1,0 +1,51 @@
+# mender-image-systemd-boot: prepare image for a systemd-boot system
+
+# Move required files into the image partition boot sector
+EFI_BOOT_IMAGE_PART ?= \
+    "${IMAGE_LINK_NAME}.${EFI_BOOT_IMAGE};EFI/Linux/${EFI_BOOT_IMAGE}"
+IMAGE_BOOT_FILES_append_mender-systemd-boot = " \
+    systemd-${EFI_BOOT_IMAGE};EFI/BOOT/${EFI_BOOT_IMAGE} \
+    ${@ "${EFI_BOOT_IMAGE_PART}".replace('.efi','_a.efi') } \
+    ${@ "${EFI_BOOT_IMAGE_PART}".replace('.efi','_b.efi') } \
+    ${IMAGE_LINK_NAME}.esp/loader/main/config*;loader/main/ \
+    ${IMAGE_LINK_NAME}.esp/loader/backup/config*;loader/backup/ \
+    "
+
+IMAGE_INSTALL_append_mender-systemd-boot = " systemd-mender-config"
+
+require conf/image-uefi.conf
+
+do_uefiapp[vardeps] += "APPEND MENDER_ROOTFS_PART_A MENDER_ROOTFS_PART_B"
+do_uefiapp[depends] += "systemd-mender-config-native:do_populate_sysroot"
+inherit uefi-comboapp
+
+# overridden from meta-intel
+python create_uefiapps() {
+    # We must clean up anything that matches the expected output pattern, to ensure that
+    # the next steps do not accidentally use old files.
+    import glob
+    path = d.expand('${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}')
+    for old_efi in glob.glob(path + '.boot*.efi'):
+        os.unlink(old_efi)
+
+    append = d.getVar('APPEND')
+
+    # Use A/B kernel suffixes with modified root= arguments
+    d.setVar('APPEND', '%s root=%s' % (append, d.getVar('MENDER_ROOTFS_PART_A')))
+    create_uefiapp(d, uuid=None, app_suffix='_a')
+    d.setVar('APPEND', '%s root=%s' % (append, d.getVar('MENDER_ROOTFS_PART_B')))
+    create_uefiapp(d, uuid=None, app_suffix='_b')
+
+    from subprocess import check_call
+    check_call("ab_setup.py init " + path + '.esp', shell=True)
+}
+
+
+# Copy unified kernel images images to /bin, so fw_setenv can pick them up when an upgrade
+# is requested.
+fakeroot do_uefiapp_deploy() {
+    rm -rf ${IMAGE_ROOTFS}/boot/*
+    dest=${IMAGE_ROOTFS}/bin
+    mkdir -p $dest
+    uefiapp_deploy_at $dest
+}

--- a/meta-mender-core/classes/mender-maybe-setup.bbclass
+++ b/meta-mender-core/classes/mender-maybe-setup.bbclass
@@ -37,6 +37,9 @@ python() {
         # Integration with GRUB.
         'mender-grub',
 
+        # Enabled by GRUB/systemd-boot to extend UEFI overlay recipes.
+        'mender-efi-boot',
+
         # Install of Mender, with the minimum components. This includes no
         # references to specific partition layouts.
         'mender-client-install',

--- a/meta-mender-core/classes/mender-maybe-setup.bbclass
+++ b/meta-mender-core/classes/mender-maybe-setup.bbclass
@@ -66,6 +66,9 @@ python() {
         # Include Mender as a systemd service.
         'mender-systemd',
 
+        # Use Mender together with systemd-boot.
+        'mender-systemd-boot',
+
         # Enable Mender configuration specific to UBI.
         'mender-ubi',
 

--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -267,6 +267,10 @@ _MENDER_PART_IMAGE_DEPENDS_append_mender-grub_aarch64 = " u-boot:do_deploy"
 
 _MENDER_PART_IMAGE_DEPENDS_append_mender-uboot = " u-boot:do_deploy"
 _MENDER_PART_IMAGE_DEPENDS_append_mender-grub_mender-bios = " grub:do_deploy"
+_MENDER_PART_IMAGE_DEPENDS_append_mender-systemd-boot = " \
+    systemd-boot:do_deploy \
+    ${IMAGE_BASENAME}:do_uefiapp_deploy \
+"
 
 do_image_sdimg[depends] += "${_MENDER_PART_IMAGE_DEPENDS}"
 do_image_sdimg[depends] += " ${@bb.utils.contains('SOC_FAMILY', 'rpi', 'bootfiles:do_populate_sysroot', '', d)}"

--- a/meta-mender-core/classes/mender-setup-grub.inc
+++ b/meta-mender-core/classes/mender-setup-grub.inc
@@ -19,3 +19,5 @@ python() {
     if d.getVar('MENDER_GRUB_STORAGE_DEVICE'):
         bb.fatal("MENDER_GRUB_STORAGE_DEVICE is deprecated. This is now dynamically determined at runtime.")
 }
+
+MENDER_FEATURES_ENABLE_append_mender-grub = "mender-efi-boot"

--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -20,6 +20,7 @@ python() {
 
 MENDER_BOOT_PART_MOUNT_LOCATION = "/boot/efi"
 MENDER_BOOT_PART_MOUNT_LOCATION_mender-uboot = "/uboot"
+MENDER_BOOT_PART_MOUNT_LOCATION_mender-systemd-boot = "/boot"
 MENDER_BOOT_PART_MOUNT_LOCATION_mender-grub_mender-bios = "/boot/grub"
 
 # Set Yocto variable.

--- a/meta-mender-core/classes/mender-setup-systemd-boot.inc
+++ b/meta-mender-core/classes/mender-setup-systemd-boot.inc
@@ -1,0 +1,10 @@
+# Mender systemd-boot support
+
+EFI_PROVIDER_mender-systemd-boot = "systemd-boot"
+
+# systemd-boot requires a slightly larger default boot partition
+MENDER_BOOT_PART_SIZE_MB_DEFAULT_mender-systemd-boot = "64"
+
+WKS_FILE_DEPENDS_BOOTLOADERS_remove_mender-systemd-boot = "grub-efi"
+
+MENDER_FEATURES_ENABLE_append_mender-systemd-boot = "mender-efi-boot"

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -340,5 +340,6 @@ require mender-setup-grub.inc
 require mender-setup-image.inc
 require mender-setup-install.inc
 require mender-setup-systemd.inc
+require mender-setup-systemd-boot.inc
 require mender-setup-ubi.inc
 require mender-setup-uboot.inc

--- a/meta-mender-core/recipes-bsp/systemd-mender-config/files/ab_setup.py
+++ b/meta-mender-core/recipes-bsp/systemd-mender-config/files/ab_setup.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# Copyright 2021 Signify Netherlands B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from subprocess import check_call
+
+import hashlib
+import shutil
+import struct
+import sys
+import os
+import re
+
+# 6 bytes header + 2*256*2 paths UTF16LE
+AB_SIZE = 1030
+AB_FORMAT = "6B512s512s"
+
+# 256 bits -> 256/8 = 32 bytes
+SHA256_SIZE = 32
+
+ROOTFS_OFFSET = 1
+
+def try_read_file(path, length):
+    """Try to read the designated file with the specified length. Fill with
+       zeroes if it does not exist."""
+    try:
+        with open(path, "rb") as f:
+            bytes = f.read()
+
+            # If the file was as long as expected, return its contents
+            if len(bytes) == length:
+                return bytes
+    except FileNotFoundError:
+        pass
+
+    # Otherwise return zeroes
+    return bytearray(length)
+
+def write_file(path, contents):
+    with open(path, "wb") as f:
+        f.write(contents)
+
+def write_config(esp_base, config):
+    """Commit the specified config to disk."""
+    config_hash = hashlib.sha256(config).digest()
+
+    os.makedirs("{}/loader/main".format(esp_base), exist_ok=True)
+    write_file("{}/loader/main/config".format(esp_base), config)
+    write_file("{}/loader/main/config.sha256".format(esp_base), config_hash)
+
+    os.makedirs("{}/loader/backup".format(esp_base), exist_ok=True)
+    write_file("{}/loader/backup/config".format(esp_base), config)
+    write_file("{}/loader/backup/config.sha256".format(esp_base), config_hash)
+
+def get_config(esp_base):
+    """Get a config object from disk, (re-)creating if it does not yet exist
+       or is invalid."""
+    config_a = try_read_file("{}/loader/main/config".format(esp_base), AB_SIZE)
+    config_b = try_read_file("{}/loader/backup/config".format(esp_base), AB_SIZE)
+
+    sum_a = try_read_file("{}/loader/main/config.sha256".format(esp_base), SHA256_SIZE)
+    sum_b = try_read_file("{}/loader/backup/config.sha256".format(esp_base), SHA256_SIZE)
+
+    hash_a = hashlib.sha256(config_a).digest()
+    hash_b = hashlib.sha256(config_b).digest()
+
+    a_valid = sum_a == hash_a
+    b_valid = sum_b == hash_b
+
+    # Can happen if a commit was interrupted
+    # Assume A is the intended configuration and use that
+    if a_valid and b_valid and config_a != config_b:
+        b_valid = False
+
+    if a_valid and not b_valid:
+        # Recover config B from A
+        write_config(esp_base, config_a)
+        return config_a
+
+    if b_valid and not a_valid:
+        # Recover config A from B
+        write_config(esp_base, config_b)
+        return config_b
+
+    if not a_valid and not b_valid:
+        # A and B configs invalid, use defaults
+        write_config(esp_base, default_config())
+        return default_config()
+
+    # Both valid, return A
+    return config_a
+
+def parse_config(config):
+    _, pending, boot_count, max_boot_count, active_slot, _, a_efi, b_efi = struct.unpack(AB_FORMAT, config)
+
+    active_slot = active_slot & 0x1
+
+    return {
+        "pending": pending,
+        "boot_count": boot_count,
+        "max_boot_count": max_boot_count,
+        "active_slot": active_slot,
+        "a_efi": a_efi.decode("UTF-16LE").rstrip("\x00"),
+        "b_efi": b_efi.decode("UTF-16LE").rstrip("\x00")
+    }
+
+def serialize_config(config):
+
+    return struct.pack(
+        AB_FORMAT,
+        0x1,
+        config["pending"],
+        config["boot_count"], 
+        config["max_boot_count"],
+        config["active_slot"] & 0x1,
+        0x0,
+        config["a_efi"].encode("UTF-16LE"),
+        config["b_efi"].encode("UTF-16LE")
+    )
+
+def default_config():
+    config = {}
+
+    config["pending"] = 0
+    config["boot_count"] = 0
+    config["max_boot_count"] = 1
+    config["active_slot"] = 0
+    config["a_efi"] = "\\EFI\\Linux\\bootx64_a.efi"
+    config["b_efi"] = "\\EFI\\Linux\\bootx64_b.efi"
+
+    return serialize_config(config)
+
+def root_device():
+    mounts = None
+
+    # /dev/sda2 / ext4 rw,relatime,errors=remount-ro 0 0
+    with open("/proc/mounts", "r") as f:
+        mounts = f.readlines()
+
+    # /dev/sda2 /
+    mounts = [m.split(" ")[0:2] for m in mounts]
+    mounts = [m[0] for m in mounts if m[1] == "/"]
+
+    # /dev/sda
+    return re.sub("\d+$", "", mounts[0])
+
+def extract_kernel(esp_base, config, slot):
+    # Set up pick from inactive slot
+    slot_name = "a" if slot == 0 else "b"
+    partition_name = "{}{}".format(root_device(), slot + ROOTFS_OFFSET)
+    inactive_base = "/mnt/inactive"
+
+    source_kernel_path = "{}/bin/bootx64_{}.efi".format(inactive_base, slot_name)
+    target_kernel_path = "{}{}".format(esp_base, config["{}_efi".format(slot_name)].replace("\\", "/"))
+
+    # Mount inactive slot and extract file
+    os.makedirs(inactive_base, exist_ok=True)
+    check_call(["mount", partition_name, inactive_base])
+
+    shutil.copyfile(source_kernel_path, target_kernel_path);
+
+    check_call(["umount", inactive_base])
+    os.rmdir(inactive_base)
+    os.sync()
+
+def set_mender_key(esp_base, config, key, value):
+    if key == "mender_boot_part":
+        v = int(value) - ROOTFS_OFFSET
+        config["active_slot"] = v
+        extract_kernel(esp_base, config, v)
+    elif key == "upgrade_available":
+        config["pending"] = int(value)
+        config["boot_count"] = 0
+    elif key == "bootcount":
+        config["boot_count"] = int(value)
+    elif key == "max_boot_count":
+        config[key] = int(value)
+
+def get_mender_key(config, key):
+    if key == "mender_boot_part" or key == "mender_boot_part_hex":
+        return config["active_slot"] + ROOTFS_OFFSET
+    elif key == "mender_uboot_separator":
+        return "1"
+    elif key == "upgrade_available":
+        return config["pending"]
+    elif key == "bootcount":
+        return config["boot_count"]
+    elif key == "max_boot_count":
+        return config["max_boot_count"]
+    else:
+        return ""
+
+def to_kv(attributes):
+    if len(attributes) == 2:
+        return [a.strip() for a in attributes]
+    else:
+        return [attributes[0].strip(), None]
+
+def set_mender_keys(esp_base, config, attributes):
+    kvs = [to_kv(re.split("=| ", kv, 1)) for kv in attributes]
+
+    for key, value in kvs:
+        set_mender_key(esp_base, config, key, value)
+
+def print_mender_keys(config, keys):
+    for key in keys:
+        print("{}={}".format(key, get_mender_key(config, key)))
+
+def fw_printenv(config):
+    if len(sys.argv[1:]) > 0:
+        keys = sys.argv[1:]
+    else:
+        keys = ["mender_boot_part", "upgrade_available", "bootcount"]
+    print_mender_keys(config, keys)
+
+def fw_setenv(esp_base, config):
+    lines = sys.stdin.readlines()
+    set_mender_keys(esp_base, config, lines)
+    write_config(esp_base, serialize_config(config))
+
+def fw_init(path):
+    write_config(path, default_config())
+
+def fw_cmd():
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ''
+
+    if cmd in "init":
+        if len(sys.argv) == 3:
+            fw_init(sys.argv[2])
+            sys.exit(0)
+
+    sys.exit(1)
+
+if __name__ == "__main__":
+    progname = sys.argv[0]
+    if not (progname.endswith("printenv") or progname.endswith("setenv")):
+        fw_cmd()
+
+    esp_base = "/boot"
+    config = parse_config(get_config(esp_base))
+
+    if "printenv" in progname:
+        fw_printenv(config)
+    elif "setenv" in progname:
+        fw_setenv(esp_base, config)
+    else:
+        sys.exit(1)

--- a/meta-mender-core/recipes-bsp/systemd-mender-config/systemd-mender-config.bb
+++ b/meta-mender-core/recipes-bsp/systemd-mender-config/systemd-mender-config.bb
@@ -1,0 +1,25 @@
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/${LICENSE};md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+RDEPENDS_${PN} = "python3"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI = " \
+    file://ab_setup.py \
+    "
+
+S = "${WORKDIR}"
+
+do_compile() {
+    :
+}
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 "${WORKDIR}/ab_setup.py" "${D}${sbindir}"
+
+    ln -s "../..${sbindir}/ab_setup.py" "${D}${sbindir}/systemd-boot-printenv"
+    ln -s "../..${sbindir}/ab_setup.py" "${D}${sbindir}/systemd-boot-setenv"
+}
+
+BBCLASSEXTEND += "native"

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -1,5 +1,5 @@
 require initramfs-module-install.inc
 
-do_install_append_mender-grub() {
+do_install_append_mender-efi-boot() {
     install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install-efi.sh
 }

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install.inc
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install.inc
@@ -1,8 +1,8 @@
-FILESEXTRAPATHS_prepend_mender-grub := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend_mender-efi-boot := "${THISDIR}/files:"
 
-SRC_URI_append_mender-grub = " file://init-install-efi-mender.sh "
+SRC_URI_append_mender-efi-boot = " file://init-install-efi-mender.sh "
 
-do_install_append_mender-grub() {
+do_install_append_mender-efi-boot() {
     # Overwrite the version of this file provided by upstream
     sed -e 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh > init-install-efi-mender-altered.sh
 }

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install_%.bbappend
@@ -1,5 +1,5 @@
 require initramfs-module-install.inc
 
-do_install_append_mender-grub() {
+do_install_append_mender-efi-boot() {
     install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install.sh
 }

--- a/meta-mender-core/recipes-core/meta/wic-tools.bbappend
+++ b/meta-mender-core/recipes-core/meta/wic-tools.bbappend
@@ -1,0 +1,1 @@
+DEPENDS_remove_mender-systemd-boot = "grub grub-efi grub-efi-native"

--- a/meta-mender-core/recipes-core/systemd/files/systemd-boot-slotconfig.patch
+++ b/meta-mender-core/recipes-core/systemd/files/systemd-boot-slotconfig.patch
@@ -1,0 +1,316 @@
+commit 9859c61858d6a55dc648bafef46c554a93d87285
+Author: Liam White McShane <liam.white@timesys.com>
+Date:   Fri Jul 23 13:53:17 2021 -0400
+
+    Add slot config
+
+diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
+index 176028efa4..80c5641e2a 100644
+--- a/src/boot/efi/boot.c
++++ b/src/boot/efi/boot.c
+@@ -14,6 +14,7 @@
+ #include "pe.h"
+ #include "random-seed.h"
+ #include "shim.h"
++#include "slot.h"
+ #include "util.h"
+ 
+ #ifndef EFI_OS_INDICATIONS_BOOT_TO_FW_UI
+@@ -2257,6 +2258,46 @@ out_unload:
+         return err;
+ }
+ 
++static EFI_STATUS boot_ab(EFI_LOADED_IMAGE *parent_image, EFI_HANDLE device, EFI_FILE *root_dir, ABConfig *config) {
++        EFI_HANDLE image;
++        _cleanup_freepool_ EFI_DEVICE_PATH *path = NULL;
++        EFI_STATUS err;
++
++        if (config->boot_count >= config->max_boot_count) {
++                Print(L"Boot failed %d time(s) on slot %d\n", config->boot_count, config->active_slot);
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                switch_active_slot(root_dir, config);
++        }
++
++        if (config->upgrade_pending) {
++                Print(L"Upgrade pending, trying new boot on slot %d\n", config->active_slot);
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                increment_boot_count(root_dir, config);
++        }
++
++        path = FileDevicePath(device, config->active_slot == SLOT_A ? config->a_efi : config->b_efi);
++        if (!path) {
++                Print(L"Error getting device path\n");
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                return EFI_INVALID_PARAMETER;
++        }
++
++        err = uefi_call_wrapper(BS->LoadImage, 6, TRUE, parent_image, path, NULL, 0, &image);
++        if (EFI_ERROR(err)) {
++                _cleanup_freepool_ CHAR16 *str = NULL;
++                str = DevicePathToStr(path);
++                Print(L"Error loading image %s: %r\n", str, err);
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                return err;
++        }
++
++        efivar_set_time_usec(L"LoaderTimeExecUSec", 0);
++        err = uefi_call_wrapper(BS->StartImage, 3, image, NULL, NULL);
++
++        uefi_call_wrapper(BS->UnloadImage, 1, image);
++        return err;
++}
++
+ static EFI_STATUS reboot_into_firmware(VOID) {
+         _cleanup_freepool_ CHAR8 *b = NULL;
+         UINTN size;
+@@ -2332,6 +2373,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         CHAR16 *loaded_image_path;
+         EFI_STATUS err;
+         Config config;
++        ABConfig ab_config;
+         UINT64 init_usec;
+         BOOLEAN menu = FALSE;
+         CHAR16 uuid[37];
+@@ -2377,6 +2419,10 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                 }
+         }
+ 
++        if (get_ab_config(root_dir, &ab_config) && !EFI_ERROR(boot_ab(image, loaded_image->DeviceHandle, root_dir, &ab_config))) {
++              return EFI_SUCCESS;
++        }
++
+         /* the filesystem path to this image, to prevent adding ourselves to the menu */
+         loaded_image_path = DevicePathToStr(loaded_image->FilePath);
+         efivar_set(L"LoaderImageIdentifier", loaded_image_path, FALSE);
+diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
+index ed81cefcd5..fcae727a12 100644
+--- a/src/boot/efi/meson.build
++++ b/src/boot/efi/meson.build
+@@ -12,6 +12,7 @@ efi_headers = files('''
+         random-seed.h
+         sha256.h
+         shim.h
++        slot.h
+         splash.h
+         util.h
+ '''.split())
+@@ -31,6 +32,7 @@ systemd_boot_sources = '''
+         random-seed.c
+         sha256.c
+         shim.c
++        slot.c
+ '''.split()
+ 
+ stub_sources = '''
+diff --git a/src/boot/efi/slot.c b/src/boot/efi/slot.c
+new file mode 100644
+index 0000000000..7b364c078b
+--- /dev/null
++++ b/src/boot/efi/slot.c
+@@ -0,0 +1,175 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include <efi.h>
++#include <efilib.h>
++
++#include "sha256.h"
++#include "slot.h"
++#include "util.h"
++
++static EFI_STATUS read_file(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN size, UINT8 *buf) {
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE handle = NULL;
++        EFI_STATUS err;
++
++        err = uefi_call_wrapper(dir->Open, 5, dir, &handle, (CHAR16 *) name, EFI_FILE_MODE_READ, 0ULL);
++        if (EFI_ERROR(err))
++                return err;
++
++        err = uefi_call_wrapper(handle->Read, 3, handle, &size, (CHAR8 *) buf);
++        if (EFI_ERROR(err))
++                return err;
++
++        return err;
++}
++
++static EFI_STATUS write_file(EFI_FILE_HANDLE dir, const CHAR16 *name, UINTN size, UINT8 *buf) {
++        _cleanup_(FileHandleClosep) EFI_FILE_HANDLE handle = NULL;
++        EFI_STATUS err;
++
++        err = uefi_call_wrapper(dir->Open, 5, dir, &handle, (CHAR16 *) name, EFI_FILE_MODE_READ | EFI_FILE_MODE_WRITE, 0ULL);
++        if (EFI_ERROR(err)) {
++                return err;
++        }
++
++        err = uefi_call_wrapper(handle->Write, 3, handle, &size, (CHAR8 *) buf);
++        if (EFI_ERROR(err)) {
++                return err;
++        }
++
++        return err;
++}
++
++static EFI_STATUS hash_and_write_file(EFI_FILE_HANDLE dir, const CHAR16 *name, const CHAR16 *sum_name, UINTN size, UINT8 *buf) {
++        struct sha256_ctx ctx;
++        UINT8 hash[32];
++        EFI_STATUS err;
++
++        sha256_init_ctx(&ctx);
++        sha256_process_bytes(buf, size, &ctx);
++        sha256_finish_ctx(&ctx, &hash);
++
++        err = write_file(dir, name, size, buf);
++        if (EFI_ERROR(err))
++                return err;
++
++        err = write_file(dir, sum_name, 32, (UINT8 *) &hash);
++        if (EFI_ERROR(err))
++                return err;
++
++        return err;
++}
++
++static BOOLEAN validate_sha256sum(const UINT8 *buf, UINTN size, UINT8 sum[32]) {
++        struct sha256_ctx ctx;
++        UINT8 hash[32];
++
++        sha256_init_ctx(&ctx);
++        sha256_process_bytes(buf, size, &ctx);
++        sha256_finish_ctx(&ctx, &hash);
++
++        return CompareMem(sum, hash, 32) == 0;
++}
++
++static BOOLEAN write_config(EFI_FILE_HANDLE root_dir, ABConfig *config) {
++        EFI_STATUS err;
++
++        err = hash_and_write_file(root_dir, L"\\loader\\main\\config", L"\\loader\\main\\config.sha256", sizeof(ABConfig), (UINT8 *) config);
++        if (EFI_ERROR(err)) {
++                Print(L"Couldn't write config_a!\n");
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                return FALSE;
++        }
++
++        err = hash_and_write_file(root_dir, L"\\loader\\backup\\config", L"\\loader\\backup\\config.sha256", sizeof(ABConfig), (UINT8 *) config);
++        if (EFI_ERROR(err)) {
++                Print(L"Couldn't write config_b!\n");
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                return FALSE;
++        }
++
++        return TRUE;
++}
++
++BOOLEAN get_ab_config(EFI_FILE_HANDLE root_dir, ABConfig *config) {
++        ABConfig config_a, config_b;
++        UINT8 sum_a[32], sum_b[32];
++        BOOLEAN a_valid, b_valid;
++        EFI_STATUS err_a, err_b;
++
++        err_a = read_file(root_dir, L"\\loader\\main\\config", sizeof(config_a), (UINT8 *) &config_a);
++        err_b = read_file(root_dir, L"\\loader\\backup\\config", sizeof(config_b), (UINT8 *) &config_b);
++
++        if (EFI_ERROR(err_a) && EFI_ERROR(err_b)) {
++                /* No readable boot slots detected. Quiet error. */
++                return FALSE;
++        }
++
++        err_a = read_file(root_dir, L"\\loader\\main\\config.sha256", sizeof(sum_a), (UINT8 *) &sum_a);
++        err_b = read_file(root_dir, L"\\loader\\backup\\config.sha256", sizeof(sum_b), (UINT8 *) &sum_b);
++
++        if (EFI_ERROR(err_a) && EFI_ERROR(err_b)) {
++                Print(L"Boot slots detected but no checksums present\n");
++                return FALSE;
++        }
++
++        a_valid = validate_sha256sum((UINT8 *) &config_a, sizeof(config_a), sum_a);
++        b_valid = validate_sha256sum((UINT8 *) &config_b, sizeof(config_b), sum_b);
++
++        if (!a_valid && !b_valid) {
++                Print(L"Boot slots detected but all checksums invalid\n");
++                uefi_call_wrapper(BS->Stall, 1, 3 * 1000 * 1000);
++                return FALSE;
++        }
++
++        // If both config slots are valid but are not equal, assume B was
++        // interrupted in the process of writing and recreate it from A.
++        if (a_valid && b_valid && CompareMem(&config_a, &config_b, sizeof(config_a)) != 0) {
++                b_valid = FALSE;
++        }
++
++        if (a_valid && !b_valid) {
++                Print(L"Recovering config B from config A\n");
++
++                CopyMem(&config_b, &config_a, sizeof(config_a));
++                CopyMem(&sum_b, &sum_a, sizeof(sum_a));
++
++                write_file(root_dir, L"\\loader\\backup\\config", sizeof(config_a), (UINT8 *) &config_b);
++                write_file(root_dir, L"\\loader\\backup\\config.sha256", sizeof(sum_b), (UINT8 *) &sum_b);
++
++                b_valid = TRUE;
++        }
++
++        if (b_valid && !a_valid) {
++                Print(L"Recovering config A from config B\n");
++
++                CopyMem(&config_a, &config_b, sizeof(config_b));
++                CopyMem(&sum_a, &sum_b, sizeof(sum_b));
++
++                write_file(root_dir, L"\\loader\\main\\config", sizeof(config_a), (UINT8 *) &config_a);
++                write_file(root_dir, L"\\loader\\main\\config.sha256", sizeof(sum_a), (UINT8 *) &sum_a);
++
++                a_valid = TRUE;
++        }
++
++        *config = config_a;
++        return TRUE;
++}
++
++BOOLEAN increment_boot_count(EFI_FILE_HANDLE root_dir, ABConfig *config) {
++        if (config->boot_count >= config->max_boot_count) {
++                Print(L"Boot count already at max, not incrementing!\n");
++                return FALSE;
++        }
++
++        config->boot_count++;
++
++        return write_config(root_dir, config);
++}
++
++BOOLEAN switch_active_slot(EFI_FILE_HANDLE root_dir, ABConfig *config) {
++        config->active_slot = !config->active_slot;
++        config->upgrade_pending = FALSE;
++        config->boot_count = 0;
++
++        return write_config(root_dir, config);
++}
+diff --git a/src/boot/efi/slot.h b/src/boot/efi/slot.h
+new file mode 100644
+index 0000000000..04f7b2d78f
+--- /dev/null
++++ b/src/boot/efi/slot.h
+@@ -0,0 +1,25 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++#pragma once
++
++#include <efi.h>
++
++#define SLOT_A 0
++
++typedef struct {
++        /* Metadata about the structure */
++        UINT8 version;              // 0x1
++        UINT8 upgrade_pending;      // Set to nonzero value by userspace if boot_efi has changed
++        UINT8 boot_count;           // Incremented by bootloader when booting if upgrade_pending
++        UINT8 max_boot_count;       // Maximum allowed unsuccessful boot count
++        UINT8 active_slot;          // Zero -- a; Nonzero -- b
++        UINT8 reserved;
++
++        /* Paths of the unified kernel images */
++        CHAR16 a_efi[256];          // L"\\EFI\\Linux\\linux_a.efi"
++        CHAR16 b_efi[256];          // L"\\EFI\\Linux\\linux_b.efi"
++} ABConfig;
++
++BOOLEAN get_ab_config(EFI_FILE_HANDLE root_dir, ABConfig *config);
++
++BOOLEAN increment_boot_count(EFI_FILE_HANDLE root_dir, ABConfig *config);
++BOOLEAN switch_active_slot(EFI_FILE_HANDLE root_dir, ABConfig *config);

--- a/meta-mender-core/recipes-core/systemd/systemd-boot_%.bbappend
+++ b/meta-mender-core/recipes-core/systemd/systemd-boot_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://systemd-boot-slotconfig.patch"


### PR DESCRIPTION
# add `systemd-boot` support

This PR replaces #1474, which contained our first draft based on `zeus`. We have rebased to `master` and verified that everything continues to work. In addition to almost all of the changes requested in the original PR, I tossed in a couple of `repo` manifests for cloning the repositories for testing purposes. Let me know what further issues need to be addressed.

The biggest outstanding issue is the question of `meta-intel` integration. Right now, I believe that dependency has been isolated to `mender-image-systemd-boot.bbclass`, and that could be replaced with a new implementation. Ideally, these (and other) implementations could co-exist behind an abstraction, at which point I feel compelled to ask whether this branch provides sufficient proof-of-concept to allow it to be merged as-is. After all, we do not want to eliminate `meta-intel` for our use case, and others might want to use this class to integrate with with it. 