### PR TITLE
feat: set LAYERCOMPAT to kirkstone only

### DIFF
--- a/meta-mender-commercial/conf/layer.conf
+++ b/meta-mender-commercial/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_COLLECTIONS += "mender-commercial"
 BBFILE_PATTERN_mender-commercial = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender-commercial = "6"
 
-LAYERSERIES_COMPAT_mender-commercial = "dunfell kirkstone"
+LAYERSERIES_COMPAT_mender-commercial = "kirkstone"
 LAYERDEPENDS_mender-commercial = "mender"
 
 # See https://tracker.mender.io/browse/MEN-3513 and

--- a/meta-mender-core/conf/layer.conf
+++ b/meta-mender-core/conf/layer.conf
@@ -17,5 +17,5 @@ BBFILE_PRIORITY_mender = "6"
 
 INHERIT += "mender-maybe-setup"
 
-LAYERSERIES_COMPAT_mender = "dunfell hardknott honister kirkstone"
+LAYERSERIES_COMPAT_mender = "kirkstone"
 LAYERDEPENDS_mender = "core"

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -22,5 +22,5 @@ MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT ?= "608"
 IMAGE_OVERHEAD_FACTOR = "1.0"
 IMAGE_FEATURES += "splash"
 
-LAYERSERIES_COMPAT_mender-demo = "dunfell hardknott honister kirkstone"
+LAYERSERIES_COMPAT_mender-demo = "kirkstone"
 LAYERDEPENDS_mender-demo = "mender openembedded-layer"

--- a/meta-mender-qemu/conf/layer.conf
+++ b/meta-mender-qemu/conf/layer.conf
@@ -12,7 +12,7 @@ BBFILE_COLLECTIONS += "mender-qemu"
 BBFILE_PATTERN_mender-qemu = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender-qemu = "6"
 
-LAYERSERIES_COMPAT_mender-qemu = "dunfell hardknott honister kirkstone"
+LAYERSERIES_COMPAT_mender-qemu = "kirkstone"
 LAYERDEPENDS_mender-qemu = "mender"
 
 MENDER_EFI_LOADER:mender-image-uefi:qemux86 = "ovmf"

--- a/meta-mender-raspberrypi-demo/conf/layer.conf
+++ b/meta-mender-raspberrypi-demo/conf/layer.conf
@@ -13,4 +13,4 @@ BBFILE_PATTERN_mender-raspberrypi-demo = "^${LAYERDIR}/"
 
 LAYERDEPENDS_mender-raspberrypi-demo = "mender mender-demo mender-raspberrypi"
 
-LAYERSERIES_COMPAT_mender-raspberrypi-demo = "dunfell hardknott honister kirkstone"
+LAYERSERIES_COMPAT_mender-raspberrypi-demo = "kirkstone"

--- a/meta-mender-raspberrypi/conf/layer.conf
+++ b/meta-mender-raspberrypi/conf/layer.conf
@@ -14,7 +14,7 @@ BBFILE_PRIORITY_mender-raspberrypi = "10"
 
 LAYERDEPENDS_mender-raspberrypi = "mender raspberrypi"
 
-LAYERSERIES_COMPAT_mender-raspberrypi = "dunfell hardknott honister kirkstone"
+LAYERSERIES_COMPAT_mender-raspberrypi = "kirkstone"
 
 # Raspberry Pi doesn't work with GRUB currently.
 _MENDER_IMAGE_TYPE_DEFAULT:rpi = "mender-image-sd"


### PR DESCRIPTION
This restricts to the usage of the layer to the
kirkstone release only, in order to facilitate
the LTS scheme.

Changelog: Title
Ticket: MEN-5681

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>