### PR TITLE
chore: remove unnecessary python2-dev package

### DIFF
--- a/tests/acceptance/requirements_deb.txt
+++ b/tests/acceptance/requirements_deb.txt
@@ -42,7 +42,6 @@ nodejs
 pass
 pkg-config
 psmisc
-python2-dev
 python3-dev
 python3-libvirt
 python3-pip


### PR DESCRIPTION
Remove unnecessary python2-dev package: there's no python 2 in ubuntu:18:04

```
oot@a2f304a7fa54:/# ls /usr/bin/python*
python3            python3-config     python3.6          python3.6-config   python3.6m         python3.6m-config  python3m           python3m-config 
```

Docker image cannot be built because of `E: Unable to locate package python2-dev` error message.

Failing job: https://gitlab.com/Northern.tech/Mender/mender-test-containers/-/jobs/2564428900#L926

Signed-off-by: Maciej Tomczuk <maciej.tomczuk@northern.tech>