### PR TITLE
test: Use latin_1 coding so we can keep using str when printing logs.

### DIFF
--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -333,8 +333,8 @@ class TestUbootAutomation:
                     continue
 
                 total += 1
-                with open(os.path.join(env["LOGS"], file), "rb") as fd:
-                    if b"AutoPatchFailed\n" in fd.readlines():
+                with open(os.path.join(env["LOGS"], file), encoding="latin_1") as fd:
+                    if "AutoPatchFailed\n" in fd.readlines():
                         failed += 1
 
             assert total == len(
@@ -366,9 +366,11 @@ class TestUbootAutomation:
                 )
             except AssertionError:
                 for file in os.listdir(env["LOGS"]):
-                    with open(os.path.join(env["LOGS"], file), "rb") as fd:
+                    with open(
+                        os.path.join(env["LOGS"], file), encoding="latin_1"
+                    ) as fd:
                         log = fd.readlines()
-                        if b"AutoPatchFailed\n" in log:
+                        if "AutoPatchFailed\n" in log:
                             print("Last 50 lines of output from failed board: " + file)
                             print("".join(log[-50:]))
                 raise


### PR DESCRIPTION
This only affects the error path, which fails due to the content being
bytes. Switch to latin_1 coding instead, which accepts the entire
0-255 range of byte characters.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
