### PR TITLE
grub-efi-precompiled: fix license identifier

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
@@ -15,8 +15,8 @@ inherit grub-mender-grubenv
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-LICENSE = "GPL-3.0"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LICENSE = "GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
 
 URL_BASE ?= "https://d1b0l86ne08fsf.cloudfront.net/grub-mender-grubenv/grub-efi"
 


### PR DESCRIPTION
Changelog: none

This reflects the licence identifier change in upstream
commit b0130fcf91daee0d905af755302fabe608da141c

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits have a [`Changelog`](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md#changelog-tags) tag. If nothing should be added to the Changelog, add a `Changelog: None` tag. If there is a change, add `Changelog: Commit`, or `Changelog: Title`, depending on what should be included in the changelog.

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
