### PR TITLE
master: bugfix releases Mender 3.1.1, Mender 3.0.2 and Mender 2.6.4

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_1.0.1.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_1.0.1.bb
@@ -1,0 +1,6 @@
+require mender-monitor.inc
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.0.3.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.0.3.bb
@@ -1,0 +1,30 @@
+require mender-connect.inc
+
+RDEPENDS_${PN} = "glib-2.0 mender-client (>= 2.5)"
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=1.0.x"
+
+# Tag: 1.0.3
+SRCREV = "0afe7b7e419b041d7c009a000e4051d1f8d2d6db"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LIC_FILES_CHKSUM.sha256;md5=4aa566b2374f3be53deec0f817972b86"

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.2.1.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_1.2.1.bb
@@ -1,0 +1,30 @@
+require mender-connect.inc
+
+RDEPENDS_${PN} = "glib-2.0 mender-client (>= 2.5)"
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=1.2.x"
+
+# Tag: 1.2.1
+SRCREV = "fbe91be3b2c3abc9f42b6f159ebcf19e54508219"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = "file://src/github.com/mendersoftware/mender-connect/LIC_FILES_CHKSUM.sha256;md5=dd3da225d534811819029628549b934d"


### PR DESCRIPTION
Cherry-pick the relevant recipes from bugfix releases Mender 3.1.1, Mender 3.0.2 and Mender 2.6.4