### PR TITLE
Break the link to u-boot for AARCH64

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -270,7 +270,6 @@ _MENDER_PART_IMAGE_DEPENDS += "${@bb.utils.contains('MENDER_DATA_PART_FSTYPE', '
 # This assumes that U-boot is used on ARM, this could become problematic
 # if we add support for other bootloaders on ARM, e.g Barebox.
 _MENDER_PART_IMAGE_DEPENDS_append_mender-grub_arm =     " u-boot:do_deploy"
-_MENDER_PART_IMAGE_DEPENDS_append_mender-grub_aarch64 = " u-boot:do_deploy"
 
 _MENDER_PART_IMAGE_DEPENDS_append_mender-uboot = " u-boot:do_deploy"
 _MENDER_PART_IMAGE_DEPENDS_append_mender-grub_mender-bios = " grub:do_deploy"

--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -8,7 +8,7 @@ IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-gpt', ' 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_x86 =     " kernel-image"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_x86-64 =  " kernel-image"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_arm =     " kernel-image kernel-devicetree"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_aarch64 = " kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS_append_mender-image_aarch64 = " kernel-image"
 
 python() {
     features = d.getVar('MENDER_FEATURES').split()

--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
@@ -28,8 +28,6 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
-require version_logic.inc
-
 PROVIDES = "grub-efi grub-editenv"
 RPROVIDES_${PN} = "grub-efi grub-editenv"
 

--- a/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
+++ b/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
@@ -2,7 +2,6 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI_append_cfg_file += " file://cfg"
 
-require version_logic.inc
 
 do_check_config_efi_stub() {
 }


### PR DESCRIPTION
# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

The linking for u-boot for AARCH64 doesn't work, therefore remove it.
Remove unnecessary inclusion of `version_logic.inc`
