### PR TITLE
Refresh e2fsprog patch and mark layer compatible with hardknott

### DIFF
--- a/meta-mender-core/recipes-core/systemd/systemd-boot_%.bbappend
+++ b/meta-mender-core/recipes-core/systemd/systemd-boot_%.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://systemd-boot-slotconfig.patch"
+SRC_URI:mender-systemd-boot += "file://systemd-boot-slotconfig.patch"

--- a/meta-mender-core/recipes-devtools/e2fsprogs/patches/0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch
+++ b/meta-mender-core/recipes-devtools/e2fsprogs/patches/0001-Do-not-use-metadata_csum-feature-on-ext4-by-default.patch
@@ -1,7 +1,7 @@
-From 526daf6081b9b72d85ab427acef7c0f9a7c94c33 Mon Sep 17 00:00:00 2001
+From 41833dcd332338f403b341c8be8e175718159d8f Mon Sep 17 00:00:00 2001
 From: Kristian Amlie <kristian.amlie@northern.tech>
 Date: Mon, 2 Dec 2019 15:24:11 +0100
-Subject: [PATCH 1/1] Do not use metadata_csum feature on ext4 by default.
+Subject: [PATCH] Do not use metadata_csum feature on ext4 by default.
 
 Even very recent versions of e2fsprogs (1.44.3) don't support it.
 
@@ -11,7 +11,7 @@ Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/misc/mke2fs.conf.in b/misc/mke2fs.conf.in
-index 00afd91..695dc3f 100644
+index 01e35cf8..138a6413 100644
 --- a/misc/mke2fs.conf.in
 +++ b/misc/mke2fs.conf.in
 @@ -11,7 +11,7 @@
@@ -20,8 +20,9 @@ index 00afd91..695dc3f 100644
  	ext4 = {
 -		features = has_journal,extent,huge_file,flex_bg,metadata_csum,64bit,dir_nlink,extra_isize
 +		features = has_journal,extent,huge_file,flex_bg,64bit,dir_nlink,extra_isize
+ 		inode_size = 256
  	}
  	small = {
-		blocksize = 1024
---
-2.7.4
+-- 
+2.32.0
+

--- a/meta-mender-qemu/conf/layer.conf
+++ b/meta-mender-qemu/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_COLLECTIONS += "mender-qemu"
 BBFILE_PATTERN_mender-qemu = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender-qemu = "6"
 
-LAYERSERIES_COMPAT_mender-qemu = "dunfell honister kirkstone"
+LAYERSERIES_COMPAT_mender-qemu = "dunfell hardknott honister kirkstone"
 LAYERDEPENDS_mender-qemu = "mender"
 
 EXTRA_IMAGEDEPENDS:append_mender-image-uefi:x86 = " ovmf"

--- a/meta-mender-raspberrypi-demo/conf/layer.conf
+++ b/meta-mender-raspberrypi-demo/conf/layer.conf
@@ -13,4 +13,4 @@ BBFILE_PATTERN_mender-raspberrypi-demo = "^${LAYERDIR}/"
 
 LAYERDEPENDS_mender-raspberrypi-demo = "mender mender-demo mender-raspberrypi"
 
-LAYERSERIES_COMPAT_mender-raspberrypi-demo = "dunfell honister kirkstone"
+LAYERSERIES_COMPAT_mender-raspberrypi-demo = "dunfell hardknott honister kirkstone"

--- a/meta-mender-raspberrypi/conf/layer.conf
+++ b/meta-mender-raspberrypi/conf/layer.conf
@@ -14,7 +14,7 @@ BBFILE_PRIORITY_mender-raspberrypi = "10"
 
 LAYERDEPENDS_mender-raspberrypi = "mender raspberrypi"
 
-LAYERSERIES_COMPAT_mender-raspberrypi = "dunfell honister kirkstone"
+LAYERSERIES_COMPAT_mender-raspberrypi = "dunfell hardknott honister kirkstone"
 
 # Raspberry Pi doesn't work with GRUB currently.
 _MENDER_IMAGE_TYPE_DEFAULT_rpi = "mender-image-sd"


### PR DESCRIPTION
Hi,

just a quick patch refresh for e2fsprog and mark the layer compatible with hardknott   