### PR TITLE
grub-mender-grubenv.inc: clean build folder in do_configure task

### DIFF
--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -88,6 +88,8 @@ mender_rootfsa_uuid=$mender_rootfsa_uuid
 mender_rootfsb_uuid=$mender_rootfsb_uuid
 EOF
     fi
+
+    oe_runmake -f ${S}/Makefile clean
 }
 
 do_compile() {


### PR DESCRIPTION
If a variable in do_configure task changed do_configure task is triggered
again but not do_compile.This patch clean the build folder and triggered
do_compile task again to get a fresh grub.cfg file with the fresh generated
data from do_configure task.

Signed-off-by: Sebastian Suesens <sebastian.suesens@baslerweb.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
