### PR TITLE
mender-gateway: Fix do_version_check

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
@@ -21,8 +21,8 @@ S = "${WORKDIR}/mender-gateway-${PV}"
 
 do_version_check() {
     if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
-        if ! strings ${WORKDIR}/${SUB_FOLDER}/mender-gateway | fgrep -q "${PN} ${PV}"; then
-            bbfatal "String '${PN} ${PV}' not found in binary. Is it the correct version? Check with --version. Possible candidates: $(strings ${WORKDIR}/${SUB_FOLDER}/mender-gateway | grep '${PN} [a-f0-9]')"
+        if ! strings ${S}/${SUB_FOLDER}/mender-gateway | grep -q "^${PV}$"; then
+            bbfatal "String '${PV}' not found in binary. Is it the correct version? Check with --version."
         fi
     fi
 }


### PR DESCRIPTION
Two fixes:
* The source file was incorrect (use S instead of WORKDIR)
* The string "mender-gateway <PV>" is not present on the go binary, look
  look for only the version instead.