### PR TITLE
MEN-5300: add a recipe for mender-gateway

### DIFF
--- a/meta-mender-commercial/classes/mender-closed-source-utils.bbclass
+++ b/meta-mender-commercial/classes/mender-closed-source-utils.bbclass
@@ -1,0 +1,55 @@
+
+def mender_closed_source_srcrev_from_src_uri(d, src_uri, repo_name):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None or pref_version == "":
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if pref_version and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, SRCREV won't be used for defining PV
+        return ""
+    else:
+        # Extract SRCREV from the tarball filename
+        import glob
+        import re
+        # Remove "file://" prefix
+        src_uri_list = src_uri.split()
+        if len(src_uri_list) == 0:
+            # No source specified. We won't be building this component.
+            return ""
+        src_uri_glob = src_uri_list[0][len("file://"):]
+        # Get the filename
+        filenames = glob.glob(src_uri_glob)
+        if len(filenames) == 0:
+            bb.error("Failed to find %s in path %s" % (src_uri_glob, repo_name))
+            bb.error("Please make sure SRC_URI_pn-%s is pointing to the downloaded tarball " % repo_name)
+        elif len(filenames) != 1:
+            bb.error("Expected exactly one file, found: %s" % filenames)
+        filename = os.path.basename(filenames[0])
+        # Now extract the version from the filename
+        m = re.match(repo_name + r"-master\.tar\.(?:xz|gz)", filename)
+        if m:
+            # Building from external tarball, do not append git info
+            return ""
+        m = re.match(repo_name + r"-([0-9]+\.[0-9]+\.[0-9]+(?:-build[0-9]+)?)\.tar\.(?:xz|gz)", filename)
+        if m:
+            # The tarball is a tagged version, in which case SRCREV is not to
+            # be used but still needs to parse
+            return ""
+        m = re.match(repo_name + r"-([0-9a-f]{7,})\.tar\.(?:xz|gz)", filename)
+        if m:
+            # Building from internal tarball, append git info
+            return "-git+" + m.group(1)
+        # At this point the version is unknown.
+        bb.fatal("Unknown version. Failed to parse %s" % filename)
+
+def mender_closed_source_pv_from_preferred_version(d, srcrev):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None or pref_version == "":
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if pref_version is not None and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, use the version as is. This means that
+        # we can build tags with "-build" in them from this recipe, but not
+        # final tags, which will need their own recipe.
+        return pref_version
+    else:
+        # Else return "master${SRCREV}".
+        return "master%s" % srcrev

--- a/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb
+++ b/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb
@@ -1,0 +1,3 @@
+require recipes-extended/images/core-image-full-cmdline.bb
+
+IMAGE_INSTALL_append = " mender-gateway"

--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
@@ -1,0 +1,49 @@
+LICENSE = "CLOSED"
+LICENSE_FLAGS = "commercial"
+
+inherit systemd
+
+SUB_FOLDER_arm = "arm"
+SUB_FOLDER_aarch64 = "aarch64"
+SUB_FOLDER_x86-64 = "x86_64"
+
+COMPATIBLE_HOSTS = "arm|aarch64|x86_64"
+
+FILES_${PN} = " \
+    ${bindir}/mender-gateway \
+"
+
+FILES_${PN}_append_mender-systemd = " \
+    ${systemd_system_unitdir}/mender-gateway.service \
+"
+
+S = "${WORKDIR}/mender-gateway-${PV}"
+
+do_version_check() {
+    if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
+        if ! strings ${WORKDIR}/${SUB_FOLDER}/mender-gateway | fgrep -q "${PN} ${PV}"; then
+            bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/${SUB_FOLDER}/mender-gateway | grep '${PN} [a-f0-9]')"
+        fi
+    fi
+}
+addtask do_version_check after do_unpack before do_install
+
+SYSTEMD_SERVICE_${PN}_mender-systemd = "mender-gateway.service"
+
+do_install() {
+    install -d -m 755 ${D}${bindir}
+    install -m 755 ${S}/${SUB_FOLDER}/mender-gateway ${D}${bindir}/mender-gateway
+
+    # install config file if provided
+    if [ -f ${WORKDIR}/mender-gateway.conf ]; then
+        install -d -m 755 ${D}/${sysconfdir}/mender
+        install -m 0600 ${WORKDIR}/mender-gateway.conf ${D}/${sysconfdir}/mender/mender-gateway.conf
+    else
+        bbwarn "No mender-gateway.conf found in SRC_URI, no mender-gateway.conf installed. The gateway will run with the default parameters"
+    fi
+}
+
+do_install_append_mender-systemd() {
+    install -d -m 755 ${D}${systemd_unitdir}/system/
+    install -m 644 ${S}/support/mender-gateway.service ${D}${systemd_unitdir}/system/mender-gateway.service
+}

--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_git.bb
@@ -1,0 +1,19 @@
+require mender-gateway.inc
+
+inherit mender-closed-source-utils
+
+SRCREV = "${@mender_closed_source_srcrev_from_src_uri(d, '${SRC_URI}', 'mender-gateway')}"
+
+PV = "${@mender_closed_source_pv_from_preferred_version(d, '${SRCREV}')}"
+
+def tarball_directory_from_pv(d, pv):
+    return pv.split("master-git+")[-1]
+
+# Define S to work both on git sha and "master" tarballs
+S = "${WORKDIR}/mender-gateway-${@tarball_directory_from_pv(d, '${PV}')}"
+
+# Skip version check
+MENDER_DEVMODE = "true"
+
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor_git.bb
@@ -1,61 +1,10 @@
 require mender-monitor.inc
 
-# This is the developent recipe for which the recipe version gets defined from the archive name.
+inherit mender-closed-source-utils
 
-def mender_monitor_srcrev_from_src_uri(d, src_uri):
-    pref_version = d.getVar("PREFERRED_VERSION")
-    if pref_version is not None and pref_version.find("-build") >= 0:
-        # If "-build" is in the version, SRCREV won't be used for defining PV
-        return ""
-    else:
-        # Extract SRCREV from the tarball filename
-        import glob
-        import re
-        # Remove "file://" prefix
-        src_uri_list = src_uri.split()
-        if len(src_uri_list) == 0:
-            # No source specified. We won't be building this component.
-            return ""
-        src_uri_glob = src_uri_list[0][len("file://"):]
-        # Get the filename
-        filenames = glob.glob(src_uri_glob)
-        if len(filenames) == 0:
-            bb.error("Failed to find mender monitor on path %s" % src_uri_glob)
-            bb.error("Please make sure SRC_URI_pn-mender-monitor is pointing to the downloaded tarball ")
-        elif len(filenames) != 1:
-            bb.error("Expected exactly one file, found: %s" % filenames)
-        filename = os.path.basename(filenames[0])
-        # Now extract the version from the filename
-        if filename == "mender-monitor-master.tar.gz":
-            # Building from external tarball, do not append git info
-            return ""
-        m = re.match(r"mender-monitor-([0-9]+\.[0-9]+\.[0-9]+(?:-build[0-9]+)?)\.tar\.gz", filename)
-        if m is not None:
-            # The tarball is a tagged version, in which case SRCREV is not to
-            # be used but still needs to parse
-            return ""
-        m = re.match(r"mender-monitor-([0-9a-f]{7,})\.tar\.gz", filename)
-        if m is not None:
-            # Building from internal tarball, append git info
-            return "-git+" + m.group(1)
-        # At this point the version is unknown.
-        bb.fatal("Unknown version. Failed to parse %s" % filename)
-        return ""
+SRCREV = "${@mender_closed_source_srcrev_from_src_uri(d, '${SRC_URI}', 'mender-monitor')}"
 
-SRCREV = "${@mender_monitor_srcrev_from_src_uri(d, '${SRC_URI}')}"
-
-def mender_monitor_version_from_preferred_version(d, srcrev):
-    pref_version = d.getVar("PREFERRED_VERSION")
-    if pref_version is not None and pref_version.find("-build") >= 0:
-        # If "-build" is in the version, use the version as is. This means that
-        # we can build tags with "-build" in them from this recipe, but not
-        # final tags, which will need their own recipe.
-        return pref_version
-    else:
-        # Else return "master${SRCREV}".
-        return "master%s" % srcrev
-
-PV = "${@mender_monitor_version_from_preferred_version(d, '${SRCREV}')}"
+PV = "${@mender_closed_source_pv_from_preferred_version(d, '${SRCREV}')}"
 
 # Skip version check
 MENDER_DEVMODE = "true"

--- a/tests/acceptance/commercial/test_mender_gateway.py
+++ b/tests/acceptance/commercial/test_mender_gateway.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# Copyright 2022 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import subprocess
+
+import pytest
+
+from utils.common import (
+    build_image,
+    latest_build_artifact,
+)
+
+
+@pytest.mark.commercial
+@pytest.mark.min_mender_version("3.3.0")
+class TestMenderGateway:
+    @pytest.mark.only_with_image("ext4")
+    def test_build_mender_gateway(
+        self, request, bitbake_variables, prepared_test_build, bitbake_image
+    ):
+        build_image(
+            prepared_test_build["build_dir"],
+            prepared_test_build["bitbake_corebase"],
+            bitbake_image,
+            ['IMAGE_INSTALL_append = " mender-gateway"'],
+            [
+                'BBLAYERS_append = " %s/../meta-mender-commercial"'
+                % bitbake_variables["LAYERDIR_MENDER"]
+            ],
+        )
+        image = latest_build_artifact(
+            request, prepared_test_build["build_dir"], "core-image*.ext4"
+        )
+
+        output = subprocess.check_output(
+            ["debugfs", "-R", "stat /usr/bin/mender-gateway", image]
+        ).decode()
+        assert "Type: regular" in output

--- a/tests/meta-mender-ci/conf/layer.conf
+++ b/tests/meta-mender-ci/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_PRIORITY_meta-mender-ci = "10"
 LAYERSERIES_COMPAT_meta-mender-ci = "dunfell"
 
 # We need a bit more than the demo layer to fit test dependencies
-MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "658"
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "708"
 
 IMAGE_FEATURES_append = " read-only-rootfs"
 IMAGE_INSTALL_append = "\


### PR DESCRIPTION
Adds a closed source Yocto recipe for mender-gateway. Only the git
recipe is included in this commit. The recipe takes a tarball containing
the pre-compiled binaries and support files and just installs them on
the target.

A piece of code from mender-monitor has been refactored into a common
class for reuse in all closed source recipes that define SRCREV from the
tarball filename.

Acceptance test added accordingly.

Changelog: Add recipe for mender-gateway_git
Changelog: Add testing image mender-gateway-image-full-cmdline