### PR TITLE
prevent pseudo inode mismatch w/ efi-secure-boot

### DIFF
--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -275,7 +275,7 @@ mender_merge_bootfs_and_image_boot_files() {
     W="${WORKDIR}/bootfs.${BB_CURRENTTASK}"
     rm -rf "$W"
 
-    cp -al "${IMAGE_ROOTFS}/${MENDER_BOOT_PART_MOUNT_LOCATION}" "$W"
+    cp -a "${IMAGE_ROOTFS}/${MENDER_BOOT_PART_MOUNT_LOCATION}" "$W"
 
     # Put in variable to avoid expansion and ';' being parsed by shell.
     image_boot_files="${IMAGE_BOOT_FILES}"
@@ -307,7 +307,7 @@ mender_merge_bootfs_and_image_boot_files() {
                 fi
             else
                 # create a hardlink if possible (prerequisite: the paths are below the same mount point), do a normal copy otherwise
-                cp -l "$file" "$destfile" || cp "$file" "$destfile"
+                cp "$file" "$destfile"
             fi
         done
     done


### PR DESCRIPTION
I get pseudo/abort inode mismatch errors on `LockDown.efi` when doing
back-to-back builds. The first build works fine. Building again (without cleaning and without changes)
fails.

I'm using the latest versions of dunfell.

`pseudo.log`:
```
path mismatch [2 links]: ino 1313785
db '/production-image/1.0-r0/rootfs/boot/efi/EFI/BOOT/LockDown.efi'
req '/production-image/1.0-r0/bootfs.image_uefiimg/EFI/BOOT/LockDown.efi'. 
```

Adding `PSEUDO_DSIABLE=1` to the rm/cleanup in
mender_merge_bootfs_and_image_boot_files resolves this issue, but I'm not 100% sure if this is the real fix
or just patching the symptoms.

I've looked [meta-efi-secure-boot](https://github.com/jiazhang0/meta-secure-core/tree/master/meta-efi-secure-boot/recipes-bsp/efitools) and don't see anything wrong/weird with `LockDown.efi`

----
What do y'all think?