### PR TITLE
Rename bb variable

### DIFF
--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -6,7 +6,7 @@ inherit mender-helpers
 # For some reason 'bitbake -e' does not report the MACHINE value so
 # we use this as a proxy in case it is not available when needed.
 export MENDER_MACHINE = "${MACHINE}"
-BB_HASHBASE_WHITELIST += "MENDER_MACHINE"
+BB_BASEHASH_IGNORE_VARS += "MENDER_MACHINE"
 
 # The storage device that holds the device partitions.
 MENDER_STORAGE_DEVICE ??= "${MENDER_STORAGE_DEVICE_DEFAULT}"


### PR DESCRIPTION
Used script 'scripts/contrib/convert-variable-renames.py' from
openembedded-core meta layer to convert new override syntax.
Refer bitbake, commit efaafc9ec2e8c0475e3fb27e877a1c0a5532a0e5.

Changelog: None

Signed-off-by: Preeti Sachan <preeti.sachan@intel.com>