### PR TITLE
mender-client: clone the repo using the tag set in PV variable

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -1,6 +1,8 @@
 DESCRIPTION = "Mender tool for doing OTA software updates."
 HOMEPAGE = "https://mender.io"
 
+SRCREV = "${PV}"
+
 BBCLASSEXTEND = "native"
 RDEPENDS_${PN}_class-native = ""
 DEPENDS_class-native = ""

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_3.1.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_3.1.0.bb
@@ -4,14 +4,10 @@ require mender-client.inc
 #-------------------------------------------------------------------------------
 # THINGS TO CONSIDER FOR EACH RELEASE:
 # - SRC_URI (particularly "branch")
-# - SRCREV
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
 SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=3.1.x"
-
-# Tag: 3.1.0
-SRCREV = "4c077c92f313aac92bf3bb492ef479b3447ddc08"
 
 # Enable this in Betas, and in branches that cannot carry this major version as
 # default.


### PR DESCRIPTION
Hi @lluiscampos,

I would like to know why you don't use directly the ${PV} to set the SRCREV.

Is it a bad practice? IMO this avoid a bad manipulation the SHA1 

