### PR TITLE
fix: Mender-connect RDEPENDS set dynamically for release branches

### DIFF
--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -1,5 +1,15 @@
 require mender-connect.inc
 
+RDEPENDS_${PN} = "glib-2.0 mender-client (>= ${@mender_client_minimum_required_version(d)})"
+
+def mender_client_minimum_required_version(d):
+    version = mender_connect_branch_from_preferred_version(d)
+    if version.endswith("x"):
+        major, minor, *_ = version.split(".")
+        if int(major) == 1 and int(minor) <= 2:
+            return "2.5"
+    return "3.2"
+
 # The revision listed below is not really important, it's just a way to avoid
 # network probing during parsing if we are not gonna build the git version
 # anyway. If git version is enabled, the AUTOREV will be chosen instead of the


### PR DESCRIPTION
Through adding the RDEPENDS (>= 3.2) for the mender-client in mender-connect,
older release branches cannot build using the git-recipe.

This fix is simply adding a function for selecting the minimal required version
for release branches in git recipes through returning:

2.5 when version <= 1.2.x
3.2 otherwise

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


