### PR TITLE
Fixes for Pseudo abort issue

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -129,6 +129,23 @@ _MENDER_TAGS = "${@bb.utils.contains('PACKAGECONFIG', 'dbus', '', 'nodbus', d)}"
 EXTRA_OEMAKE_append = " TAGS='${_MENDER_TAGS}'"
 GOPTESTBUILDFLAGS_append = " -tags '${_MENDER_TAGS}'"
 
+do_configure_prepend () {
+    # Remove all the src present in build if it is not a symbolic link to ${S}
+    if [ -d ${B}/src ]; then
+        rm -rf ${B}/src
+    fi
+}
+
+do_configure_append () {
+    # Remove the symbolic link created by go.bbclass in do_configure. This is to
+    # make sure that the build environment ${B} does not touch ${S} in any way.
+    if [ -h ${B}/src ]; then
+        rm ${B}/src
+    fi
+    mkdir -p $(dirname ${B}/src/${GO_IMPORT})
+    cp --archive ${S}/src/${GO_IMPORT} ${B}/src/${GO_IMPORT}
+}
+
 do_compile() {
     GOPATH="${B}:${S}"
     export GOPATH

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -1151,31 +1151,47 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             prepared_test_build["build_dir"],
             prepared_test_build["bitbake_corebase"],
             "mender-client",
-            ['PACKAGECONFIG_remove = "dbus"'],
+            target="-c clean mender-client",
         )
 
-        env = get_bitbake_variables(
-            request, "mender-client", prepared_test_build=prepared_test_build
-        )
+        try:
+            build_image(
+                prepared_test_build["build_dir"],
+                prepared_test_build["bitbake_corebase"],
+                "mender-client",
+                ['PACKAGECONFIG_remove = "dbus"'],
+            )
 
-        # Get dynamic section info from binary.
-        output = subprocess.check_output(
-            [env["READELF"], "-d", os.path.join(env["D"], "usr/bin/mender")]
-        ).decode()
+            env = get_bitbake_variables(
+                request, "mender-client", prepared_test_build=prepared_test_build
+            )
 
-        # Verify the output is sane.
-        assert "libc" in output
+            # Get dynamic section info from binary.
+            output = subprocess.check_output(
+                [env["READELF"], "-d", os.path.join(env["D"], "usr/bin/mender")]
+            ).decode()
 
-        # Actual test.
-        assert "libglib" not in output
+            # Verify the output is sane.
+            assert "libc" in output
 
-        # Make sure busconfig files are also gone.
-        assert not os.path.exists(
-            os.path.join(env["D"], "usr/share/dbus-1/system.d/io.mender.conf")
-        )
-        assert not os.path.exists(
-            os.path.join(env["D"], "etc/dbus-1/system.d/io.mender.conf")
-        )
+            # Actual test.
+            assert "libglib" not in output
+
+            # Make sure busconfig files are also gone.
+            assert not os.path.exists(
+                os.path.join(env["D"], "usr/share/dbus-1/system.d/io.mender.conf")
+            )
+            assert not os.path.exists(
+                os.path.join(env["D"], "etc/dbus-1/system.d/io.mender.conf")
+            )
+
+        finally:
+            build_image(
+                prepared_test_build["build_dir"],
+                prepared_test_build["bitbake_corebase"],
+                "mender-client",
+                target="-c clean mender-client",
+            )
 
     @pytest.mark.min_mender_version("2.5.0")
     @pytest.mark.only_with_image("ext4")

--- a/tests/meta-mender-ci/recipes-testing/mender-coverage-client/mender-client_%.bbappend
+++ b/tests/meta-mender-ci/recipes-testing/mender-coverage-client/mender-client_%.bbappend
@@ -1,6 +1,6 @@
 SUMMARY_append_mender-testing-enabled = ": Build a Mender client which records coverage during its invocation"
 
-DEPENDS_append_mender-testing-enabled = " gobinarycoverage-native rsync-native"
+DEPENDS_append_mender-testing-enabled = " gobinarycoverage-native"
 
 do_instrument_client[dirs] =+ "${GOTMPDIR}"
 do_instrument_client[doc] = "Modifies the Mender client source to enable coverage analysis"
@@ -12,23 +12,6 @@ do_instrument_client () {
 
 do_instrument_client_class-native() {
     true
-}
-
-do_configure_prepend_mender-testing-enabled () {
-    # Remove all the src present in build if it is not a symbolic link to ${S}
-    if [ -d ${B}src ]; then
-        rm -rf ${B}src
-    fi
-
-}
-
-do_configure_append_mender-testing-enabled () {
-    # Remove the symbolic link created by go.bbclass in do_configure
-    if [ -h ${B}src ]; then
-        rm ${B}src
-    fi
-    mkdir -p ${B}src/${GO_IMPORT}
-    rsync --archive --recursive --delete ${S}/src/${GO_IMPORT}/ ${B}/src/${GO_IMPORT}/
 }
 
 python () {


### PR DESCRIPTION
```
commit f6c1a8cf55c34898909ff7a6ed577f0dc50920f0
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon May 23 21:00:30 2022

    test: nodbus: Clean the mender-client between builds.
    
    We need it because tag changes ("nodbus") are not picked up without
    cleaning first.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 8b4eb998b9552203792de3ba9b66c027df64a64e
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon May 23 16:46:35 2022

    fix: Force building in separate build directory, even with `externalsrc`.
    
    The problem with building in `${S}` is that files remain there after
    a build, due to bad interoperability between the `externalsrc` and
    `go` classes, the `clean` target does not clean this up. Therefore,
    force the creation of a separate build directory always, even if it's
    based on an `externalsrc` directory.
    
    This was always needed for coverage analysis, so just steal the code
    from there.
    
    Changelog: Title
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```