### PR TITLE
MEN-5216: test_dbus.py: Extend tests to verify local proxy URL

### DIFF
--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -22,7 +22,10 @@ from multiprocessing import Process
 
 from mock_server import setup_mock_server
 
-from utils.common import cleanup_mender_state
+from utils.common import (
+    cleanup_mender_state,
+    version_is_minimum,
+)
 
 
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
@@ -101,6 +104,11 @@ class TestDBus:
                 time.sleep(5)
 
             assert f'string "{self.JWT_TOKEN}' in output
+            if version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
+                assert 'string "http://localhost:' in output
+            else:
+                assert 'string "https://docker.mender.io' in output
+
         finally:
             connection.run("systemctl stop mender-client")
             cleanup_mender_state(connection)
@@ -167,6 +175,10 @@ class TestDBus:
 
                 output = result.stdout.strip()
                 assert f'string "{self.JWT_TOKEN}' in output
+                if version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
+                    assert 'string "http://localhost:' in output
+                else:
+                    assert 'string "https://docker.mender.io' in output
 
             finally:
                 p.terminate()


### PR DESCRIPTION
In the context of MEN-5216, the D-Bus APIs shall return http://localhost
URL and not the Mender backend one.