### PR TITLE
Dunfell: Changes to support interoperability with kirkstone.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/acceptance/image-tests"]
 	path = tests/acceptance/image-tests
 	url = https://github.com/mendersoftware/mender-image-tests
-	branch = master
+	branch = dunfell

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -107,8 +107,10 @@ class TestDBus:
                 time.sleep(5)
 
             assert f'string "{self.JWT_TOKEN}' in output
-            if version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
+            if version_is_minimum(bitbake_variables, "mender-client", "3.4.0"):
                 assert 'string "http://127.0.0.1:' in output
+            elif version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
+                assert 'string "http://localhost:' in output
             else:
                 assert 'string "https://docker.mender.io' in output
 
@@ -178,8 +180,10 @@ class TestDBus:
 
                 output = result.stdout.strip()
                 assert f'string "{self.JWT_TOKEN}' in output
-                if version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
+                if version_is_minimum(bitbake_variables, "mender-client", "3.4.0"):
                     assert 'string "http://127.0.0.1:' in output
+                elif version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
+                    assert 'string "http://localhost:' in output
                 else:
                     assert 'string "https://docker.mender.io' in output
 

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ class TestDBus:
 
             assert f'string "{self.JWT_TOKEN}' in output
             if version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
-                assert 'string "http://localhost:' in output
+                assert 'string "http://127.0.0.1:' in output
             else:
                 assert 'string "https://docker.mender.io' in output
 
@@ -179,7 +179,7 @@ class TestDBus:
                 output = result.stdout.strip()
                 assert f'string "{self.JWT_TOKEN}' in output
                 if version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
-                    assert 'string "http://localhost:' in output
+                    assert 'string "http://127.0.0.1:' in output
                 else:
                     assert 'string "https://docker.mender.io' in output
 

--- a/tests/build-conf/beagleboneblack/local.conf
+++ b/tests/build-conf/beagleboneblack/local.conf
@@ -243,6 +243,13 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/qemux86-64-bios-grub-gpt/local.conf
+++ b/tests/build-conf/qemux86-64-bios-grub-gpt/local.conf
@@ -245,6 +245,13 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/qemux86-64-bios-grub/local.conf
+++ b/tests/build-conf/qemux86-64-bios-grub/local.conf
@@ -241,6 +241,13 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/qemux86-64-uefi-grub/local.conf
+++ b/tests/build-conf/qemux86-64-uefi-grub/local.conf
@@ -241,6 +241,13 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/raspberrypi3/local.conf
+++ b/tests/build-conf/raspberrypi3/local.conf
@@ -23,6 +23,13 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/raspberrypi4/local.conf
+++ b/tests/build-conf/raspberrypi4/local.conf
@@ -23,6 +23,13 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/vexpress-qemu-flash/local.conf
+++ b/tests/build-conf/vexpress-qemu-flash/local.conf
@@ -24,6 +24,13 @@ EXTRA_IMAGE_FEATURES="debug-tweaks"
 
 USER_CLASSES ?= "buildstats image-mklibs"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 INHERIT += "externalsrc"
 
 INHERIT += "mender-full-ubi"

--- a/tests/build-conf/vexpress-qemu-uboot-uefi-grub/local.conf
+++ b/tests/build-conf/vexpress-qemu-uboot-uefi-grub/local.conf
@@ -241,6 +241,13 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/build-conf/vexpress-qemu/local.conf
+++ b/tests/build-conf/vexpress-qemu/local.conf
@@ -241,6 +241,13 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Commercial components for Mender.
+LICENSE_FLAGS_WHITELIST_append = " \
+    commercial_mender-binary-delta \
+    commercial_mender-monitor \
+    commercial_mender-gateway \
+"
+
 # In order to build from the repository that Jenkins has cloned, instead of
 # letting bitbake pull the sources, we use "externalsrc".
 INHERIT += "externalsrc"

--- a/tests/meta-mender-ci/conf/layer.conf
+++ b/tests/meta-mender-ci/conf/layer.conf
@@ -14,7 +14,10 @@ LAYERSERIES_COMPAT_meta-mender-ci = "dunfell"
 # We need a bit more than the demo layer to fit test dependencies
 MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "708"
 
-IMAGE_FEATURES_append = " read-only-rootfs"
+IMAGE_FEATURES_append = " \
+    read-only-rootfs \
+    ssh-server-openssh \
+"
 IMAGE_INSTALL_append = "\
     lsb-test \
     ${MENDER_MOCK_SERVER} \


### PR DESCRIPTION
Just cherry-picks, but I did fork the mender-image-tests repository, see https://github.com/mendersoftware/mender-image-tests/pull/68.