### PR TITLE
MEN-5290: Acceptance tests for mender-connect

### DIFF
--- a/tests/acceptance/mocks/mock_dbus_server.py
+++ b/tests/acceptance/mocks/mock_dbus_server.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from gi.repository import GLib
+from pydbus import SystemBus
+from pydbus.generic import signal
+
+
+class IoMenderAuthenticationIface:
+    """
+<node>
+	<interface name="io.mender.Authentication1">
+		<method name="GetJwtToken">
+			<arg type="s" name="token" direction="out"/>
+			<arg type="s" name="server_url" direction="out"/>
+		</method>
+		<method name="FetchJwtToken">
+			<arg type="b" name="success" direction="out"/>
+		</method>
+        <signal name="JwtTokenStateChange">
+			<arg type="s" name="token"/>
+			<arg type="s" name="server_url"/>
+		</signal>
+		<method name="MockSetJwtToken">
+			<arg type="s" name="token" direction="in"/>
+			<arg type="s" name="server_url" direction="in"/>
+		</method>
+		<method name="MockSetJwtTokenAndEmitSignal">
+			<arg type="s" name="token" direction="in"/>
+			<arg type="s" name="server_url" direction="in"/>
+		</method>
+	</interface>
+</node>
+	"""
+
+    def __init__(self):
+        self.token = ""
+        self.server_url = ""
+
+    def GetJwtToken(self):
+        return self.token, self.server_url
+
+    def FetchJwtToken(self):
+        return True
+
+    JwtTokenStateChange = signal()
+
+    def MockSetJwtToken(self, token, server_url):
+        self.token = token
+        self.server_url = server_url
+        return True
+
+    def MockSetJwtTokenAndEmitSignal(self, token, server_url):
+        self.token = token
+        self.server_url = server_url
+        self.JwtTokenStateChange(self.token, self.server_url)
+        return True
+
+
+loop = GLib.MainLoop()
+bus = SystemBus()
+service = IoMenderAuthenticationIface()
+bus.publish("io.mender.AuthenticationManager", service)
+print("Mock for D-Bus interface io.mender.Authentication1 ready")
+loop.run()

--- a/tests/acceptance/mocks/mock_websocket_server.py
+++ b/tests/acceptance/mocks/mock_websocket_server.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import argparse
+
+import asyncio
+import websockets
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("port", type=int, help="port")
+
+args = parser.parse_args()
+
+server_host = "localhost"
+
+
+async def hello(websocket, path):
+    await websocket.recv()
+
+
+start_server = websockets.serve(hello, server_host, args.port)
+serverws = asyncio.get_event_loop().run_until_complete(start_server)
+
+port = serverws.server.sockets[0].getsockname()[1]
+server_url = f"http://{server_host}:{port}"
+
+print("Listening on %s" % server_url)
+asyncio.get_event_loop().run_forever()

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -57,7 +57,7 @@ class TestDBus:
 
             # Wait one state machine cycle for the D-Bus API to be available
             for _ in range(12):
-                result = connection.run("journalctl -u mender-client")
+                result = connection.run("journalctl --unit mender-client")
                 if (
                     "Authorize failed:" in result.stdout
                     or "Failed to authorize" in result.stdout

--- a/tests/acceptance/test_mender-connect.py
+++ b/tests/acceptance/test_mender-connect.py
@@ -1,0 +1,345 @@
+#!/usr/bin/python
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import time
+import os
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from utils.common import (
+    cleanup_mender_state,
+    put_no_sftp,
+)
+
+
+def put_mock_files(connection):
+    # TODO: These files could be installed as a yocto package, maybe extending mender-mock-server
+    mocks_dir = os.path.join(os.path.dirname(__file__), "mocks")
+    put_no_sftp(
+        os.path.join(mocks_dir, "mock_websocket_server.py"),
+        connection,
+        remote="/tmp/mock_websocket_server.py",
+    )
+    put_no_sftp(
+        os.path.join(mocks_dir, "mock_dbus_server.py"),
+        connection,
+        remote="/tmp/mock_dbus_server.py",
+    )
+
+
+class SshZombieProccess:
+    """Starts a remote process in the background and captures its PID"""
+
+    def __init__(self, connection, remote_command, unique_id) -> None:
+        self._conn = connection
+        self._pid_file = f"/tmp/{unique_id}.pid"
+        self._sh_file = f"/tmp/{unique_id}.sh"
+
+        wrapper = NamedTemporaryFile()
+        wrapper.write(
+            f"""
+{remote_command} >/dev/null 2>&1 &
+echo $! >{self._pid_file}
+""".encode()
+        )
+        wrapper.flush()
+
+        put_no_sftp(
+            wrapper.name, connection, remote=self._sh_file,
+        )
+        connection.run(f"bash {self._sh_file}")
+        result = connection.run(f"cat {self._pid_file}")
+
+        self._pid = int(result.stdout)
+
+    def _kill(self):
+        return self._conn.run(f"kill {self._pid}", warn=True)
+
+    def kill(self):
+        """Kills the zombie process, expect to exist"""
+        result = self._kill()
+        assert result.exited == 0
+
+    def terminate(self):
+        """Kills the zombie process, do not error if it was already killed"""
+        self._kill()
+        self._conn.run(f"rm -f {self._sh_file} {self._pid_file}")
+
+
+def start_mock_dbus_server(connection):
+    return SshZombieProccess(
+        connection, "python3 /tmp/mock_dbus_server.py", "mock_dbus_server"
+    )
+
+
+def wait_for_mock_dbus_server(connection):
+    start = time.time()
+    while time.time() < start + 60:
+        result = connection.run(
+            "dbus-send --print-reply --system "
+            "--dest=io.mender.AuthenticationManager "
+            "/io/mender/AuthenticationManager "
+            "io.mender.Authentication1.FetchJwtToken ",
+            warn=True,
+        )
+
+        if result.exited == 0 and "boolean true" in result.stdout:
+            # The interface is ready
+            break
+        elif (
+            "The name io.mender.AuthenticationManager was not provided by any .service files"
+            in result.stderr
+        ):
+            # The interface is not ready, sleep and retry
+            time.sleep(2)
+        else:
+            # Unexpected error, fail here
+            pytest.fail("Unknown error '%s'" % result.stderr)
+    else:
+        pytest.fail(
+            "Timed out waiting for io.mender.AuthenticationManager D-Bus interface"
+        )
+
+
+def start_mock_websockets_server(connection, port):
+    return SshZombieProccess(
+        connection,
+        f"python3 /tmp/mock_websocket_server.py {port}",
+        f"mock_websocket_server_{port}",
+    )
+
+
+def dbus_set_token_and_url(connection, token, server_url):
+    connection.run(
+        "dbus-send --print-reply --system "
+        "--dest=io.mender.AuthenticationManager "
+        "/io/mender/AuthenticationManager "
+        "io.mender.Authentication1.MockSetJwtToken "
+        f"string:'{token}' string:'{server_url}'"
+    )
+
+
+def dbus_set_token_and_url_and_emit_signal(connection, token, server_url):
+    connection.run(
+        "dbus-send --print-reply --system "
+        "--dest=io.mender.AuthenticationManager "
+        "/io/mender/AuthenticationManager "
+        "io.mender.Authentication1.MockSetJwtTokenAndEmitSignal "
+        f"string:'{token}' string:'{server_url}'"
+    )
+
+
+def wait_for_string_in_log(connection, since, timeout, search_string):
+    output = ""
+    while time.time() < since + timeout:
+        print("Searching for '%s' in mender-connect's journal:" % search_string)
+        output = connection.run(
+            "journalctl --unit mender-connect --since '%s'"
+            % time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(since)),
+        ).stdout
+        if search_string in output:
+            break
+        time.sleep(2)
+    else:
+        pytest.fail("Timed out waiting for '%s'" % search_string)
+
+    return output
+
+
+@pytest.mark.usefixtures("setup_board", "bitbake_path")
+@pytest.mark.not_for_machine("vexpress-qemu-flash")
+class TestMenderConnect:
+    @pytest.mark.min_mender_version("2.5.0")
+    def test_mender_connect_auth_changes(
+        self, connection,
+    ):
+        """Test that mender-connect can re-establish the connection on D-Bus signals"""
+
+        try:
+            proc_server_dbus = None
+            proc_server_ws_one = None
+            proc_server_ws_two = None
+
+            # start the mocks
+            put_mock_files(connection)
+            proc_server_dbus = start_mock_dbus_server(connection)
+            proc_server_ws_one = start_mock_websockets_server(connection, 5000)
+            proc_server_ws_two = start_mock_websockets_server(connection, 6000)
+
+            wait_for_mock_dbus_server(connection)
+            dbus_set_token_and_url(connection, "token1", "http://localhost:5000")
+
+            # start the mender-connect service
+            startup_time = time.time()
+            connection.run(
+                "systemctl --job-mode=ignore-dependencies start mender-connect"
+            )
+
+            # wait for first connect
+            _ = wait_for_string_in_log(
+                connection,
+                startup_time,
+                30,
+                "Connection established with http://localhost:5000",
+            )
+
+            # 1. Change token
+            signal_time = time.time()
+            dbus_set_token_and_url_and_emit_signal(
+                connection, "token2", "http://localhost:5000"
+            )
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                30,
+                "Connection established with http://localhost:5000",
+            )
+
+            # 2. Change url
+            signal_time = time.time()
+            dbus_set_token_and_url_and_emit_signal(
+                connection, "token2", "http://localhost:6000"
+            )
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                30,
+                "Connection established with http://localhost:6000",
+            )
+
+            # 3. Change token and url
+            signal_time = time.time()
+            dbus_set_token_and_url_and_emit_signal(
+                connection, "token3", "http://localhost:5000"
+            )
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                30,
+                "Connection established with http://localhost:5000",
+            )
+
+            # 4. Unauthorize and re-authorize
+            signal_time = time.time()
+            dbus_set_token_and_url_and_emit_signal(connection, "", "")
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                30,
+                "dbusEventLoop terminated 0 sessions, 0 shells",
+            )
+            dbus_set_token_and_url_and_emit_signal(
+                connection, "token4", "http://localhost:6000"
+            )
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                30,
+                "Connection established with http://localhost:6000",
+            )
+
+        finally:
+            connection.run(
+                "systemctl --job-mode=ignore-dependencies stop mender-connect || true"
+            )
+            connection.run("cat /tmp/*.log || true")
+            if proc_server_dbus is not None:
+                proc_server_dbus.terminate()
+            if proc_server_ws_one is not None:
+                proc_server_ws_one.terminate()
+            if proc_server_ws_two is not None:
+                proc_server_ws_two.terminate()
+            cleanup_mender_state(connection)
+
+    @pytest.mark.min_mender_version("2.5.0")
+    def test_mender_connect_reconnect(
+        self, connection,
+    ):
+        """Test that mender-connect can re-establish the connection on remote errors"""
+
+        try:
+            proc_server_dbus = None
+            proc_server_ws_one = None
+            proc_server_ws_two = None
+
+            # start the mocks
+            put_mock_files(connection)
+            proc_server_dbus = start_mock_dbus_server(connection)
+            proc_server_ws_one = start_mock_websockets_server(connection, 5000)
+            proc_server_ws_two = start_mock_websockets_server(connection, 6000)
+
+            wait_for_mock_dbus_server(connection)
+            dbus_set_token_and_url(connection, "badtoken", "http://localhost:12345")
+
+            # start the mender-connect service
+            startup_time = time.time()
+            connection.run(
+                "systemctl --job-mode=ignore-dependencies start mender-connect"
+            )
+
+            # wait for error
+            _ = wait_for_string_in_log(
+                connection,
+                startup_time,
+                300,
+                "eventLoop: error reconnecting: failed to connect after max number of retries",
+            )
+
+            # Set correct parameters
+            signal_time = time.time()
+            dbus_set_token_and_url_and_emit_signal(
+                connection, "goodtoken", "http://localhost:5000"
+            )
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                300,
+                "Connection established with http://localhost:5000",
+            )
+
+            dbus_set_token_and_url(connection, "", "")
+            kill_time = time.time()
+            # kill the server and wait for error
+            proc_server_ws_one.kill()
+            _ = wait_for_string_in_log(
+                connection, kill_time, 300, "error reconnecting:",
+            )
+
+            # Signal the other server
+            signal_time = time.time()
+            dbus_set_token_and_url_and_emit_signal(
+                connection, "goodtoken", "http://localhost:6000"
+            )
+            _ = wait_for_string_in_log(
+                connection,
+                signal_time,
+                300,
+                "Connection established with http://localhost:6000",
+            )
+
+        finally:
+            connection.run(
+                "systemctl --job-mode=ignore-dependencies stop mender-connect || true"
+            )
+            if proc_server_dbus is not None:
+                proc_server_dbus.terminate()
+            if proc_server_ws_one is not None:
+                proc_server_ws_one.terminate()
+            if proc_server_ws_two is not None:
+                proc_server_ws_two.terminate()
+            connection.run("cat /tmp/*.log || true")
+            connection.run("rm -f /tmp/*.log /tmp/*.py")
+            cleanup_mender_state(connection)

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -490,8 +490,8 @@ class TestUpdateControl:
                 ), "Looks like the client did not pause!"
 
         except:
-            connection.run("journalctl -u mender-client | cat")
-            connection.run("journalctl -u mender-mock-server | cat")
+            connection.run("journalctl --unit mender-client | cat")
+            connection.run("journalctl --unit mender-mock-server | cat")
             raise
 
         finally:
@@ -611,8 +611,8 @@ class TestUpdateControl:
             assert "ArtifactFailure" not in log
 
         except:
-            connection.run("journalctl -u mender-client | cat")
-            connection.run("journalctl -u mender-mock-server | cat")
+            connection.run("journalctl --unit mender-client | cat")
+            connection.run("journalctl --unit mender-mock-server | cat")
             raise
 
         finally:
@@ -678,7 +678,7 @@ done
             # more than would cause a failure.
             while time.time() < timeout:
                 output = connection.run(
-                    "journalctl -u mender-client -S '%s' | grep 'State transition: mender-update-control '"
+                    "journalctl --unit mender-client --since '%s' | grep 'State transition: mender-update-control '"
                     % time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(now)),
                     warn=True,
                 ).stdout
@@ -708,8 +708,8 @@ done
             assert "ArtifactFailure" not in log
 
         except:
-            connection.run("journalctl -u mender-client | cat")
-            connection.run("journalctl -u mender-mock-server | cat")
+            connection.run("journalctl --unit mender-client | cat")
+            connection.run("journalctl --unit mender-mock-server | cat")
             raise
 
         finally:

--- a/tests/build-conf/beagleboneblack/bblayers.conf
+++ b/tests/build-conf/beagleboneblack/bblayers.conf
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   "

--- a/tests/build-conf/qemux86-64-bios-grub-gpt/bblayers.conf
+++ b/tests/build-conf/qemux86-64-bios-grub-gpt/bblayers.conf
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-mender/meta-mender-qemu"

--- a/tests/build-conf/qemux86-64-bios-grub/bblayers.conf
+++ b/tests/build-conf/qemux86-64-bios-grub/bblayers.conf
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-mender/meta-mender-qemu"

--- a/tests/build-conf/qemux86-64-uefi-grub/bblayers.conf
+++ b/tests/build-conf/qemux86-64-uefi-grub/bblayers.conf
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-mender/meta-mender-qemu"

--- a/tests/build-conf/raspberrypi3/bblayers.conf
+++ b/tests/build-conf/raspberrypi3/bblayers.conf
@@ -15,6 +15,7 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-raspberrypi-demo \
   @WORKSPACE@/meta-raspberrypi \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-openembedded/meta-multimedia \
   @WORKSPACE@/meta-openembedded/meta-networking \
   @WORKSPACE@/meta-openembedded/meta-python \

--- a/tests/build-conf/raspberrypi4/bblayers.conf
+++ b/tests/build-conf/raspberrypi4/bblayers.conf
@@ -15,6 +15,7 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-raspberrypi-demo \
   @WORKSPACE@/meta-raspberrypi \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-openembedded/meta-multimedia \
   @WORKSPACE@/meta-openembedded/meta-networking \
   @WORKSPACE@/meta-openembedded/meta-python \

--- a/tests/build-conf/vexpress-qemu-flash/bblayers.conf
+++ b/tests/build-conf/vexpress-qemu-flash/bblayers.conf
@@ -12,5 +12,6 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-mender/meta-mender-qemu \
   "

--- a/tests/build-conf/vexpress-qemu-uboot-uefi-grub/bblayers.conf
+++ b/tests/build-conf/vexpress-qemu-uboot-uefi-grub/bblayers.conf
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-mender/meta-mender-qemu"

--- a/tests/build-conf/vexpress-qemu/bblayers.conf
+++ b/tests/build-conf/vexpress-qemu/bblayers.conf
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \
+  @WORKSPACE@/meta-openembedded/meta-python \
   @WORKSPACE@/meta-mender/meta-mender-qemu"

--- a/tests/meta-mender-ci/conf/layer.conf
+++ b/tests/meta-mender-ci/conf/layer.conf
@@ -11,12 +11,24 @@ BBFILE_PRIORITY_meta-mender-ci = "10"
 
 LAYERSERIES_COMPAT_meta-mender-ci = "dunfell"
 
+# We need a bit more than the demo layer to fit test dependencies
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "658"
+
 IMAGE_FEATURES_append = " read-only-rootfs"
-IMAGE_INSTALL_append = " lsb-test ${MENDER_MOCK_SERVER} logger-update-module"
+IMAGE_INSTALL_append = "\
+    lsb-test \
+    ${MENDER_MOCK_SERVER} \
+    logger-update-module \
+    ${DBUS_WEBSOCKETS_TEST} \
+"
 
 MENDER_MOCK_SERVER = "mender-mock-server"
 # There isn't enough space to install this on vexpress-qemu-flash.
 MENDER_MOCK_SERVER_vexpress-qemu-flash = ""
+
+DBUS_WEBSOCKETS_TEST = "python3-websockets python3-pydbus"
+# There isn't enough space to install this on vexpress-qemu-flash.
+DBUS_WEBSOCKETS_TEST_vexpress-qemu-flash = ""
 
 LAYERDEPENDS_meta-mender-ci_append = " mender"
 

--- a/tests/meta-mender-ci/recipes-devtools/python/python3-websockets_%.bbappend
+++ b/tests/meta-mender-ci/recipes-devtools/python/python3-websockets_%.bbappend
@@ -1,0 +1,19 @@
+# python3-asyncio depends on python3-threading. Error trace follows:
+#   File "/usr/lib/python3.8/asyncio/base_events.py", line 780, in run_in_executor
+#     executor = concurrent.futures.ThreadPoolExecutor()
+#   File "/usr/lib/python3.8/concurrent/futures/__init__.py", line 49, in __getattr__
+#     from .thread import ThreadPoolExecutor as te
+#   File "/usr/lib/python3.8/concurrent/futures/thread.py", line 11, in <module>
+#     import queue
+# ModuleNotFoundError: No module named 'queue'
+#
+# However seems to be missing at:
+# https://github.com/lgirdk/poky/blob/dunfell/meta/recipes-devtools/python/python3/python3-manifest.json#L117
+#
+# Fix it here for our tests with a .bbappend
+#
+
+RDEPENDS_${PN} = "\
+    ${PYTHON_PN}-asyncio \
+    ${PYTHON_PN}-threading \
+"


### PR DESCRIPTION
So that we can verify re-connection cases.

Two simple mocks have been developed:
* mock_dbus_server.py to mock D-Bus API and have a way from the test to
  set the parameters and/or trigger the signal
* mock_websocket_server.py just accepts any websocket connection

meta-mender-ci has been updated to install the dependencies and increase
the image size.