### PR TITLE
mender-qemu support for mender-gateway requirements

### DIFF
--- a/meta-mender-qemu/docker/qemux86-64/Dockerfile
+++ b/meta-mender-qemu/docker/qemux86-64/Dockerfile
@@ -17,6 +17,9 @@
 #       Use SERVER_URL as server address for client.
 # -e TENANT_TOKEN=<token>
 #       Use token as tenant token for client.
+# -e MENDER_GATEWAY_CONFFILE=<conffile>
+#       Copy the configuration file for mender-gateway
+#       Note that the file needs to be mounted into the Docker container
 
 FROM alpine:3.15.0
 

--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -34,9 +34,10 @@ if [ ! -e /mender-setup-complete ]; then
     ./setup-mender-configuration.py --img="$DISK_IMG" \
                                     --server-url=$SERVER_URL \
                                     --tenant-token=$TENANT_TOKEN $CONFIG_ARGS \
-                                    --docker-ip="$DOCKER_IP"
+                                    --docker-ip="$DOCKER_IP" \
+                                    --mender-gateway-conffile "$MENDER_GATEWAY_CONFFILE"
     touch /mender-setup-complete
 fi
 
-export QEMU_NET_HOSTFWD=",hostfwd=tcp::80-:80,hostfwd=tcp::85-:85"
+export QEMU_NET_HOSTFWD=",hostfwd=tcp::80-:80,hostfwd=tcp::85-:85,hostfwd=tcp::8080-:8080"
 ./mender-qemu "$@"

--- a/meta-mender-qemu/scripts/docker/setup-mender-configuration.py
+++ b/meta-mender-qemu/scripts/docker/setup-mender-configuration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ def main():
     parser.add_argument("--server-crt", help="server.crt file to put in image")
     parser.add_argument("--server-url", help="Server address to put in configuration")
     parser.add_argument("--verify-key", help="Key used to verify signed image")
+    parser.add_argument("--mender-gateway-conffile", help="Configuration file to be copied to /etc/mender/mender-gateway.conf")
     args = parser.parse_args()
 
     if len(sys.argv) == 1:
@@ -106,6 +107,10 @@ EOF
             rootfs=rootfs)
         os.unlink("mender-inventory-docker-ip")
 
+    if args.mender_gateway_conffile:
+        put(local_path=args.mender_gateway_conffile,
+            remote_path="/etc/mender/mender-gateway.conf",
+            rootfs=rootfs)
 
     # Put back ext4 image into img.
     insert_ext4(img=args.img, rootfs=rootfs)


### PR DESCRIPTION
Modified setup-mender-configuration.py to support injecting the conf
file for mender-gateway and opened the 8080 port on QEMU for the gateway
to serve.