### PR TITLE
MEN5689: fix bootfiles rename to match upstream

### DIFF
--- a/tests/build-conf/raspberrypi3/local.conf
+++ b/tests/build-conf/raspberrypi3/local.conf
@@ -298,7 +298,7 @@ INHERIT += "externalsrc"
 RPI_USE_U_BOOT = "1"
 MENDER_BOOT_PART_SIZE_MB = "40"
 
-do_image_sdimg[depends] += " bootfiles:do_populate_sysroot"
+do_image_sdimg[depends] += " rpi-bootfiles:do_populate_sysroot"
 
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
 IMAGE_FSTYPES:remove += " rpi-sdimg"

--- a/tests/build-conf/raspberrypi4/local.conf
+++ b/tests/build-conf/raspberrypi4/local.conf
@@ -298,7 +298,7 @@ INHERIT += "externalsrc"
 RPI_USE_U_BOOT = "1"
 MENDER_BOOT_PART_SIZE_MB = "40"
 
-do_image_sdimg[depends] += " bootfiles:do_populate_sysroot"
+do_image_sdimg[depends] += " rpi-bootfiles:do_populate_sysroot"
 
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
 IMAGE_FSTYPES:remove += " rpi-sdimg"


### PR DESCRIPTION
fix: adjust package rename of bootfiles to upstream in testing

Changelog:  None
Ticket: MEN5689

This adjusts the test scripts to the already existing adjustment of the payload scripts to upstream.
