### PR TITLE
chore: updated test requirements to allow base image update - pt2

### DIFF
--- a/tests/acceptance/requirements_deb.txt
+++ b/tests/acceptance/requirements_deb.txt
@@ -42,6 +42,7 @@ nodejs
 pass
 pkg-config
 psmisc
+python2-dev
 python3-dev
 python3-libvirt
 python3-pip


### PR DESCRIPTION
unfortunately the prior PR was a bit too optimistic in assuming the python packages would work, so now both 2+3 installed in their `-dev` variants