### PR TITLE
mender-artifact: fix installation when cross-compiling

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
@@ -24,5 +24,13 @@ do_compile() {
 
 do_install() {
     install -d ${D}${bindir}
-    install ${B}/bin/mender-artifact -m 0755 ${D}${bindir}
+
+    # go cross-compilation builds are in different place than native ones.
+    if [ "${BUILD_ARCH}" = "${HOST_ARCH}" ]; then
+        BUILD_BIN_FOLDER=${B}/bin
+    else
+        BUILD_BIN_FOLDER=${B}/bin/${GOOS}_${GOARCH}
+    fi
+
+    install ${BUILD_BIN_FOLDER}/mender-artifact -m 0755 ${D}${bindir}
 }


### PR DESCRIPTION
Changelog: Fix installation when cross-compiling mender-artifact

Signed-off-by: Clément Péron <peron.clem@gmail.com>