### PR TITLE
Simplify mender-client-resize-data-part and make it compatible with "partuuid" setups

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/files/mender-client-resize-data-part.sh.in
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-client-resize-data-part.sh.in
@@ -5,10 +5,10 @@ set -e
 # All sizes are in blocks of 512 bytes
 
 MENDER_DATA_PART=@MENDER_DATA_PART@
-MENDER_STORAGE_DEVICE=@MENDER_STORAGE_DEVICE@
 
-mender_storage_device_base=$(basename ${MENDER_STORAGE_DEVICE})
 mender_data_part_base=$(basename ${MENDER_DATA_PART})
+mender_storage_device_base=$(basename $(readlink -f /sys/class/block/${mender_data_part_base}/..))
+mender_storage_device=/dev/${mender_storage_device_base}
 
 total_disk_size=$(cat /sys/block/${mender_storage_device_base}/size)
 
@@ -39,6 +39,6 @@ fi
 # ensures that GPT backup headers are written to the end of the disk.
 # Note: On some MBR systems using BusyBox's fdisk this call will fail,
 # this is OK (MBR systems don't have a backup header), always return true. 
-echo "w" | fdisk ${MENDER_STORAGE_DEVICE} &> /dev/null || true
+echo "w" | fdisk ${mender_storage_device} &> /dev/null || true
 
-/usr/sbin/parted -s ${MENDER_STORAGE_DEVICE} resizepart @MENDER_DATA_PART_NUMBER@ 100%
+/usr/sbin/parted -s ${mender_storage_device} resizepart @MENDER_DATA_PART_NUMBER@ 100%

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -9,6 +9,7 @@ PACKAGES_append = " mender-modules-gen"
 
 RDEPENDS_${PN}_append_mender-growfs-data_mender-systemd = " parted util-linux-fdisk"
 RDEPENDS_${PN}_append_mender-growfs-data_mender-systemd_mender-partlabel = " util-linux-blkid"
+RDEPENDS_${PN}_append_mender-growfs-data_mender-systemd_mender-partuuid = " util-linux-blkid"
 RDEPENDS_mender-modules-gen = "bash"
 
 MENDER_CLIENT ?= "mender-client"
@@ -345,6 +346,9 @@ do_install_append_class-target_mender-growfs-data_mender-systemd() {
 
     if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
+            ${WORKDIR}/mender-client-resize-data-part.sh.in
+    elif ${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}; then
+        sed -i "s#@MENDER_DATA_PART@#\$(blkid | grep 'PARTUUID=\"${@mender_get_partuuid_from_device(d, '${MENDER_DATA_PART}')}\"' | awk -F: '{ print \$1 }')#g" \
             ${WORKDIR}/mender-client-resize-data-part.sh.in
     else
         sed -i "s#@MENDER_DATA_PART@#${MENDER_DATA_PART}#g" \

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -346,13 +346,7 @@ do_install_append_class-target_mender-growfs-data_mender-systemd() {
     if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
             ${WORKDIR}/mender-client-resize-data-part.sh.in
-
-        sed -i "s#@MENDER_STORAGE_DEVICE@#/dev/\$(basename \$(readlink -f \"/sys/class/block/\$(basename \$MENDER_DATA_PART)/..\"))#g" \
-            ${WORKDIR}/mender-client-resize-data-part.sh.in
     else
-        sed -i "s#@MENDER_STORAGE_DEVICE@#${MENDER_STORAGE_DEVICE}#g" \
-            ${WORKDIR}/mender-client-resize-data-part.sh.in
-
         sed -i "s#@MENDER_DATA_PART@#${MENDER_DATA_PART}#g" \
             ${WORKDIR}/mender-client-resize-data-part.sh.in
     fi


### PR DESCRIPTION
This PR is split into two parts:
* **Simplify mender-client-resize-data-part by figuring out the storage device from `MENDER_DATA_PART`**
  This way, we don't need to populate the script with a valid value for `MENDER_STORAGE_DEVICE` anymore. That variable doesn't exist in a "partuuid" setup and is already auto-derived in a similar way in a "partlabel" setup.
* **Make mender-client-resize-data-part compatible with "partuuid" setups**
  This commit derives the expected value for `MENDER_DATA_PART` from the PARTUUID in "partuuid" setups, in a similar way as it's already done for "partlabel" setups.

I have backported this fix to dunfell (which only supports "partuuid" but not "partlabel") in https://github.com/enlyze/meta-mender/tree/dunfell-mender-client-resize-data-partuuid and successfully tested it.
I'd be grateful if you could apply both my PR to "master" as well as my backport to "dunfell".

Fixes [MEN-3701](https://tracker.mender.io/browse/MEN-3701)