### PR TITLE
fix: have the data dir created before the client runs

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/files/mender-client-data-dir.service
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-client-data-dir.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mender persistent data dir
 After=data.mount
+Before=mender-client.service
 ConditionPathExists=!/data/mender
 
 [Service]


### PR DESCRIPTION
This adds a `Before` dependency on the mender-client service file in the service
which creates the `/data/mender` directory.

Just to insure proper ordering of events.

Changelog: Add a systemd After dependency on the `mender-client-data-dir`
service file.
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>


