### PR TITLE
meta-mender-demo: mender-monitor bbappend conditional to the version

### DIFF
--- a/meta-mender-demo/mender-commercial/mender-monitor/mender-monitor_%.bbappend
+++ b/meta-mender-demo/mender-commercial/mender-monitor/mender-monitor_%.bbappend
@@ -1,8 +1,12 @@
 
-
 do_install_append() {
-    oe_runmake \
-        -C ${S} \
-        DESTDIR=${D} \
-        install-example-monitors
+    if echo ${PV} | egrep '^1.0.'; then
+        # Nothing to append on 1.0.x recipes
+        true
+    else
+        oe_runmake \
+            -C ${S} \
+            DESTDIR=${D} \
+            install-example-monitors
+    fi
 }


### PR DESCRIPTION
The examples only exist from mender-monitor 1.1.x onwards, so we need
some special handling for older versions in the bbappend.