### PR TITLE
[dunfell] tests: Adapt to new polling policy for Update Control Maps in the client.

### DIFF
--- a/tests/acceptance/mock_server.py
+++ b/tests/acceptance/mock_server.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -24,8 +24,11 @@ import json
 EXPIRATION_TIME = 90
 BOOT_EXPIRATION_TIME = 45
 
+# Note that while waiting for a Control Map update from the server,
+# `UpdatePollIntervalSeconds` is used if it is shorter, so set it to the same
+# value.
 MENDER_CONF = """{
-    "UpdatePollIntervalSeconds": 1,
+    "UpdatePollIntervalSeconds": %d,
     "InventoryPollIntervalSeconds": 5,
     "RetryPollIntervalSeconds": 1,
     "UpdateControlMapExpirationTimeSeconds": %d,
@@ -36,6 +39,7 @@ MENDER_CONF = """{
     }
 }
 """ % (
+    EXPIRATION_TIME,
     EXPIRATION_TIME,
     BOOT_EXPIRATION_TIME,
 )

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -424,6 +424,8 @@ class TestUpdateControl:
                 connection, bitbake_variables["MENDER_DEVICE_TYPE"]
             )
 
+            connection.run("mender check-update")
+
             log = []
             pause_state_observed = 0
             continue_map_inserted = False
@@ -462,6 +464,7 @@ class TestUpdateControl:
                         make_and_deploy_artifact(
                             connection, bitbake_variables["MENDER_DEVICE_TYPE"]
                         )
+                        connection.run("mender check-update")
                         second_deployment_done = True
                     else:
                         break
@@ -590,6 +593,7 @@ class TestUpdateControl:
                 deployment_id=MUID,
                 update_control_map=case["pause_map"],
             )
+            connection.run("mender check-update")
             wait_for_state(connection, case["pause_state"])
             set_update_control_map(connection, case["continue_map"])
             log = wait_for_state(connection, "Cleanup")
@@ -607,6 +611,7 @@ class TestUpdateControl:
                 deployment_id=MUID2,
                 update_control_map=None,
             )
+            connection.run("mender check-update")
             log = wait_for_state(connection, "Cleanup")
             assert "ArtifactFailure" not in log
 
@@ -672,6 +677,8 @@ done
             make_and_deploy_artifact(
                 connection, bitbake_variables["MENDER_DEVICE_TYPE"]
             )
+
+            connection.run("mender check-update")
 
             timeout = now + 300
             # Wait until we have received 100 state transitions, which is way


### PR DESCRIPTION
The client now uses the shortest interval among
`UpdatePollIntervalSeconds` and
`UpdateControlMapExpirationTimeSeconds` when deciding how long to wait
before re-querying the server for an Update Control Map. So we can no
longer use a quick update check time together with a slow Update
Control Map time. Instead, use the same time for both, and use the
`check-update` flag to force a quick update check at the points where
we deploy.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit dccf39a1085111a7599f9941ffa34c9d663bf244)
