### PR TITLE
MEN-5475: meta-mender-demo: Add demo functionality for mender-gateway

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
@@ -37,14 +37,6 @@ SYSTEMD_SERVICE_${PN}_mender-systemd = "mender-gateway.service"
 do_install() {
     install -d -m 755 ${D}${bindir}
     install -m 755 ${S}/${SUB_FOLDER}/mender-gateway ${D}${bindir}/mender-gateway
-
-    # install config file if provided
-    if [ -f ${WORKDIR}/mender-gateway.conf ]; then
-        install -d -m 755 ${D}/${sysconfdir}/mender
-        install -m 0600 ${WORKDIR}/mender-gateway.conf ${D}/${sysconfdir}/mender/mender-gateway.conf
-    else
-        bbwarn "No mender-gateway.conf found in SRC_URI, no mender-gateway.conf installed. The gateway will run with the default parameters"
-    fi
 }
 
 do_install_append_mender-systemd() {

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -10,6 +10,8 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILES_DYNAMIC += "\
   mender-commercial:${LAYERDIR}/mender-commercial/mender-monitor/mender-monitor*.bbappend \
+  mender-commercial:${LAYERDIR}/mender-commercial/mender-gateway/mender-gateway*.bbappend \
+  mender-commercial:${LAYERDIR}/mender-commercial/images/mender-gateway-image-full-cmdline.bbappend \
 "
 
 BBFILE_COLLECTIONS += "mender-demo"

--- a/meta-mender-demo/mender-commercial/images/mender-gateway-image-full-cmdline.bbappend
+++ b/meta-mender-demo/mender-commercial/images/mender-gateway-image-full-cmdline.bbappend
@@ -1,0 +1,1 @@
+IMAGE_INSTALL_append = " mender-gateway-doc"

--- a/meta-mender-demo/mender-commercial/mender-gateway/mender-gateway_%.bbappend
+++ b/meta-mender-demo/mender-commercial/mender-gateway/mender-gateway_%.bbappend
@@ -1,0 +1,14 @@
+
+FILES_${PN}-doc_append = " \
+    ${docdir}/mender-gateway/examples \
+    ${sysconfdir}/mender/mender-gateway.conf \
+"
+
+def examples_dir_from_s_dir(d, s):
+    return s.replace("mender-gateway-", "mender-gateway-examples-")
+
+EXAMPLES = "${@examples_dir_from_s_dir(d, '${S}')}"
+
+do_install_append() {
+    cp -R --no-dereference --preserve=mode,links -v ${EXAMPLES}/* ${D}
+}

--- a/meta-mender-qemu/scripts/docker/entrypoint.sh
+++ b/meta-mender-qemu/scripts/docker/entrypoint.sh
@@ -40,5 +40,5 @@ if [ ! -e /mender-setup-complete ]; then
     touch /mender-setup-complete
 fi
 
-export QEMU_NET_HOSTFWD=",hostfwd=tcp::80-:80,hostfwd=tcp::85-:85,hostfwd=tcp::8080-:8080"
+export QEMU_NET_HOSTFWD=",hostfwd=tcp::80-:80,hostfwd=tcp::85-:85,hostfwd=tcp::443-:443,hostfwd=tcp::8080-:8080"
 ./mender-qemu "$@"


### PR DESCRIPTION
Main commit:

    MEN-5475: meta-mender-demo: Add demo functionality for mender-gateway
    
    Requires the user to extend SRC_URI of mender-gateway with the location
    of the examples tarball:
    ```
    SRC_URI_pn-mender-gateway_append = " file:///<download-path>/mender-gateway-examples-1.0.0.tar"
    ```
    
    Download the tarball from https://docs.mender.io/downloads
    
    Changelog: Commit
