### PR TITLE
test: improve test_uboot_automation.py

### DIFF
--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2021 Northern.tech AS
+# Copyright 2022 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -333,8 +333,8 @@ class TestUbootAutomation:
                     continue
 
                 total += 1
-                with open(os.path.join(env["LOGS"], file)) as fd:
-                    if "AutoPatchFailed\n" in fd.readlines():
+                with open(os.path.join(env["LOGS"], file), "rb") as fd:
+                    if b"AutoPatchFailed\n" in fd.readlines():
                         failed += 1
 
             assert total == len(
@@ -366,9 +366,9 @@ class TestUbootAutomation:
                 )
             except AssertionError:
                 for file in os.listdir(env["LOGS"]):
-                    with open(os.path.join(env["LOGS"], file)) as fd:
+                    with open(os.path.join(env["LOGS"], file), "rb") as fd:
                         log = fd.readlines()
-                        if "AutoPatchFailed\n" in log:
+                        if b"AutoPatchFailed\n" in log:
                             print("Last 50 lines of output from failed board: " + file)
                             print("".join(log[-50:]))
                 raise


### PR DESCRIPTION
Fix spurious errors when reading binary data from the file:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 1435: invalid start byte

Changelog: None
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>