### PR TITLE
dataimg: Add F2FS support

### DIFF
--- a/meta-mender-core/classes/mender-dataimg.bbclass
+++ b/meta-mender-core/classes/mender-dataimg.bbclass
@@ -5,9 +5,15 @@ IMAGE_CMD_dataimg() {
     if [ ${MENDER_DATA_PART_FSTYPE_TO_GEN} = "btrfs" ]; then
         force_flag="-f"
         root_dir_flag="-r"
+        volume_label_flag="-L"
+    elif [ ${MENDER_DATA_PART_FSTYPE_TO_GEN} = "f2fs" ]; then
+        force_flag="-f"
+        root_dir_flag="-d"
+        volume_label_flag="-l"
     else #Assume ext3/4
         force_flag="-F"
         root_dir_flag="-d"
+        volume_label_flag="-L"
     fi
 
     dd if=/dev/zero of="${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}" count=0 bs=1M seek=${MENDER_DATA_PART_SIZE_MB}
@@ -15,7 +21,7 @@ IMAGE_CMD_dataimg() {
         $force_flag \
         "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}" \
         $root_dir_flag "${IMAGE_ROOTFS}/data" \
-        -L data \
+        $volume_label_flag data \
         ${MENDER_DATA_PART_FSOPTS}
     install -m 0644 "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
 }
@@ -30,3 +36,4 @@ do_image_dataimg[respect_exclude_path] = "0"
 do_image_dataimg[depends] += "${@bb.utils.contains('DISTRO_FEATURES', 'mender-image-ubi', 'mtd-utils-native:do_populate_sysroot', '', d)}"
 do_image_dataimg[depends] += "${@bb.utils.contains('MENDER_DATA_PART_FSTYPE_TO_GEN', 'btrfs','btrfs-tools-native:do_populate_sysroot','',d)}"
 do_image_dataimg[depends] += "${@bb.utils.contains_any('MENDER_DATA_PART_FSTYPE_TO_GEN', 'ext2 ext3 ext4','e2fsprogs-native:do_populate_sysroot','',d)}"
+do_image_dataimg[depends] += "${@bb.utils.contains('MENDER_DATA_PART_FSTYPE_TO_GEN', 'f2fs','f2fs-tools-native:do_populate_sysroot','',d)}"


### PR DESCRIPTION
Add a new feature to support F2FS (Flash-Friendly File System) for
the data partition with variable MENDER_DATA_PART_FSTYPE_TO_GEN.

Changelog: Support F2FS for the data partition

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Cherry pick the commit that adds the new feature for f2fs support for the `/data` partition which has been already merged in branch `master`.
