### PR TITLE
QA-387 Embed a clean image

### DIFF
--- a/meta-mender-qemu/docker/build-docker
+++ b/meta-mender-qemu/docker/build-docker
@@ -4,6 +4,9 @@ cd "$(dirname "$0")"
 
 BUILD_DEFAULTS=1
 IMAGE_NAME="core-image-full-cmdline"
+# the name of an extra image to embed in the conatiner
+# this image will be used in tests, see integration/tests/run.sh
+EMBEDDED_IMAGE_NAME=""
 
 usage() {
     cat <<EOF
@@ -19,6 +22,8 @@ All options after MACHINE are given to "docker build".
 -i, --image <IMAGE_NAME>
 	The name of the image being used in the container. Defaults to
 	$IMAGE_NAME.
+-I, --embedded-image <IMAGE_NAME>
+	The image being put inside the generated image.
 EOF
 }
 
@@ -34,6 +39,14 @@ while [ -n "$1" ]; do
                 exit 1
             fi
             IMAGE_NAME="$1"
+            ;;
+        -I|--embedded-image)
+            shift
+            if [ -z "$1" ]; then
+                echo "Need to specify image name with -I / --embedded-image." 1>&2
+                exit 1
+            fi
+            EMBEDDED_IMAGE_NAME="$1"
             ;;
         -h|--help)
             usage
@@ -64,6 +77,7 @@ fi
 
 set -e
 
+EMBEDDED_IMAGE_NAME_BUILD_ARG=
 DOCKER_ARGS=
 if [ $BUILD_DEFAULTS = 1 ]; then
     if [ ! -d "$BUILDDIR" ]; then
@@ -83,17 +97,24 @@ if [ $BUILD_DEFAULTS = 1 ]; then
         echo "Neither mender-image-uefi nor mender-image-sd are set! Don't know which image to use!" 1>&2
         exit 1
     fi
+    if [ "${EMBEDDED_IMAGE_NAME}" != "" ]; then
+        EMBEDDED_IMAGE_NAME_BUILD_ARG="--build-arg EMBEDDED_IMAGE=$(basename ${EMBEDDED_IMAGE_NAME})"
+        echo "using ${EMBEDDED_IMAGE_NAME} as embedded image."
+        ln -Lf "${EMBEDDED_IMAGE_NAME}" "$MACHINE/"
+    fi
     ln -Lf "$BUILDDIR/tmp/deploy/images/$MACHINE/$DISK_IMG" "$MACHINE/"
     cat > "$MACHINE/env.txt" <<EOF
 export MACHINE=$MACHINE
 export DISK_IMG=/$DISK_IMG
+export EMBEDDED_IMAGE=/$(basename "${EMBEDDED_IMAGE_NAME}")
 EOF
 
     case "$MACHINE" in
         qemux86-64)
             ln -Lf "$BUILDDIR/tmp/deploy/images/$MACHINE/ovmf.qcow2" "$MACHINE/"
             ln -Lf "$BUILDDIR/tmp/deploy/images/$MACHINE/ovmf.vars.qcow2" "$MACHINE/"
-            DOCKER_ARGS="--build-arg DISK_IMAGE=$DISK_IMG --build-arg BOOTLOADER=ovmf.qcow2 --build-arg BOOTLOADER_DATA=ovmf.vars.qcow2"
+            DOCKER_ARGS="${EMBEDDED_IMAGE_NAME_BUILD_ARG} --build-arg DISK_IMAGE=$DISK_IMG --build-arg BOOTLOADER=ovmf.qcow2 --build-arg BOOTLOADER_DATA=ovmf.vars.qcow2"
+            echo "running with $DOCKER_ARGS"
             cat >> "$MACHINE/env.txt" <<EOF
 export BOOTLOADER=/ovmf.qcow2
 export BOOTLOADER_DATA=/ovmf.vars.qcow2
@@ -102,6 +123,7 @@ EOF
         vexpress-qemu)
             ln -Lf "$BUILDDIR/tmp/deploy/images/$MACHINE/u-boot.elf" "$MACHINE/"
             DOCKER_ARGS="--build-arg DISK_IMAGE=$DISK_IMG --build-arg BOOTLOADER=u-boot.elf"
+            echo "running with $DOCKER_ARGS"
             cat >> "$MACHINE/env.txt" <<EOF
 export BOOTLOADER=/u-boot.elf
 EOF

--- a/meta-mender-qemu/docker/qemux86-64/Dockerfile
+++ b/meta-mender-qemu/docker/qemux86-64/Dockerfile
@@ -1,6 +1,8 @@
 # Usage of Docker image.
 #
 # While building:
+# --build-arg EMBEDDED_IMAGE_NAME=<uefiimg>
+#       image to add to the Docker image
 # --build-arg DISK_IMAGE=<uefiimg>
 #       image to add to the Docker image
 # --build-arg BOOTLOADER=<ovmf.qcow2>
@@ -37,10 +39,12 @@ RUN rm -rf /var/cache/apk/*
 RUN echo qemux86-64 > /machine.txt
 
 ARG DISK_IMAGE=scripts/docker/empty-file
+ARG EMBEDDED_IMAGE=scripts/docker/empty-file
 ARG BOOTLOADER=scripts/docker/empty-file
 ARG BOOTLOADER_DATA=scripts/docker/empty-file
 
 COPY $DISK_IMAGE .
+COPY $EMBEDDED_IMAGE .
 COPY $BOOTLOADER ./ovmf.qcow2
 COPY $BOOTLOADER_DATA ./ovmf.vars.qcow2
 

--- a/meta-mender-qemu/scripts/docker/extract_fs
+++ b/meta-mender-qemu/scripts/docker/extract_fs
@@ -19,7 +19,10 @@ trap failure ERR
 trap cleanup EXIT
 
 DEV=$(losetup -f)
-IMG=$(ls /*img | head -n 1)
+IMG_PREFIX=${1}
+IMG=$(ls /${IMG_PREFIX}*img* | head -n 1)
+[[ $IMG == *gz ]] && gzip -d "$IMG"
+IMG=$(ls /${IMG_PREFIX}*img | head -n 1)
 OUTPUT=/output/$(sed -e 's/\.[^.]*img$/.ext4/' <<<$(basename $IMG))
 
 losetup $DEV $IMG


### PR DESCRIPTION
Those go together:

* https://github.com/mendersoftware/mender-qa/pull/580
  build and prepare so called clean images and pass them to build-docker
  to embed in the images we later /extract_fs in integration tests
* https://github.com/mendersoftware/meta-mender/pull/1663
  support for a new flag that allows to specify an extra image
  to embed in the container
* https://github.com/mendersoftware/integration/pull/1983
  use the clean images in the tests and test for artifact_info
  in a explicit manner

ChangeLog: none
Signed-off-by: Peter Grzybowski <peter@northern.tech>
