### PR TITLE
lsb-ld: Avoid lib64/*.a issues on multilib systems

### DIFF
--- a/meta-mender-core/recipes-core/lsb-ld/lsb-ld.bb
+++ b/meta-mender-core/recipes-core/lsb-ld/lsb-ld.bb
@@ -12,5 +12,8 @@ ALLOW_EMPTY_${PN} = "1"
 FILES_${PN}_x86-64 = "/lib64"
 
 do_install_x86-64() {
-    ln -sf lib ${D}/lib64
+    # Avoid issues with ./lib64/*.a on multilib systems
+    if ${@bb.utils.contains('MULTILIBS','multilib:lib32','false','true',d)}; then
+        ln -sf lib ${D}/lib64
+    fi
 }


### PR DESCRIPTION
Fix do_install for x86-64 to avoid issues with ./lib64/*.a and
missing arent directory structure during do_package on multilib
systems.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
