### PR TITLE
 Add `honister` (Yocto version) compatibility

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
+++ b/meta-mender-commercial/recipes-mender/mender-monitor/mender-monitor.inc
@@ -14,7 +14,7 @@ FILES:${PN} = " \
     /data/mender-monitor \
 "
 
-FILES:${PN}:append_mender-systemd = " \
+FILES:${PN}:append:mender-systemd = " \
     ${systemd_system_unitdir}/mender-monitor.service \
 "
 
@@ -30,7 +30,7 @@ do_version_check() {
 }
 addtask do_version_check after do_unpack before do_install
 
-SYSTEMD_SERVICE:${PN}_mender-systemd = "mender-monitor.service"
+SYSTEMD_SERVICE:${PN}:mender-systemd = "mender-monitor.service"
 
 do_install() {
     oe_runmake \
@@ -40,18 +40,17 @@ do_install() {
     install -d ${D}/${localstatedir}/lib/mender-monitor
 }
 
-do_install:append_mender-systemd() {
+do_install:append:mender-systemd() {
     oe_runmake \
         -C ${S} \
         DESTDIR=${D} \
         install-systemd
 }
 
-do_install:append_mender-image() {
+do_install:append:mender-image() {
         # symlink /var/lib/mender-monitor to /data/mender-monitor
         rm -rf ${D}/${localstatedir}/lib/mender-monitor
         ln -s /data/mender-monitor ${D}/${localstatedir}/lib/mender-monitor
 
         install -m 755 -d ${D}/data/mender-monitor
 }
-

--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -117,4 +117,4 @@ IMAGE_CMD:mender () {
 
 IMAGE_CMD:mender[vardepsexclude] += "IMAGE_ID"
 # We need to have the filesystem image generated already.
-IMAGE_TYPEDEP_mender:append = " ${ARTIFACTIMG_FSTYPE}"
+IMAGE_TYPEDEP:mender:append = " ${ARTIFACTIMG_FSTYPE}"

--- a/meta-mender-core/classes/mender-dataimg.bbclass
+++ b/meta-mender-core/classes/mender-dataimg.bbclass
@@ -19,7 +19,7 @@ IMAGE_CMD:dataimg() {
         ${MENDER_DATA_PART_FSOPTS}
     install -m 0644 "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
 }
-IMAGE_CMD:dataimg_mender-image-ubi() {
+IMAGE_CMD:dataimg:mender-image-ubi() {
     mkfs.ubifs -o "${WORKDIR}/data.ubifs" -r "${IMAGE_ROOTFS}/data" ${MKUBIFS_ARGS}
     install -m 0644 "${WORKDIR}/data.ubifs" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
 }

--- a/meta-mender-core/classes/mender-image-systemd-boot.bbclass
+++ b/meta-mender-core/classes/mender-image-systemd-boot.bbclass
@@ -3,7 +3,7 @@
 # Move required files into the image partition boot sector
 EFI_BOOT_IMAGE_PART ?= \
     "${IMAGE_LINK_NAME}.${EFI_BOOT_IMAGE};EFI/Linux/${EFI_BOOT_IMAGE}"
-IMAGE_BOOT_FILES:append_mender-systemd-boot = " \
+IMAGE_BOOT_FILES:append:mender-systemd-boot = " \
     systemd-${EFI_BOOT_IMAGE};EFI/BOOT/${EFI_BOOT_IMAGE} \
     ${@ "${EFI_BOOT_IMAGE_PART}".replace('.efi','_a.efi') } \
     ${@ "${EFI_BOOT_IMAGE_PART}".replace('.efi','_b.efi') } \
@@ -11,7 +11,7 @@ IMAGE_BOOT_FILES:append_mender-systemd-boot = " \
     ${IMAGE_LINK_NAME}.esp/loader/backup/config*;loader/backup/ \
     "
 
-IMAGE_INSTALL:append_mender-systemd-boot = " systemd-mender-config"
+IMAGE_INSTALL:append:mender-systemd-boot = " systemd-mender-config"
 
 require conf/image-uefi.conf
 

--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -269,11 +269,11 @@ _MENDER_PART_IMAGE_DEPENDS += "${@bb.utils.contains('MENDER_DATA_PART_FSTYPE', '
 #
 # This assumes that U-boot is used on ARM, this could become problematic
 # if we add support for other bootloaders on ARM, e.g Barebox.
-_MENDER_PART_IMAGE_DEPENDS:append_mender-grub_arm =     " u-boot:do_deploy"
+_MENDER_PART_IMAGE_DEPENDS:append:mender-grub_arm =     " u-boot:do_deploy"
 
-_MENDER_PART_IMAGE_DEPENDS:append_mender-uboot = " u-boot:do_deploy"
-_MENDER_PART_IMAGE_DEPENDS:append_mender-grub_mender-bios = " grub:do_deploy"
-_MENDER_PART_IMAGE_DEPENDS:append_mender-systemd-boot = " \
+_MENDER_PART_IMAGE_DEPENDS:append:mender-uboot = " u-boot:do_deploy"
+_MENDER_PART_IMAGE_DEPENDS:append:mender-grub:mender-bios = " grub:do_deploy"
+_MENDER_PART_IMAGE_DEPENDS:append:mender-systemd-boot = " \
     systemd-boot:do_deploy \
     ${IMAGE_BASENAME}:do_uefiapp_deploy \
 "
@@ -288,23 +288,23 @@ do_image_biosimg[depends] += "${_MENDER_PART_IMAGE_DEPENDS}"
 
 do_image_gptimg[depends] += "${_MENDER_PART_IMAGE_DEPENDS}"
 
-IMAGE_TYPEDEP_sdimg:append   = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
-IMAGE_TYPEDEP_uefiimg:append = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
-IMAGE_TYPEDEP_biosimg:append = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
-IMAGE_TYPEDEP_gptimg:append  = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
+IMAGE_TYPEDEP:sdimg:append   = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
+IMAGE_TYPEDEP:uefiimg:append = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
+IMAGE_TYPEDEP:biosimg:append = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
+IMAGE_TYPEDEP:gptimg:append  = " ${ARTIFACTIMG_FSTYPE} dataimg bootimg"
 
 # This isn't actually a dependency, but a way to avoid sdimg and uefiimg
 # building simultaneously, since wic will use the same file names in both, and
 # in parallel builds this is a recipe for disaster.
-IMAGE_TYPEDEP_uefiimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)}"
+IMAGE_TYPEDEP:uefiimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)}"
 # And same here.
-IMAGE_TYPEDEP_biosimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)}"
+IMAGE_TYPEDEP:biosimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)}"
 # And same here.
-IMAGE_TYPEDEP_gptimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
+IMAGE_TYPEDEP:gptimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'biosimg', ' biosimg', '', d)}"
 # Make sure the Mender part image is available in the live installer
-IMAGE_TYPEDEP_hddimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
+IMAGE_TYPEDEP:hddimg:append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'gptimg', ' gptimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)} \
                                ${@bb.utils.contains('IMAGE_FSTYPES', 'biosimg', ' biosimg', '', d)}"
@@ -416,4 +416,4 @@ IMAGE_CMD:mtdimg() {
     ln -sfn "${IMAGE_NAME}.mtdimg" "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.mtdimg"
 }
 
-IMAGE_TYPEDEP_mtdimg:append = " ubimg"
+IMAGE_TYPEDEP:mtdimg:append = " ubimg"

--- a/meta-mender-core/classes/mender-setup-bios.inc
+++ b/meta-mender-core/classes/mender-setup-bios.inc
@@ -1,12 +1,12 @@
 # Make sure that GRUB is flashed to first non-partition table sector.
-MENDER_IMAGE_BOOTLOADER_FILE_DEFAULT_mender-grub_mender-bios = "grub-core.img"
-MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_DEFAULT_mender-grub_mender-bios_mender-image-bios = "1"
+MENDER_IMAGE_BOOTLOADER_FILE_DEFAULT:mender-grub:mender-bios = "grub-core.img"
+MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_DEFAULT:mender-grub:mender-bios:mender-image-bios = "1"
 
 # The first non-partition table sector of GPT is 34.
 # https://en.wikipedia.org/wiki/GUID_Partition_Table
-MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_DEFAULT_mender-grub_mender-bios_mender-image-gpt = "34"
+MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_DEFAULT:mender-grub:mender-bios:mender-image-gpt = "34"
 
 # And that the 1st stage bootloader is in the MBR.
-MENDER_MBR_BOOTLOADER_FILE_DEFAULT_mender-grub_mender-bios = "boot.img"
+MENDER_MBR_BOOTLOADER_FILE_DEFAULT:mender-grub:mender-bios = "boot.img"
 
-EXTRA_IMAGEDEPENDS:append_mender-grub_mender-bios = " grub"
+EXTRA_IMAGEDEPENDS:append:mender-grub:mender-bios = " grub"

--- a/meta-mender-core/classes/mender-setup-grub.inc
+++ b/meta-mender-core/classes/mender-setup-grub.inc
@@ -12,12 +12,12 @@ PREFERRED_RPROVIDER_virtual/grub-bootconf ?= "grub-mender-grubenv"
 # Set EFI_PROVIDER.  Not all MACHINE configs use it but notably
 # intel-corei7-64 does and without this we use the default of systemd-boot.
 EFI_PROVIDER ?= ""
-EFI_PROVIDER_mender-grub = "grub-efi"
-EFI_PROVIDER_mender-grub_mender-bios = ""
+EFI_PROVIDER:mender-grub = "grub-efi"
+EFI_PROVIDER:mender-grub:mender-bios = ""
 
 python() {
     if d.getVar('MENDER_GRUB_STORAGE_DEVICE'):
         bb.fatal("MENDER_GRUB_STORAGE_DEVICE is deprecated. This is now dynamically determined at runtime.")
 }
 
-MENDER_FEATURES_ENABLE:append_mender-grub = " mender-efi-boot"
+MENDER_FEATURES_ENABLE:append:mender-grub = " mender-efi-boot"

--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -5,10 +5,10 @@ IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-uefi', '
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-bios', ' biosimg biosimg.bmap', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-gpt', ' gptimg gptimg.bmap', '', d)}"
 
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append_mender-image:x86 =     " kernel-image"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append_mender-image:x86-64 =  " kernel-image"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append_mender-image:arm =     " kernel-image kernel-devicetree"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append_mender-image:aarch64 = " kernel-image"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:mender-image:x86 =     " kernel-image"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:mender-image:x86-64 =  " kernel-image"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:mender-image:arm =     " kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:mender-image:aarch64 = " kernel-image"
 
 python() {
     features = d.getVar('MENDER_FEATURES').split()
@@ -19,12 +19,12 @@ python() {
 }
 
 MENDER_BOOT_PART_MOUNT_LOCATION = "/boot/efi"
-MENDER_BOOT_PART_MOUNT_LOCATION_mender-uboot = "/uboot"
-MENDER_BOOT_PART_MOUNT_LOCATION_mender-systemd-boot = "/boot"
-MENDER_BOOT_PART_MOUNT_LOCATION_mender-grub_mender-bios = "/boot/grub"
+MENDER_BOOT_PART_MOUNT_LOCATION:mender-uboot = "/uboot"
+MENDER_BOOT_PART_MOUNT_LOCATION:mender-systemd-boot = "/boot"
+MENDER_BOOT_PART_MOUNT_LOCATION:mender-grub:mender-bios = "/boot/grub"
 
 # Set Yocto variable.
-EFI_PREFIX_mender-image = "${MENDER_BOOT_PART_MOUNT_LOCATION}"
+EFI_PREFIX:mender-image = "${MENDER_BOOT_PART_MOUNT_LOCATION}"
 
 # Update fstab for Mender
 ROOTFS_POSTPROCESS_COMMAND:append = " mender_update_fstab_file;"
@@ -91,7 +91,7 @@ mender_create_scripts_version_file() {
     echo -n "${MENDER_STATE_SCRIPTS_VERSION}" > ${IMAGE_ROOTFS}${sysconfdir}/mender/scripts/version
 }
 
-IMAGE_ROOTFS_EXCLUDE_PATH:append_mender-image = " data/ ${@d.getVar('MENDER_BOOT_PART_MOUNT_LOCATION')[1:]}/"
+IMAGE_ROOTFS_EXCLUDE_PATH:append:mender-image = " data/ ${@d.getVar('MENDER_BOOT_PART_MOUNT_LOCATION')[1:]}/"
 
 
 ################################################################################

--- a/meta-mender-core/classes/mender-setup-systemd-boot.inc
+++ b/meta-mender-core/classes/mender-setup-systemd-boot.inc
@@ -1,10 +1,10 @@
 # Mender systemd-boot support
 
-EFI_PROVIDER_mender-systemd-boot = "systemd-boot"
+EFI_PROVIDER:mender-systemd-boot = "systemd-boot"
 
 # systemd-boot requires a slightly larger default boot partition
-MENDER_BOOT_PART_SIZE_MB_DEFAULT_mender-systemd-boot = "64"
+MENDER_BOOT_PART_SIZE_MB_DEFAULT:mender-systemd-boot = "64"
 
-WKS_FILE_DEPENDS_BOOTLOADERS:remove_mender-systemd-boot = "grub-efi"
+WKS_FILE_DEPENDS_BOOTLOADERS:remove:mender-systemd-boot = "grub-efi"
 
-MENDER_FEATURES_ENABLE:append_mender-systemd-boot = " mender-efi-boot"
+MENDER_FEATURES_ENABLE:append:mender-systemd-boot = " mender-efi-boot"

--- a/meta-mender-core/classes/mender-setup-ubi.inc
+++ b/meta-mender-core/classes/mender-setup-ubi.inc
@@ -2,20 +2,20 @@
 # Variables
 ################################################################################
 
-ARTIFACTIMG_FSTYPE_DEFAULT_mender-ubi = "ubifs"
+ARTIFACTIMG_FSTYPE_DEFAULT:mender-ubi = "ubifs"
 
-MENDER_STORAGE_DEVICE_DEFAULT_mender-ubi = "ubi0"
+MENDER_STORAGE_DEVICE_DEFAULT:mender-ubi = "ubi0"
 
 # The base name of the devices that hold individual volumes.
-MENDER_STORAGE_DEVICE_BASE_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE}_"
+MENDER_STORAGE_DEVICE_BASE_DEFAULT:mender-ubi = "${MENDER_STORAGE_DEVICE}_"
 
 # The numbers of the two rootfs partitions in the A/B partition layout.
-MENDER_ROOTFS_PART_A_NUMBER_DEFAULT_mender-ubi = "0"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_mender-ubi = "1"
+MENDER_ROOTFS_PART_A_NUMBER_DEFAULT:mender-ubi = "0"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:mender-ubi = "1"
 
 # The partition number holding the data partition.
-MENDER_DATA_PART_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE_BASE}2"
-MENDER_DATA_PART_FSTYPE_DEFAULT_mender-ubi = "ubifs"
+MENDER_DATA_PART_DEFAULT:mender-ubi = "${MENDER_STORAGE_DEVICE_BASE}2"
+MENDER_DATA_PART_FSTYPE_DEFAULT:mender-ubi = "ubifs"
 
 # u-boot command ubifsmount requires volume name as the only argument
 # and hence we need to keep track of that since we load kernel/dtb from
@@ -23,33 +23,33 @@ MENDER_DATA_PART_FSTYPE_DEFAULT_mender-ubi = "ubifs"
 #
 # It also needs the volume index e.g.
 # ubifsmount ubi0:rootfsa
-MENDER_ROOTFS_PART_A_NAME_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE}:rootfsa"
-MENDER_ROOTFS_PART_B_NAME_DEFAULT_mender-ubi = "${MENDER_STORAGE_DEVICE}:rootfsb"
+MENDER_ROOTFS_PART_A_NAME_DEFAULT:mender-ubi = "${MENDER_STORAGE_DEVICE}:rootfsa"
+MENDER_ROOTFS_PART_B_NAME_DEFAULT:mender-ubi = "${MENDER_STORAGE_DEVICE}:rootfsb"
 
 # The name of of the MTD part holding your UBI volumes.
-MENDER_MTD_UBI_DEVICE_NAME_DEFAULT_mender-ubi = "ubi"
+MENDER_MTD_UBI_DEVICE_NAME_DEFAULT:mender-ubi = "ubi"
 
 # Boot part is not used when building UBI image.
-MENDER_BOOT_PART_DEFAULT_mender-ubi = ""
-MENDER_BOOT_PART_NUMBER_DEFAULT_mender-ubi = ""
-MENDER_BOOT_PART_SIZE_MB_DEFAULT_mender-ubi = "0"
+MENDER_BOOT_PART_DEFAULT:mender-ubi = ""
+MENDER_BOOT_PART_NUMBER_DEFAULT:mender-ubi = ""
+MENDER_BOOT_PART_SIZE_MB_DEFAULT:mender-ubi = "0"
 
 # These are not applicable when building UBI image.
-MENDER_UBOOT_STORAGE_DEVICE_DEFAULT_mender-ubi = "dummy"
-MENDER_UBOOT_STORAGE_INTERFACE_DEFAULT_mender-ubi = "dummy"
+MENDER_UBOOT_STORAGE_DEVICE_DEFAULT:mender-ubi = "dummy"
+MENDER_UBOOT_STORAGE_INTERFACE_DEFAULT:mender-ubi = "dummy"
 
 # Align UBI partitions to the LEB block size instead of the PEB size, since
 # the bookeeping bytes used by UBI are basically lost as far as storage space
 # is concerned.
-MENDER_PARTITION_ALIGNMENT_DEFAULT_mender-ubi = "${MENDER_UBI_LEB_SIZE}"
+MENDER_PARTITION_ALIGNMENT_DEFAULT:mender-ubi = "${MENDER_UBI_LEB_SIZE}"
 
 # Will be relative to start of first MTD partition, so should be zero.
-MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_DEFAULT_mender-ubi = "0"
+MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_DEFAULT:mender-ubi = "0"
 
 # since UBIFS employs compression, disable the max rootfs size checking.
-MENDER_IMAGE_ROOTFS_MAXSIZE_DEFAULT_mender-ubi = ""
+MENDER_IMAGE_ROOTFS_MAXSIZE_DEFAULT:mender-ubi = ""
 
-MENDER_PARTITIONING_OVERHEAD_KB_DEFAULT_mender-ubi = "${@mender_get_partitioning_overhead_kb_ubi(d)}"
+MENDER_PARTITIONING_OVERHEAD_KB_DEFAULT:mender-ubi = "${@mender_get_partitioning_overhead_kb_ubi(d)}"
 
 # Definition of mtdids and mtdparts (taken from U-Boot's mtdparts.c):
 #
@@ -103,7 +103,7 @@ MENDER_IS_ON_MTDID ??= "${@mender_default_mender_mtdid(d)}"
 MENDER_MTDPARTS ??= "${@mender_make_mtdparts(d)}"
 
 # Usually included in first mtd partition.
-MENDER_IMAGE_BOOTLOADER_FILE_DEFAULT_mender-ubi = "u-boot.${UBOOT_SUFFIX}"
+MENDER_IMAGE_BOOTLOADER_FILE_DEFAULT:mender-ubi = "u-boot.${UBOOT_SUFFIX}"
 
 ################################################################################
 # Most of the information about various Flash properties below has been grabbed

--- a/meta-mender-core/classes/mender-setup-uboot.inc
+++ b/meta-mender-core/classes/mender-setup-uboot.inc
@@ -16,7 +16,7 @@ MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET ??= "${MENDER_PARTITION_ALIGNMENT}"
 # real size in the U-Boot recipe later. Must be an *even* multiple of the
 # alignment. Most people should not need to set this, and if so, only because it
 # produces an error if left to the default.
-MENDER_RESERVED_SPACE_BOOTLOADER_DATA_DEFAULT_mender-uboot = \
+MENDER_RESERVED_SPACE_BOOTLOADER_DATA_DEFAULT:mender-uboot = \
     "${@mender_get_env_total_aligned_size(${MENDER_PARTITION_ALIGNMENT}, \
                                           ${MENDER_PARTITION_ALIGNMENT})}"
 

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -105,7 +105,7 @@ MENDER_DEVICE_TYPE ??= "${MENDER_DEVICE_TYPE_DEFAULT}"
 MENDER_DEVICE_TYPE_DEFAULT = "${MACHINE}"
 
 # To tell the difference from a beaglebone-yocto image with only U-Boot.
-MENDER_DEVICE_TYPE_DEFAULT:beaglebone-yocto_mender-grub = "${MACHINE}-grub"
+MENDER_DEVICE_TYPE_DEFAULT:beaglebone-yocto:mender-grub = "${MACHINE}-grub"
 
 # Space separated list of device types compatible with the built update.
 MENDER_DEVICE_TYPES_COMPATIBLE ??= "${MENDER_DEVICE_TYPES_COMPATIBLE_DEFAULT}"
@@ -293,7 +293,7 @@ python mender_vars_handler() {
 
         for k in d.keys():
             if k.startswith("MENDER_"):
-                if re.search("_[-a-z0-9][-\w]*$", k) != None:
+                if re.search("[:_][-a-z0-9][-\w]*$", k) != None:
                     # skip variable overrides
                     continue;
 
@@ -331,7 +331,7 @@ python mender_vars_handler() {
         mender_vars = {}
         for k in d.keys():
             if k.startswith("MENDER_"):
-                if re.search("_[-a-z0-9][-\w]*$", k) == None:
+                if re.search("[:_][-a-z0-9][-\w]*$", k) == None:
                     mender_vars[k] = ""
                     #mender_vars[k] = d.getVar(k) might be useful for inspection
         with open (path, 'w') as f:

--- a/meta-mender-core/classes/mender-ubimg.bbclass
+++ b/meta-mender-core/classes/mender-ubimg.bbclass
@@ -110,7 +110,7 @@ EOF
 
 }
 
-IMAGE_TYPEDEP_ubimg:append = " ubifs dataimg ${@bb.utils.contains('MENDER_BOOT_PART_SIZE_MB', '0', '', 'bootimg', d)}"
+IMAGE_TYPEDEP:ubimg:append = " ubifs dataimg ${@bb.utils.contains('MENDER_BOOT_PART_SIZE_MB', '0', '', 'bootimg', d)}"
 
 # So that we can use the files from excluded paths in the full images.
 do_image_ubimg[respect_exclude_path] = "0"

--- a/meta-mender-core/conf/layer.conf
+++ b/meta-mender-core/conf/layer.conf
@@ -17,5 +17,5 @@ BBFILE_PRIORITY_mender = "6"
 
 INHERIT += "mender-maybe-setup"
 
-LAYERSERIES_COMPAT_mender = "dunfell hardknott"
+LAYERSERIES_COMPAT_mender = "dunfell hardknott honister"
 LAYERDEPENDS_mender = "core"

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -6,7 +6,7 @@ inherit grub-mender-grubenv
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 GRUB_CONF_LOCATION = "${EFI_FILES_PATH}"
-GRUB_CONF_LOCATION_mender-bios = "${MENDER_BOOT_PART_MOUNT_LOCATION}"
+GRUB_CONF_LOCATION:mender-bios = "${MENDER_BOOT_PART_MOUNT_LOCATION}"
 
 FILES:${PN} += "/data/mender_grubenv.config \
                 ${GRUB_CONF_LOCATION}/grub.cfg \
@@ -30,10 +30,10 @@ SRC_URI:append = "${@bb.utils.contains('PACKAGECONFIG', 'force-grub-prompt', ' f
 PACKAGECONFIG[debug-log] = ",,,"
 
 RDEPENDS:${PN} = "grub-efi"
-RDEPENDS:${PN}_mender-bios = "grub"
+RDEPENDS:${PN}:mender-bios = "grub"
 
 PROVIDES = "${@mender_feature_is_enabled('mender-grub', "virtual/grub-bootconf", "", d)}"
-RPROVIDES:${PN} = "${@mender_feature_is_enabled('mender-grub', "virtual/grub-bootconf", "", d)}"
+RPROVIDES:${PN} = "${@mender_feature_is_enabled('mender-grub', "virtual-grub-bootconf", "", d)}"
 
 # See https://www.gnu.org/software/grub/manual/grub/grub.html#debug
 DEBUG_LOG_CATEGORY ?= "all"

--- a/meta-mender-core/recipes-bsp/grub/grub-mender.inc
+++ b/meta-mender-core/recipes-bsp/grub/grub-mender.inc
@@ -1,18 +1,18 @@
-FILESEXTRAPATHS:prepend_mender-grub := "${THISDIR}/patches:"
+FILESEXTRAPATHS:prepend:mender-grub := "${THISDIR}/patches:"
 
 # virtual/grub-bootconf will be removed by upstream recipes when using
 # efi-secure-boot. However, we explicitly want to include grub-mender-grubenv.
-RDEPENDS:${PN}:class-target:append_mender-grub = " grub-mender-grubenv"
+RDEPENDS:${PN}:class-target:append:mender-grub = " grub-mender-grubenv"
 
 # Setup EFI_BOOT_PATH for meta-secure-core.
-EFI_BOOT_PATH_mender-grub = "${MENDER_BOOT_PART_MOUNT_LOCATION}/EFI/BOOT"
+EFI_BOOT_PATH:mender-grub = "${MENDER_BOOT_PART_MOUNT_LOCATION}/EFI/BOOT"
 
 # Mender needs these.
-GRUB_BUILDIN:append_mender-grub = " cat echo gcry_sha256 halt hashsum loadenv sleep reboot test regexp"
+GRUB_BUILDIN:append:mender-grub = " cat echo gcry_sha256 halt hashsum loadenv sleep reboot test regexp"
 
-GRUBPLATFORM:arm_mender-grub = "efi"
+GRUBPLATFORM:arm:mender-grub = "efi"
 
-do_configure:prepend_mender-grub() {
+do_configure:prepend:mender-grub() {
     if [ "${KERNEL_IMAGETYPE}" = "uImage" ]; then
         bbfatal "GRUB is not compatible with KERNEL_IMAGETYPE = uImage. Please change it to either zImage or bzImage."
     fi

--- a/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
+++ b/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI:append_cfg_file += " file://cfg"
+SRC_URI:append:cfg_file += " file://cfg"
 
 
 do_check_config_efi_stub() {

--- a/meta-mender-core/recipes-bsp/grub/mender-grub-impl.inc
+++ b/meta-mender-core/recipes-bsp/grub/mender-grub-impl.inc
@@ -4,7 +4,7 @@ require grub-mender.inc
 
 inherit deploy
 
-SRC_URI:append_mender-bios = " file://bios-cfg"
+SRC_URI:append:mender-bios = " file://bios-cfg"
 
 GRUB_TARGET:x86 = "i386-pc"
 GRUB_TARGET:x86-64 = "i386-pc"
@@ -13,7 +13,7 @@ GRUB_TARGET:x86-64 = "i386-pc"
 GRUB_BUILDIN ?= "boot linux ext2 fat serial part_msdos part_gpt normal \
                  iso9660 configfile search loadenv test"
 
-GRUB_BUILDIN:append_mender-bios = " biosdisk"
+GRUB_BUILDIN:append:mender-bios = " biosdisk"
 
 python do_setcorelocation () {
 }

--- a/meta-mender-core/recipes-bsp/grub/version_logic.inc
+++ b/meta-mender-core/recipes-bsp/grub/version_logic.inc
@@ -1,7 +1,7 @@
-DEPENDS:append_mender-grub:arm = " u-boot"
-DEPENDS:append_mender-grub:aarch64 = " u-boot"
-RDEPENDS:${PN}:append_mender-grub:arm = " u-boot"
-RDEPENDS:${PN}:append_mender-grub:aarch64 = " u-boot"
+DEPENDS:append:mender-grub:arm = " u-boot"
+DEPENDS:append:mender-grub:aarch64 = " u-boot"
+RDEPENDS:${PN}:append:mender-grub:arm = " u-boot"
+RDEPENDS:${PN}:append:mender-grub:aarch64 = " u-boot"
 
 # MEN-2404: These older versions have broken EFI support. Unfortunately it does
 # not seem to be possible to specify a range of conflicting versions. If so, we
@@ -20,11 +20,11 @@ def mender_u_boot_version_conflict(d):
         return " %s (<= %s)" % (pp, bad_version)
     else:
         return ""
-RCONFLICTS:${PN}_mender-grub:arm = "${@mender_u_boot_version_conflict(d)}"
-RCONFLICTS:${PN}_mender-grub:aarch64 = "${@mender_u_boot_version_conflict(d)}"
+RCONFLICTS:${PN}:mender-grub:arm = "${@mender_u_boot_version_conflict(d)}"
+RCONFLICTS:${PN}:mender-grub:aarch64 = "${@mender_u_boot_version_conflict(d)}"
 
 # It's actually U-Boot that needs the dtb files to be in the boot partition, in
 # order to load EFI apps correctly, but due to the wide range of U-Boot recipes
 # out there, it's easier to add the dependency here.
-RDEPENDS:${PN}:append_mender-image_mender-grub:arm = " boot-partition-devicetree"
-RDEPENDS:${PN}:append_mender-image_mender-grub:aarch64 = " boot-partition-devicetree"
+RDEPENDS:${PN}:append:mender-image:mender-grub:arm = " boot-partition-devicetree"
+RDEPENDS:${PN}:append:mender-image:mender-grub:aarch64 = " boot-partition-devicetree"

--- a/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -2,9 +2,9 @@ include ${@mender_feature_is_enabled("mender-uboot","u-boot-mender-helpers.inc",
 
 RPROVIDES:${PN} += "u-boot-default-env"
 
-FILES:${PN}:append_mender-uboot = " /data/u-boot/fw_env.config"
+FILES:${PN}:append:mender-uboot = " /data/u-boot/fw_env.config"
 
-do_compile:append_mender-uboot() {
+do_compile:append:mender-uboot() {
     alignment_bytes=${MENDER_PARTITION_ALIGNMENT}
     if [ $(expr ${MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET} % $alignment_bytes) -ne 0 ]; then
         bberror "MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET must be aligned to" \
@@ -19,7 +19,7 @@ do_compile:append_mender-uboot() {
 }
 do_compile[depends] += "u-boot:do_deploy"
 
-do_install:append_mender-uboot() {
+do_install:append:mender-uboot() {
     install -d -m 755 ${D}${sysconfdir}
     ln -sf /data/u-boot/fw_env.config ${D}${sysconfdir}/fw_env.config
 

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
@@ -14,11 +14,11 @@ MENDER_UBOOT_AUTO_CONFIGURE ??= "${@bb.utils.contains('MENDER_FEATURES', 'mender
 ################################################################################
 FILESEXTRAPATHS:prepend := "${THISDIR}/patches:${THISDIR}/files:"
 
-SRC_URI:append_mender-uboot = " file://0001-Add-missing-header-which-fails-on-recent-GCC.patch"
-SRC_URI:append_mender-uboot = " file://0002-Generic-boot-code-for-Mender.patch"
-SRC_URI:append_mender-uboot = " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
+SRC_URI:append:mender-uboot = " file://0001-Add-missing-header-which-fails-on-recent-GCC.patch"
+SRC_URI:append:mender-uboot = " file://0002-Generic-boot-code-for-Mender.patch"
+SRC_URI:append:mender-uboot = " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
 
-SRC_URI:append_mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
+SRC_URI:append:mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
                                                     '1', \
                                                     ' file://0004-Disable-CONFIG_BOOTCOMMAND-and-enable-CONFIG_MENDER_.patch', \
                                                     '', \
@@ -212,7 +212,7 @@ python() {
         bb.build.addtask('do_provide_mender_defines', 'do_configure', 'do_patch', d)
 }
 
-do_configure:prepend_mender-uboot() {
+do_configure:prepend:mender-uboot() {
     # Do a sanity check on some defines. The reason this is necessary, even
     # though they are defined by us, is that there are two ways the defines can
     # make it into the code, Kconfig and source code, and several things can
@@ -268,7 +268,7 @@ do_configure:prepend_mender-uboot() {
     unset IFS
 }
 
-do_compile:append_mender-uboot_mender-ubi() {
+do_compile:append:mender-uboot_mender-ubi() {
     # Doing this in do_compile instead of do_configure is actually a bit late,
     # but the U-Boot recipe doesn't separate between the stages.
 
@@ -283,7 +283,7 @@ do_compile:append_mender-uboot_mender-ubi() {
     fi
 }
 
-SRC_URI:append_mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
+SRC_URI:append:mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
                                                     '1', \
                                                     ' file://uboot_auto_configure.sh \
                                                       file://uboot_auto_patch.sh \
@@ -369,7 +369,7 @@ python() {
 do_deploy:append() {
     :
 }
-do_deploy:append_mender-uboot() {
+do_deploy:append:mender-uboot() {
     # Copy script to the deploy area with u-boot, uImage, and rootfs
     if [ -e ${WORKDIR}/uEnv.txt ] ; then
         install -d ${DEPLOYDIR}

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install-efi_%.bbappend
@@ -1,5 +1,5 @@
 require initramfs-module-install.inc
 
-do_install:append_mender-efi-boot() {
+do_install:append:mender-efi-boot() {
     install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install-efi.sh
 }

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install.inc
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install.inc
@@ -1,8 +1,8 @@
-FILESEXTRAPATHS:prepend_mender-efi-boot := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:mender-efi-boot := "${THISDIR}/files:"
 
-SRC_URI:append_mender-efi-boot = " file://init-install-efi-mender.sh "
+SRC_URI:append:mender-efi-boot = " file://init-install-efi-mender.sh "
 
-do_install:append_mender-efi-boot() {
+do_install:append:mender-efi-boot() {
     # Overwrite the version of this file provided by upstream
     sed -e 's#[@]MENDER_STORAGE_DEVICE[@]#${MENDER_STORAGE_DEVICE}#' ${WORKDIR}/init-install-efi-mender.sh > init-install-efi-mender-altered.sh
 }

--- a/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install_%.bbappend
+++ b/meta-mender-core/recipes-core/initrdscripts/initramfs-module-install_%.bbappend
@@ -1,5 +1,5 @@
 require initramfs-module-install.inc
 
-do_install:append_mender-efi-boot() {
+do_install:append:mender-efi-boot() {
     install -m 0755 ${WORKDIR}/init-install-efi-mender-altered.sh ${D}/init.d/install.sh
 }

--- a/meta-mender-core/recipes-core/meta/wic-tools.bbappend
+++ b/meta-mender-core/recipes-core/meta/wic-tools.bbappend
@@ -1,1 +1,1 @@
-DEPENDS:remove_mender-systemd-boot = "grub grub-efi grub-efi-native"
+DEPENDS:remove:mender-systemd-boot = "grub grub-efi grub-efi-native"

--- a/meta-mender-core/recipes-core/systemd/files/systemd-boot-slotconfig.patch
+++ b/meta-mender-core/recipes-core/systemd/files/systemd-boot-slotconfig.patch
@@ -1,22 +1,34 @@
+From d9398201627b0dee2ca78c78113862e324a4f8b1 Mon Sep 17 00:00:00 2001
+From: Liam White McShane <liam.white@timesys.com>
+Date: Fri, 23 Jul 2021 13:53:17 -0400
+Subject: [PATCH] systemd-boot: add A/B RFS support
+
 commit 9859c61858d6a55dc648bafef46c554a93d87285
-Author: Liam White McShane <liam.white@timesys.com>
-Date:   Fri Jul 23 13:53:17 2021 -0400
 
     Add slot config
 
+---
+ src/boot/efi/boot.c      |  46 ++++++++++
+ src/boot/efi/meson.build |   2 +
+ src/boot/efi/slot.c      | 175 +++++++++++++++++++++++++++++++++++++++
+ src/boot/efi/slot.h      |  25 ++++++
+ 4 files changed, 248 insertions(+)
+ create mode 100644 src/boot/efi/slot.c
+ create mode 100644 src/boot/efi/slot.h
+
 diff --git a/src/boot/efi/boot.c b/src/boot/efi/boot.c
-index 176028efa4..80c5641e2a 100644
+index b4f3b9605a..2dc8a3bbb1 100644
 --- a/src/boot/efi/boot.c
 +++ b/src/boot/efi/boot.c
-@@ -14,6 +14,7 @@
- #include "pe.h"
+@@ -15,6 +15,7 @@
  #include "random-seed.h"
+ #include "secure-boot.h"
  #include "shim.h"
 +#include "slot.h"
  #include "util.h"
  
  #ifndef EFI_OS_INDICATIONS_BOOT_TO_FW_UI
-@@ -2257,6 +2258,46 @@ out_unload:
+@@ -2189,6 +2190,46 @@ out_unload:
          return err;
  }
  
@@ -53,7 +65,7 @@ index 176028efa4..80c5641e2a 100644
 +                return err;
 +        }
 +
-+        efivar_set_time_usec(L"LoaderTimeExecUSec", 0);
++        efivar_set_time_usec(LOADER_GUID, L"LoaderTimeExecUSec", 0);
 +        err = uefi_call_wrapper(BS->StartImage, 3, image, NULL, NULL);
 +
 +        uefi_call_wrapper(BS->UnloadImage, 1, image);
@@ -61,9 +73,9 @@ index 176028efa4..80c5641e2a 100644
 +}
 +
  static EFI_STATUS reboot_into_firmware(VOID) {
-         _cleanup_freepool_ CHAR8 *b = NULL;
-         UINTN size;
-@@ -2332,6 +2373,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+         UINT64 old, new;
+         EFI_STATUS err;
+@@ -2257,6 +2298,7 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
          CHAR16 *loaded_image_path;
          EFI_STATUS err;
          Config config;
@@ -71,8 +83,8 @@ index 176028efa4..80c5641e2a 100644
          UINT64 init_usec;
          BOOLEAN menu = FALSE;
          CHAR16 uuid[37];
-@@ -2377,6 +2419,10 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
-                 }
+@@ -2293,6 +2335,10 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table) {
+                         return log_error_status_stall(err, L"Error installing security policy: %r", err);
          }
  
 +        if (get_ab_config(root_dir, &ab_config) && !EFI_ERROR(boot_ab(image, loaded_image->DeviceHandle, root_dir, &ab_config))) {
@@ -81,9 +93,9 @@ index 176028efa4..80c5641e2a 100644
 +
          /* the filesystem path to this image, to prevent adding ourselves to the menu */
          loaded_image_path = DevicePathToStr(loaded_image->FilePath);
-         efivar_set(L"LoaderImageIdentifier", loaded_image_path, FALSE);
+         efivar_set(LOADER_GUID, L"LoaderImageIdentifier", loaded_image_path, 0);
 diff --git a/src/boot/efi/meson.build b/src/boot/efi/meson.build
-index ed81cefcd5..fcae727a12 100644
+index afdf739d9b..200cf38fc0 100644
 --- a/src/boot/efi/meson.build
 +++ b/src/boot/efi/meson.build
 @@ -12,6 +12,7 @@ efi_headers = files('''
@@ -94,7 +106,7 @@ index ed81cefcd5..fcae727a12 100644
          splash.h
          util.h
  '''.split())
-@@ -31,6 +32,7 @@ systemd_boot_sources = '''
+@@ -32,6 +33,7 @@ systemd_boot_sources = '''
          random-seed.c
          sha256.c
          shim.c
@@ -104,7 +116,7 @@ index ed81cefcd5..fcae727a12 100644
  stub_sources = '''
 diff --git a/src/boot/efi/slot.c b/src/boot/efi/slot.c
 new file mode 100644
-index 0000000000..7b364c078b
+index 0000000000..e55b74ff99
 --- /dev/null
 +++ b/src/boot/efi/slot.c
 @@ -0,0 +1,175 @@

--- a/meta-mender-core/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-mender-core/recipes-core/systemd/systemd_%.bbappend
@@ -4,5 +4,5 @@
 # in the future and an fsck will be done.  Setting this to 0 results
 # in an epoch of January 1, 1970 which is detected as an invalid time
 # and the fsck will be skipped.
-PACKAGECONFIG:append_mender-systemd = " set-time-epoch"
-SOURCE_DATE_EPOCH_mender-systemd = "0"
+PACKAGECONFIG:append:mender-systemd = " set-time-epoch"
+SOURCE_DATE_EPOCH:mender-systemd = "0"

--- a/meta-mender-core/recipes-devtools/e2fsprogs/e2fsprogs_1.46.%.bbappend
+++ b/meta-mender-core/recipes-devtools/e2fsprogs/e2fsprogs_1.46.%.bbappend
@@ -1,2 +1,2 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/patches:"
-SRC_URI:append_mender-image = " file://0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch"
+SRC_URI:append:mender-image = " file://0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch"

--- a/meta-mender-core/recipes-devtools/e2fsprogs/patches/0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch
+++ b/meta-mender-core/recipes-devtools/e2fsprogs/patches/0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch
@@ -20,9 +20,8 @@ index 00afd91..695dc3f 100644
  	ext4 = {
 -		features = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize
 +		features = has_journal,extent,huge_file,flex_bg,64bit,dir_nlink,extra_isize
- 		inode_size = 256
  	}
  	small = {
--- 
+		blocksize = 1024
+--
 2.7.4
-

--- a/meta-mender-core/recipes-kernel/linux/linux-%.bbappend
+++ b/meta-mender-core/recipes-kernel/linux/linux-%.bbappend
@@ -16,5 +16,5 @@ def if_kernel_recipe(if_true, if_false, d):
     else:
         return if_false
 
-SRC_URI:append_mender-grub:arm = "${@if_kernel_recipe(' file://enable_efi_stub.cfg', '', d)}"
-SRC_URI:append_mender-grub:aarch64 = "${@if_kernel_recipe(' file://enable_efi_stub.cfg', '', d)}"
+SRC_URI:append:mender-grub:arm = "${@if_kernel_recipe(' file://enable_efi_stub.cfg', '', d)}"
+SRC_URI:append:mender-grub:aarch64 = "${@if_kernel_recipe(' file://enable_efi_stub.cfg', '', d)}"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -7,8 +7,8 @@ DEPENDS:class-native = ""
 
 PACKAGES:append = " mender-modules-gen"
 
-RDEPENDS:${PN}:append_mender-growfs-data_mender-systemd = " parted util-linux-fdisk"
-RDEPENDS:${PN}:append_mender-growfs-data_mender-systemd_mender-partlabel = " util-linux-blkid"
+RDEPENDS:${PN}:append:mender-growfs-data:mender-systemd = " parted util-linux-fdisk"
+RDEPENDS:${PN}:append:mender-growfs-data:mender-systemd:mender-partlabel = " util-linux-blkid"
 RDEPENDS:mender-modules-gen = "bash"
 
 MENDER_CLIENT ?= "mender-client"
@@ -62,27 +62,27 @@ FILES:mender-modules-gen = " \
 
 SYSROOT_DIRS += "/data"
 
-SRC_URI:append_mender-image_mender-systemd = " \
+SRC_URI:append:mender-image:mender-systemd = " \
     file://mender-client-data-dir.service \
 "
 
-SRC_URI:append_mender-persist-systemd-machine-id = " \
+SRC_URI:append:mender-persist-systemd-machine-id = " \
     file://mender-client-systemd-machine-id.service \
     file://mender-client-set-systemd-machine-id.sh \
 "
 
-SRC_URI:append_mender-growfs-data_mender-systemd = " \
+SRC_URI:append:mender-growfs-data:mender-systemd = " \
     file://mender-client-resize-data-part.sh.in \
     file://mender-grow-data.service \
     file://mender-systemd-growfs-data.service \
 "
 
-FILES:${PN}:append_mender-image_mender-systemd = " \
+FILES:${PN}:append:mender-image:mender-systemd = " \
     ${systemd_unitdir}/system/${MENDER_CLIENT}-data-dir.service \
     ${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/${MENDER_CLIENT}-data-dir.service \
 "
 
-FILES:${PN}:append_mender-growfs-data_mender-systemd = " \
+FILES:${PN}:append:mender-growfs-data:mender-systemd = " \
     ${bindir}/mender-client-resize-data-part \
     ${systemd_unitdir}/system/mender-grow-data.service \
     ${systemd_unitdir}/system/mender-systemd-growfs-data.service \
@@ -90,7 +90,7 @@ FILES:${PN}:append_mender-growfs-data_mender-systemd = " \
     ${systemd_unitdir}/system/data.mount.wants/mender-systemd-growfs-data.service \
 "
 
-FILES:${PN}:append_mender-persist-systemd-machine-id = " \
+FILES:${PN}:append:mender-persist-systemd-machine-id = " \
     ${systemd_unitdir}/system/mender-client-systemd-machine-id.service \
     ${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/mender-client-systemd-machine-id.service \
     ${bindir}/mender-client-set-systemd-machine-id.sh \
@@ -315,13 +315,13 @@ do_install() {
     echo ${MENDER_ROOTFS_PART_B} >> ${D}${sysconfdir}/udev/mount.blacklist.d/mender
 }
 
-do_install:append:class-target_mender-image_mender-systemd() {
+do_install:append:class-target:mender-image:mender-systemd() {
     install -m 644 ${WORKDIR}/mender-client-data-dir.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}-data-dir.service
     install -d -m 755 ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants
     ln -sf ../mender-client-data-dir.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/${MENDER_CLIENT}-data-dir.service
 }
 
-do_install:append:class-target_mender-growfs-data_mender-systemd() {
+do_install:append:class-target:mender-growfs-data:mender-systemd() {
 
     if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
@@ -352,7 +352,7 @@ do_install:append:class-target_mender-growfs-data_mender-systemd() {
     ln -sf ../mender-systemd-growfs-data.service ${D}${systemd_unitdir}/system/data.mount.wants/
 }
 
-do_install:append:class-target_mender-persist-systemd-machine-id() {
+do_install:append:class-target:mender-persist-systemd-machine-id() {
     install -m 644 ${WORKDIR}/mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/
     install -d -m 755 ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants
     ln -sf ../mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -16,11 +16,11 @@ FILES:${PN} = " \
     /data/mender-configure \
 "
 
-FILES:${PN}:append_mender-systemd = " \
+FILES:${PN}:append:mender-systemd = " \
     ${systemd_system_unitdir}/mender-configure-apply-device-config.service \
 "
 
-SYSTEMD_SERVICE:${PN}_mender-systemd = "mender-configure-apply-device-config.service"
+SYSTEMD_SERVICE:${PN}:mender-systemd = "mender-configure-apply-device-config.service"
 
 FILES:${PN}-demo = " \
     ${libdir}/mender-configure/apply-device-config.d/mender-demo-raspberrypi-led \
@@ -56,7 +56,7 @@ EOF
     echo '}' >> ${D}/data/mender-configure/device-config.json
 }
 
-do_install:append_mender-systemd() {
+do_install:append:mender-systemd() {
     oe_runmake \
         -C ${S} \
         DESTDIR=${D} \

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -20,5 +20,5 @@ MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT ?= "608"
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_FEATURES += "splash"
 
-LAYERSERIES_COMPAT_mender-demo = "dunfell hardknott"
+LAYERSERIES_COMPAT_mender-demo = "dunfell hardknott honister"
 LAYERDEPENDS_mender-demo = "mender openembedded-layer"

--- a/meta-mender-demo/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-mender-demo/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,4 +1,4 @@
 # Pretty insecure to use the same SSH key on all devices, even for a demo image,
 # but we need it for performance reasons on QEMU. So restrict it to QEMU.
-RDEPENDS:${PN}-sshd:append_vexpress-qemu = " ssh-demo-keys"
-RDEPENDS:${PN}-sshd:append_vexpress-qemu-flash = " ssh-demo-keys"
+RDEPENDS:${PN}-sshd:append:vexpress-qemu = " ssh-demo-keys"
+RDEPENDS:${PN}-sshd:append:vexpress-qemu-flash = " ssh-demo-keys"

--- a/meta-mender-demo/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-mender-demo/recipes-core/base-files/base-files_%.bbappend
@@ -1,6 +1,6 @@
 MENDER_DEMO_HOST_IP_ADDRESS ?= ""
 
-do_install:append_mender-image() {
+do_install:append:mender-image() {
     if [ -n "${MENDER_DEMO_HOST_IP_ADDRESS}" ]; then
         echo "${MENDER_DEMO_HOST_IP_ADDRESS} docker.mender.io s3.docker.mender.io" >> ${D}${sysconfdir}/hosts
     fi

--- a/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/meta-mender-demo/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -1,13 +1,13 @@
-RDEPENDS:${PN}:append_mender-client-install = " hello-mender boot-script"
+RDEPENDS:${PN}:append:mender-client-install = " hello-mender boot-script"
 
 # This is for tests. Without the tests creating a special file, the service will
 # do nothing.
-RDEPENDS:${PN}:append_mender-client-install = "${@bb.utils.contains_any('MENDER_MACHINE', 'vexpress-qemu vexpress-qemu-flash qemux86-64 qemuxu86', ' mender-reboot-detector', '', d)}"
+RDEPENDS:${PN}:append:mender-client-install = "${@bb.utils.contains_any('MENDER_MACHINE', 'vexpress-qemu vexpress-qemu-flash qemux86-64 qemuxu86', ' mender-reboot-detector', '', d)}"
 
 # In our demo package we use busybox, which is built in a generic, non-Yocto
 # way. Therefore we need LSB support so that the dynamic linker is found.
 # Specifically, this creates the symlink /lib64 -> /lib.
-RDEPENDS:${PN}:append_mender-client-install = " lsb-ld"
+RDEPENDS:${PN}:append:mender-client-install = " lsb-ld"
 
 def maybe_mender_connect(d):
     pref = d.getVar('PREFERRED_VERSION:pn-mender-client')
@@ -30,4 +30,4 @@ def maybe_mender_configure(d):
         return " mender-configure mender-configure-demo mender-configure-scripts"
 
 # Install Mender add-ons, but only if the client is recent enough.
-RDEPENDS:${PN}:append_mender-image = "${@maybe_mender_connect(d)}${@maybe_mender_configure(d)}"
+RDEPENDS:${PN}:append:mender-image = "${@maybe_mender_connect(d)}${@maybe_mender_configure(d)}"

--- a/meta-mender-demo/recipes-core/psplash/psplash_git.bbappend
+++ b/meta-mender-demo/recipes-core/psplash/psplash_git.bbappend
@@ -1,9 +1,9 @@
-FILESEXTRAPATHS:prepend_mender-client-install := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:mender-client-install := "${THISDIR}/files:"
 
-SRC_URI:append_mender-client-install = " \
+SRC_URI:append:mender-client-install = " \
 	file://mender.io.png \
 "
 
 # Explicitly set to all arch/machines, otherwise breaks on raspberrypi builds
 # with error "Nothing RPROVIDES 'psplash-raspberrypi'"
-SPLASH_IMAGES_mender-client-install:all = "file://mender.io.png;outsuffix=default"
+SPLASH_IMAGES:mender-client-install:all = "file://mender.io.png;outsuffix=default"

--- a/meta-mender-demo/recipes-core/systemd-conf/systemd-conf_%.bbappend
+++ b/meta-mender-demo/recipes-core/systemd-conf/systemd-conf_%.bbappend
@@ -1,16 +1,16 @@
-FILESEXTRAPATHS:prepend_mender-systemd := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:mender-systemd := "${THISDIR}/files:"
 
-SRC_URI:append_mender-systemd = " \
+SRC_URI:append:mender-systemd = " \
     file://eth.network \
     file://en.network \
 "
 
-FILES:${PN}:append_mender-systemd = " \
+FILES:${PN}:append:mender-systemd = " \
     ${sysconfdir}/systemd/network/eth.network \
     ${sysconfdir}/systemd/network/en.network \
 "
 
-do_install:append_mender-systemd() {
+do_install:append:mender-systemd() {
         install -d ${D}${sysconfdir}/systemd/network
         install -m 0755 ${WORKDIR}/eth.network ${D}${sysconfdir}/systemd/network
         install -m 0755 ${WORKDIR}/en.network ${D}${sysconfdir}/systemd/network

--- a/meta-mender-demo/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/meta-mender-demo/recipes-mender/mender-client/mender-client_%.bbappend
@@ -1,14 +1,14 @@
-MENDER_UPDATE_POLL_INTERVAL_SECONDS_mender-client-install = "5"
-MENDER_INVENTORY_POLL_INTERVAL_SECONDS_mender-client-install = "5"
-MENDER_RETRY_POLL_INTERVAL_SECONDS_mender-client-install = "30"
+MENDER_UPDATE_POLL_INTERVAL_SECONDS:mender-client-install = "5"
+MENDER_INVENTORY_POLL_INTERVAL_SECONDS:mender-client-install = "5"
+MENDER_RETRY_POLL_INTERVAL_SECONDS:mender-client-install = "30"
 
-MENDER_UPDATE_CONTROL_MAP_EXPIRATION_TIME_SECONDS_mender-client-install = "90"
-MENDER_UPDATE_CONTROL_MAP_BOOT_EXPIRATION_TIME_SECONDS_mender-client-install = "45"
+MENDER_UPDATE_CONTROL_MAP_EXPIRATION_TIME_SECONDS:mender-client-install = "90"
+MENDER_UPDATE_CONTROL_MAP_BOOT_EXPIRATION_TIME_SECONDS:mender-client-install = "45"
 
 # Depend on mender-server-certificate, which on demo layer installs the demo cert
 DEPENDS:append:class-target = " mender-server-certificate"
 RDEPENDS:${PN}:append:class-target = " mender-server-certificate"
 
-do_compile:prepend_mender-client-install() {
+do_compile:prepend:mender-client-install() {
   bbwarn "You are building with the mender-demo layer, which is not intended for production use"
 }

--- a/meta-mender-demo/recipes-sato/packagegroups/packagegroup-core-x11-sato.bbappend
+++ b/meta-mender-demo/recipes-sato/packagegroups/packagegroup-core-x11-sato.bbappend
@@ -1,1 +1,1 @@
-NETWORK_MANAGER_mender-image = "systemd"
+NETWORK_MANAGER:mender-image = "systemd"

--- a/meta-mender-qemu/classes/vexpress-nor_image.bbclass
+++ b/meta-mender-qemu/classes/vexpress-nor_image.bbclass
@@ -1,7 +1,7 @@
 inherit image_types
 
 # we need ubimg to be present
-IMAGE_TYPEDEP_vexpress-nor = "mtdimg"
+IMAGE_TYPEDEP:vexpress-nor = "mtdimg"
 
 IMAGE_CMD:vexpress-nor() {
     set -ex

--- a/meta-mender-qemu/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_%.bbappend
+++ b/meta-mender-qemu/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_%.bbappend
@@ -1,3 +1,3 @@
-FILESEXTRAPATHS:prepend_mender-client-install := "${THISDIR}/files:"
-SRC_URI:append:arm_mender-client-install = " file://02_qemu_console_arm_grub.cfg;subdir=git"
-SRC_URI:append:x86-64_mender-client-install = " file://02_qemu_console_x86_grub.cfg;subdir=git"
+FILESEXTRAPATHS:prepend:mender-client-install := "${THISDIR}/files:"
+SRC_URI:append:arm:mender-client-install = " file://02_qemu_console_arm_grub.cfg;subdir=git"
+SRC_URI:append:x86-64:mender-client-install = " file://02_qemu_console_x86_grub.cfg;subdir=git"

--- a/meta-mender-qemu/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/meta-mender-qemu/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,2 +1,2 @@
 # We use U-Boot as a UEFI provider on QEMU.
-RDEPENDS:${PN}:append_mender-grub:arm = " u-boot"
+RDEPENDS:${PN}:append:mender-grub:arm = " u-boot"

--- a/meta-mender-qemu/recipes-bsp/grub/grub_%.bbappend
+++ b/meta-mender-qemu/recipes-bsp/grub/grub_%.bbappend
@@ -1,6 +1,6 @@
-FILESEXTRAPATHS:prepend_mender-grub := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:mender-grub := "${THISDIR}/files:"
 
-SRC_URI:append_mender-grub = " file://01_mender_serial_console_grub.cfg"
+SRC_URI:append:mender-grub = " file://01_mender_serial_console_grub.cfg"
 
 # We need these because we use QEMU with -nographic argument.
-GRUB_BUILDIN:append_mender-bios = " serial terminal"
+GRUB_BUILDIN:append:mender-bios = " serial terminal"

--- a/meta-mender-qemu/recipes-bsp/u-boot/u-boot-vexpress-qemu.inc
+++ b/meta-mender-qemu/recipes-bsp/u-boot/u-boot-vexpress-qemu.inc
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/patches:${THISDIR}/files:"
 
-SRC_URI:append_vexpress-qemu-flash = " file://0001-vexpress-qemu-specific-fixes-for-Flash.patch"
-SRC_URI:append_vexpress-qemu-flash = " file://0001-Revert-cfi_flash-Fix-detection-of-8-bit-bus-flash-de.patch"
+SRC_URI:append:vexpress-qemu-flash = " file://0001-vexpress-qemu-specific-fixes-for-Flash.patch"
+SRC_URI:append:vexpress-qemu-flash = " file://0001-Revert-cfi_flash-Fix-detection-of-8-bit-bus-flash-de.patch"

--- a/meta-mender-qemu/recipes-bsp/u-boot/u-boot_2021.07.bbappend
+++ b/meta-mender-qemu/recipes-bsp/u-boot/u-boot_2021.07.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/patches:"
 
-SRC_URI:append:arm_mender-grub = " file://0001-efi_loader-Omit-memory-with-no-map-when-returning-me.patch"
+SRC_URI:append:arm:mender-grub = " file://0001-efi_loader-Omit-memory-with-no-map-when-returning-me.patch"

--- a/meta-mender-qemu/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-mender-qemu/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,4 +1,4 @@
-do_install:append_mender-systemd () {
+do_install:append:mender-systemd () {
 	install -d ${D}${systemd_unitdir}/system/network.target.wants
 	ln -s ../sshdgenkeys.service ${D}${systemd_unitdir}/system/network.target.wants/
 }

--- a/meta-mender-qemu/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/meta-mender-qemu/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,5 +1,5 @@
 
-do_install:append_mender-client-install () {
+do_install:append:mender-client-install () {
 	# see MEN-3730, this is to align with the current default settings on raspbian
 	cat >> "${D}${sysconfdir}/ssl/openssl.cnf" <<EOF
 [system_default_sect]

--- a/meta-mender-qemu/recipes-extended/sudo/sudo_%.bbappend
+++ b/meta-mender-qemu/recipes-extended/sudo/sudo_%.bbappend
@@ -6,9 +6,8 @@ do_install:append:qemux86-64 () {
     ln -s /data/usr/bin/sudo ${D}/usr/bin/sudo
 }
 
-do_install:append_vexpress-qemu () {
+do_install:append:vexpress-qemu () {
     mkdir -p ${D}/data/usr/bin
     mv ${D}/usr/bin/sudo ${D}/data/usr/bin/
     ln -s /data/usr/bin/sudo ${D}/usr/bin/sudo
 }
-

--- a/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/meta-mender-qemu/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,14 +1,14 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 # Use custom defconfig in order to enable use of the vexpress model.
-SRC_URI:append_vexpress-qemu = " file://defconfig \
+SRC_URI:append:vexpress-qemu = " file://defconfig \
                                 file://vexpress-qemu-standard.scc \
                                 file://reduce-memory-to-256m.patch \
-                               " 
+                               "
 COMPATIBLE_MACHINE_vexpress-qemu = "vexpress-qemu"
 
 # same config for vexpress-qemu-flash
-SRC_URI:append_vexpress-qemu-flash = " file://defconfig \
+SRC_URI:append:vexpress-qemu-flash = " file://defconfig \
                                        file://vexpress-qemu-standard.scc \
                                        file://reduce-memory-to-256m.patch \
                                        "
@@ -20,9 +20,9 @@ COMPATIBLE_MACHINE_vexpress-qemu-flash = "vexpress-qemu-flash"
 # at the time of writing. Rather than dig into this we will just remove this
 # patch for now. This can probably be removed later when upstream has fixed this
 # problem. (July 2018)
-KERNEL_FEATURES:remove_vexpress-qemu = "features/kernel-sample/kernel-sample.scc"
-KERNEL_FEATURES:remove_vexpress-qemu-flash = "features/kernel-sample/kernel-sample.scc"
+KERNEL_FEATURES:remove:vexpress-qemu = "features/kernel-sample/kernel-sample.scc"
+KERNEL_FEATURES:remove:vexpress-qemu-flash = "features/kernel-sample/kernel-sample.scc"
 
 # This doesn't appear in our config so remove it to avoid spurious warnings
-KERNEL_FEATURES:remove_vexpress-qemu = "features/drm-bochs/drm-bochs.scc features/scsi/scsi-debug.scc"
-KERNEL_FEATURES:remove_vexpress-qemu-flash = "features/drm-bochs/drm-bochs.scc features/scsi/scsi-debug.scc"
+KERNEL_FEATURES:remove:vexpress-qemu = "features/drm-bochs/drm-bochs.scc features/scsi/scsi-debug.scc"
+KERNEL_FEATURES:remove:vexpress-qemu-flash = "features/drm-bochs/drm-bochs.scc features/scsi/scsi-debug.scc"

--- a/meta-mender-qemu/recipes-mender/mender-client/mender-client-test-files.inc
+++ b/meta-mender-qemu/recipes-mender/mender-client/mender-client-test-files.inc
@@ -7,21 +7,21 @@
 #           for the OpenSSL to load the lib and access the key from the HSM
 # * opensc: pkcs11-tool for initialization of token
 # * gnutls-bin: provides p11tool for getting the contents of the token
-DEPENDS:append_mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11"
-RDEPENDS:${PN}:append_mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11 gnutls-bin"
+DEPENDS:append:mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11"
+RDEPENDS:${PN}:append:mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11 gnutls-bin"
 
 # Needed for the TestFaultTolerance tests in the integration repository.
-RDEPENDS:${PN}:append_mender-image:qemuall = " \
+RDEPENDS:${PN}:append:mender-image:qemuall = " \
     kernel-module-ipt-reject \
     kernel-module-ts-bm \
     kernel-module-xt-string \
 "
 
 # Used as a rootfs-image replacement when testing update modules.
-FILES:${PN}:append_mender-image:qemuall = " ${sysconfdir}/mender/rootfs-image-v2.conf \
+FILES:${PN}:append:mender-image:qemuall = " ${sysconfdir}/mender/rootfs-image-v2.conf \
                                             ${datadir}/mender/modules/v3/rootfs-image-v2"
 
-do_compile:append_mender-image:qemuall() {
+do_compile:append:mender-image:qemuall() {
     if ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'true', 'false', d)}; then
         cat > ${WORKDIR}/rootfs-image-v2.conf <<EOF
 MENDER_ROOTFS_PART_A="${MENDER_ROOTFS_PART_A}"
@@ -30,7 +30,7 @@ EOF
     fi
 }
 
-do_install:append_mender-image:qemuall() {
+do_install:append:mender-image:qemuall() {
     if ${@bb.utils.contains('PACKAGECONFIG', 'modules', 'true', 'false', d)}; then
         install -m 755 -d ${D}${datadir}/mender/modules/v3
         install -m 755 ${B}/src/${GO_IMPORT}/tests/rootfs-image-v2 ${D}${datadir}/mender/modules/v3/

--- a/meta-mender-qemu/recipes-support/libp11/libp11_0.4.%.bbappend
+++ b/meta-mender-qemu/recipes-support/libp11/libp11_0.4.%.bbappend
@@ -1,4 +1,3 @@
-DEPENDS:append_mender-client-install = " p11-kit"
+DEPENDS:append:mender-client-install = " p11-kit"
 
-SRCREV_mender-client-install = "e1210903291b1de9eabcad26e740a4b2fbcca692"
-
+SRCREV:mender-client-install = "e1210903291b1de9eabcad26e740a4b2fbcca692"

--- a/meta-mender-qemu/recipes-support/rng-tools/rng-tools_%.bbappend
+++ b/meta-mender-qemu/recipes-support/rng-tools/rng-tools_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI:append_vexpress-qemu = " file://restart-rngd.diff;patchdir=${WORKDIR}"
-SRC_URI:append_vexpress-qemu-flash = " file://restart-rngd.diff;patchdir=${WORKDIR}"
+SRC_URI:append:vexpress-qemu = " file://restart-rngd.diff;patchdir=${WORKDIR}"
+SRC_URI:append:vexpress-qemu-flash = " file://restart-rngd.diff;patchdir=${WORKDIR}"

--- a/meta-mender-raspberrypi-demo/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-mender-raspberrypi-demo/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,13 +1,13 @@
-FILESEXTRAPATHS:prepend_mender-systemd := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:mender-systemd := "${THISDIR}/files:"
 
-SRC_URI:append_mender-systemd = " file://wpa_supplicant-wlan0.conf"
+SRC_URI:append:mender-systemd = " file://wpa_supplicant-wlan0.conf"
 
-FILES:${PN}:append_mender-systemd = " ${sysconfdir}/wpa_supplicant/wpa_supplicant-wlan0.conf"
+FILES:${PN}:append:mender-systemd = " ${sysconfdir}/wpa_supplicant/wpa_supplicant-wlan0.conf"
 
 MENDER_DEMO_WIFI_SSID ?= "ssid"
 MENDER_DEMO_WIFI_PASSKEY ?= "password"
 
-do_install:append_mender-systemd() {
+do_install:append:mender-systemd() {
 
   install -d ${D}${sysconfdir}/wpa_supplicant
 

--- a/meta-mender-raspberrypi-demo/recipes-core/systemd-conf/systemd-conf_%.bbappend
+++ b/meta-mender-raspberrypi-demo/recipes-core/systemd-conf/systemd-conf_%.bbappend
@@ -1,12 +1,12 @@
-FILESEXTRAPATHS:prepend_mender-systemd := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:mender-systemd := "${THISDIR}/files:"
 
-SRC_URI:append_mender-systemd = " file://wireless.network"
+SRC_URI:append:mender-systemd = " file://wireless.network"
 
-FILES:${PN}:append_mender-systemd = " \
+FILES:${PN}:append:mender-systemd = " \
     ${sysconfdir}/systemd/network/wireless.network \
 "
 
-do_install:append_mender-systemd() {
+do_install:append:mender-systemd() {
         install -d ${D}${sysconfdir}/systemd/network
         install -m 0755 ${WORKDIR}/wireless.network ${D}${sysconfdir}/systemd/network
 }

--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS:prepend_rpi_mender-client-install := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend:rpi:mender-client-install := "${THISDIR}/files:"

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot-raspberrypi.inc
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS:prepend_rpi := "${THISDIR}/patches:"
+FILESEXTRAPATHS:prepend:rpi := "${THISDIR}/patches:"
 
 BOOTENV_SIZE_rpi ?= "0x4000"
 
@@ -6,7 +6,7 @@ BOOTENV_SIZE_rpi ?= "0x4000"
 # use of boot.scr and cmdline.txt.
 MENDER_UBOOT_AUTO_CONFIGURE_rpi = "0"
 
-SRC_URI:append_rpi_mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
+SRC_URI:append:rpi:mender-uboot = "${@bb.utils.contains('MENDER_UBOOT_AUTO_CONFIGURE', \
                                                         '1', \
                                                         '', \
                                                         ' file://0001-configs-rpi-enable-mender-requirements.patch \

--- a/meta-mender-raspberrypi/recipes-mender/mender-configure/mender-configure_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-mender/mender-configure/mender-configure_%.bbappend
@@ -1,4 +1,4 @@
-do_install:append_rpi() {
+do_install:append:rpi() {
     # Insert key.
     sed -i -e '1s/$/\n  "mender-demo-raspberrypi-led": "mmc0",/' ${D}/data/mender-configure/device-config.json
 }

--- a/tests/meta-mender-beaglebone-yocto-ci/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/tests/meta-mender-beaglebone-yocto-ci/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/patches:"
 
-SRC_URI:append_mender-testing-enabled = " file://reenable_uenvcmd.patch"
+SRC_URI:append:mender-testing-enabled = " file://reenable_uenvcmd.patch"

--- a/tests/meta-mender-beaglebone-yocto-ci/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/tests/meta-mender-beaglebone-yocto-ci/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -1,3 +1,3 @@
-RDEPENDS:${PN}:append_mender-testing-enabled = " \
+RDEPENDS:${PN}:append:mender-testing-enabled = " \
     mender-qa \
     "

--- a/tests/meta-mender-beaglebone-yocto-ci/recipes-mender/mender-qa/mender-qa.bbappend
+++ b/tests/meta-mender-beaglebone-yocto-ci/recipes-mender/mender-qa/mender-qa.bbappend
@@ -1,14 +1,14 @@
-PACKAGES:append_mender-testing-enabled = " rssh-tunnel"
-FILESEXTRAPATHS:prepend_mender-testing-enabled := "${THISDIR}/files/beagleboneblack/:${THISDIR}/files/:"
+PACKAGES:append:mender-testing-enabled = " rssh-tunnel"
+FILESEXTRAPATHS:prepend:mender-testing-enabled := "${THISDIR}/files/beagleboneblack/:${THISDIR}/files/:"
 
-SRC_URI:append_mender-testing-enabled = " \
+SRC_URI:append:mender-testing-enabled = " \
                    file://rssh.service \
                    file://id_rsa \
                    file://id_rsa.pub \
                    file://authorized_keys \
                    file://uEnv.txt"
 
-FILES:${PN}:append_mender-testing-enabled = " \
+FILES:${PN}:append:mender-testing-enabled = " \
                 ${systemd_unitdir}/system/rssh.service \
                 ${systemd_unitdir}/system/network.target.wants \
                 ${datadir}/mender-qa/rssh \
@@ -19,7 +19,7 @@ FILES:${PN}:append_mender-testing-enabled = " \
                 /home/root/.ssh \
                 /home/root/.ssh/authorized_keys"
 
-do_install:append_mender-testing-enabled() {
+do_install:append:mender-testing-enabled() {
     install -m 0644 -t ${D}${datadir}/mender-qa ${WORKDIR}/uEnv.txt
 
     install -d ${D}${systemd_unitdir}/system/network.target.wants

--- a/tests/meta-mender-beaglebone-yocto-ci/recipes-mender/mender-qa/openssh_%.bbappend
+++ b/tests/meta-mender-beaglebone-yocto-ci/recipes-mender/mender-qa/openssh_%.bbappend
@@ -1,3 +1,3 @@
-do_install:append_mender-testing-enabled () {
+do_install:append:mender-testing-enabled () {
     sed -i 's/^[#[:space:]]*PasswordAuthentication.*/PasswordAuthentication no/' ${D}${sysconfdir}/ssh/sshd_config
 }

--- a/tests/meta-mender-ci/recipes-core/base-files/base-files_%.bbappend
+++ b/tests/meta-mender-ci/recipes-core/base-files/base-files_%.bbappend
@@ -1,4 +1,4 @@
-do_install:append_mender-testing-enabled() {
+do_install:append:mender-testing-enabled() {
     # Enable /etc/issue to be changed from R/O rootfs.
     mkdir -p ${D}/data${sysconfdir}
     mv ${D}${sysconfdir}/issue ${D}/data${sysconfdir}/issue

--- a/tests/meta-mender-ci/recipes-core/os-release/os-release.bbappend
+++ b/tests/meta-mender-ci/recipes-core/os-release/os-release.bbappend
@@ -1,9 +1,9 @@
-FILES:${PN}:append_mender-testing-enabled = " /data${nonarch_libdir}/os-release /data${sysconfdir}/os-release"
-FILES:${PN}-staticdev:remove_mender-testing-enabled = "${nonarch_libdir}/os-release/*.a"
-FILES:${PN}-dev:remove_mender-testing-enabled = "${nonarch_libdir}/os-release/*.la"
-FILES:${PN}:remove_mender-testing-enabled = "${nonarch_libdir}/os-release/*"
+FILES:${PN}:append:mender-testing-enabled = " /data${nonarch_libdir}/os-release /data${sysconfdir}/os-release"
+FILES:${PN}-staticdev:remove:mender-testing-enabled = "${nonarch_libdir}/os-release/*.a"
+FILES:${PN}-dev:remove:mender-testing-enabled = "${nonarch_libdir}/os-release/*.la"
+FILES:${PN}:remove:mender-testing-enabled = "${nonarch_libdir}/os-release/*"
 
-do_install:append_mender-testing-enabled() {
+do_install:append:mender-testing-enabled() {
     # Enable os-release to be changed from a R/O rootfs.
 
     mkdir -p ${D}/data${sysconfdir}

--- a/tests/meta-mender-ci/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/tests/meta-mender-ci/recipes-mender/mender-client/mender-client_%.bbappend
@@ -9,7 +9,7 @@ do_install_ptest_base() {
 }
 
 # Produce custom level logs when MENDER_CI_LOGLEVEL is enabled
-do_install:append:class-target_mender-image_mender-systemd() {
+do_install:append:class:target_mender-image_mender-systemd() {
     if ${@'true' if d.getVar('MENDER_CI_LOGLEVEL') else 'false'}; then
         sed -i "s|ExecStart=.*|ExecStart=/usr/bin/mender --log-level ${MENDER_CI_LOGLEVEL} daemon|" \
             ${D}/${systemd_unitdir}/system/${MENDER_CLIENT}.service

--- a/tests/meta-mender-ci/recipes-mender/mender-connect/mender-connect_%.bbappend
+++ b/tests/meta-mender-ci/recipes-mender/mender-connect/mender-connect_%.bbappend
@@ -9,7 +9,7 @@ do_install_ptest_base() {
 }
 
 # Produce custom level logs when MENDER_CI_LOGLEVEL is enabled
-do_install:append:class-target_mender-image_mender-systemd() {
+do_install:append:class-target:mender-image:mender-systemd() {
     if ${@'true' if d.getVar('MENDER_CI_LOGLEVEL') else 'false'}; then
         local logging_flag=""
         if [ "${MENDER_CI_LOGLEVEL}" = "debug" ]; then

--- a/tests/meta-mender-ci/recipes-testing/mender-artifact-coverage/mender-artifact_%.bbappend
+++ b/tests/meta-mender-ci/recipes-testing/mender-artifact-coverage/mender-artifact_%.bbappend
@@ -1,6 +1,6 @@
-SUMMARY:append_mender-testing-enabled = ": Build mender-artifact with coverage recording enabled"
+SUMMARY:append:mender-testing-enabled = ": Build mender-artifact with coverage recording enabled"
 
-DEPENDS:append_mender-testing-enabled = " gobinarycoverage-native rsync-native"
+DEPENDS:append:mender-testing-enabled = " gobinarycoverage-native rsync-native"
 
 do_instrument_mender-artifact[dirs] =+ "${GOTMPDIR}"
 do_instrument_mender-artifact[doc] = "Modifies the mender-artifact source to enable coverage analysis"
@@ -10,7 +10,7 @@ do_instrument_artifact () {
     oe_runmake instrument-binary
 }
 
-do_configure:prepend_mender-testing-enabled () {
+do_configure:prepend:mender-testing-enabled () {
     # Remove all the src present in build if it is not a symbolic link to ${S}
     if [ -d ${B}src ]; then
         rm -rf ${B}src
@@ -18,7 +18,7 @@ do_configure:prepend_mender-testing-enabled () {
 
 }
 
-do_configure:append_mender-testing-enabled () {
+do_configure:append:mender-testing-enabled () {
     # Remove the symbolic link created by go.bbclass in do_configure
     if [ -h ${B}src ]; then
         rm ${B}src

--- a/tests/meta-mender-ci/recipes-testing/mender-coverage-client/mender-client_%.bbappend
+++ b/tests/meta-mender-ci/recipes-testing/mender-coverage-client/mender-client_%.bbappend
@@ -1,6 +1,6 @@
-SUMMARY:append_mender-testing-enabled = ": Build a Mender client which records coverage during its invocation"
+SUMMARY:append:mender-testing-enabled = ": Build a Mender client which records coverage during its invocation"
 
-DEPENDS:append_mender-testing-enabled = " gobinarycoverage-native rsync-native"
+DEPENDS:append:mender-testing-enabled = " gobinarycoverage-native rsync-native"
 
 do_instrument_client[dirs] =+ "${GOTMPDIR}"
 do_instrument_client[doc] = "Modifies the Mender client source to enable coverage analysis"
@@ -14,7 +14,7 @@ do_instrument_client:class-native() {
     true
 }
 
-do_configure:prepend_mender-testing-enabled () {
+do_configure:prepend:mender-testing-enabled () {
     # Remove all the src present in build if it is not a symbolic link to ${S}
     if [ -d ${B}src ]; then
         rm -rf ${B}src
@@ -22,7 +22,7 @@ do_configure:prepend_mender-testing-enabled () {
 
 }
 
-do_configure:append_mender-testing-enabled () {
+do_configure:append:mender-testing-enabled () {
     # Remove the symbolic link created by go.bbclass in do_configure
     if [ -h ${B}src ]; then
         rm ${B}src

--- a/tests/meta-mender-ci/recipes-testing/read-only-rootfs/mender-client_%.bbappend
+++ b/tests/meta-mender-ci/recipes-testing/read-only-rootfs/mender-client_%.bbappend
@@ -1,6 +1,6 @@
-FILES:${PN}:append_mender-testing-enabled = " /data/etc/mender "
+FILES:${PN}:append:mender-testing-enabled = " /data/etc/mender "
 # Run after all mender recipes are finished.
-do_install:append:class-target_mender-testing-enabled() {
+do_install:append:class-target:mender-testing-enabled() {
     mkdir -p ${D}/data/etc/mender
     mv ${D}/etc/mender/mender.conf ${D}/data/etc/mender
     ln -s /data/etc/mender/mender.conf ${D}/etc/mender/mender.conf

--- a/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/u-boot-testing_%.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/u-boot-testing_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS:${PN}:append_rpi = " rpi-u-boot-scr"
+RDEPENDS:${PN}:append:rpi = " rpi-u-boot-scr"

--- a/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/patches:"
 
 # Revert patch which breaks USB storage on Raspberry Pi.
-SRC_URI:append_mender-testing-enabled = " file://0001-Revert-usb-Only-get-64-bytes-device-descriptor-for-f.patch"
+SRC_URI:append:mender-testing-enabled = " file://0001-Revert-usb-Only-get-64-bytes-device-descriptor-for-f.patch"

--- a/tests/meta-mender-raspberrypi3-ci/recipes-core/packagegroups/packagegroup-core-boot.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-core/packagegroups/packagegroup-core-boot.bbappend
@@ -1,3 +1,3 @@
-RDEPENDS:${PN}:append_mender-testing-enabled = " \
+RDEPENDS:${PN}:append:mender-testing-enabled = " \
     mender-qa \
     "

--- a/tests/meta-mender-raspberrypi3-ci/recipes-mender/mender-qa/mender-qa.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-mender/mender-qa/mender-qa.bbappend
@@ -1,13 +1,13 @@
-PACKAGES:append_mender-testing-enabled = " rssh-tunnel"
-FILESEXTRAPATHS:prepend_mender_testing-enabled := "${THISDIR}/files/raspberrypi3:${THISDIR}/files/:"
+PACKAGES:append:mender-testing-enabled = " rssh-tunnel"
+FILESEXTRAPATHS:prepend:mender_testing-enabled := "${THISDIR}/files/raspberrypi3:${THISDIR}/files/:"
 
-SRC_URI:append_mender-testing-enabled = " \
+SRC_URI:append:mender-testing-enabled = " \
                    file://rssh.service \
                    file://id_rsa \
                    file://id_rsa.pub \
                    file://authorized_keys"
 
-FILES:${PN}:append_mender-testing-enabled = " \
+FILES:${PN}:append:mender-testing-enabled = " \
                 ${systemd_unitdir}/system/rssh.service \
                 ${systemd_unitdir}/system/network.target.wants \
                 ${datadir}/mender-qa/rssh \
@@ -18,7 +18,7 @@ FILES:${PN}:append_mender-testing-enabled = " \
                 /home/root/.ssh \
                 /home/root/.ssh/authorized_keys"
 
-do_install:append_mender-testing-enabled() {
+do_install:append:mender-testing-enabled() {
     install -d ${D}${systemd_unitdir}/system/network.target.wants
     install -t ${D}${systemd_unitdir}/system ${WORKDIR}/rssh.service
     ln -sf ../rssh.service ${D}${systemd_unitdir}/system/network.target.wants/
@@ -32,4 +32,3 @@ do_install:append_mender-testing-enabled() {
     install -d ${D}/home/root/.ssh/
     install -t ${D}/home/root/.ssh/ ${WORKDIR}/authorized_keys
 }
-

--- a/tests/meta-mender-raspberrypi3-ci/recipes-mender/mender-qa/openssh_%.bbappend
+++ b/tests/meta-mender-raspberrypi3-ci/recipes-mender/mender-qa/openssh_%.bbappend
@@ -1,3 +1,3 @@
-do_install:append_mender-testing-enabled () {
+do_install:append:mender-testing-enabled () {
     sed -i 's/^[#[:space:]]*PasswordAuthentication.*/PasswordAuthentication no/' ${D}${sysconfdir}/ssh/sshd_config
 }


### PR DESCRIPTION
# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

The following things have been done to support `honister`:
* Convert layer override to new syntax format
* Fix `mender_vars_handler()` to handle new syntax changes
* Update `layer.conf`
*  To be in-line with the new Yocto version `honister`, the systemd-boot recipe requires an update with the latest patch due to
`efivar_set_time_used` API incompatibility.