### PR TITLE
Fix incorrect checksum detection on version branches.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -35,6 +35,8 @@ MENDER_ARTIFACT_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
 def mender_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None:
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -40,6 +40,8 @@ MENDER_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
 def mender_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None:
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
@@ -33,6 +33,8 @@ MENDER_CONFIGURE_BRANCH = "${@mender_configure_branch_from_preferred_version(d)}
 
 def mender_configure_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None:
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -43,6 +43,8 @@ MENDER_CONNECT_BRANCH = "${@mender_connect_branch_from_preferred_version(d)}"
 
 def mender_connect_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None:
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.
@@ -68,7 +70,7 @@ def mender_connect_license(branch):
     return {
                "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
     }
-LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=fbe9cd162201401ffbb442445efecfdc"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87"
 LICENSE = "${@mender_connect_license(d.getVar('MENDER_CONNECT_BRANCH'))['license']}"
 
 # Downprioritize this recipe in version selections.


### PR DESCRIPTION
When using `PREFERRED_VERSION_mender-client` instead of
`PREFERRED_VERSION_pn-mender-client`, the recipe doesn't correctly
pick up the branch name, causing checksum verification to fail. The
former is what is documented in the Yocto manual, so let's make sure
we support that.

Changelog: none

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
