### PR TITLE
chore: moved qemu docker image to python base image.

### DIFF
--- a/meta-mender-qemu/docker/qemux86-64/Dockerfile
+++ b/meta-mender-qemu/docker/qemux86-64/Dockerfile
@@ -25,16 +25,11 @@
 #       Copy the configuration file for mender-gateway
 #       Note that the file needs to be mounted into the Docker container
 
-FROM alpine:3.15.0
+FROM python:3.10-alpine3.16
 
 # Install packages
-RUN apk update && apk upgrade && \
-    apk add util-linux multipath-tools \
-            bash e2fsprogs-extra python3
-
-RUN apk add qemu-system-x86_64
-
-RUN rm -rf /var/cache/apk/*
+RUN apk add --no-cache util-linux multipath-tools \
+        bash e2fsprogs-extra qemu-system-x86_64
 
 RUN echo qemux86-64 > /machine.txt
 


### PR DESCRIPTION
- since the python version installed was unversioned until now, the default target would be the latest stable
- to both prevent unintended versioning issues & speed up the build, the base image is switched to python
- also removed another image layer by avoiding the apk cache

Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>
