### PR TITLE
chore: Correct syntax on build-conf files

### DIFF
--- a/tests/build-conf/raspberrypi3/local.conf
+++ b/tests/build-conf/raspberrypi3/local.conf
@@ -301,6 +301,6 @@ MENDER_BOOT_PART_SIZE_MB = "40"
 do_image_sdimg[depends] += " rpi-bootfiles:do_populate_sysroot"
 
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
-IMAGE_FSTYPES:remove += " rpi-sdimg"
+IMAGE_FSTYPES:remove = " rpi-sdimg"
 
 ENABLE_UART = "1"

--- a/tests/build-conf/raspberrypi4/local.conf
+++ b/tests/build-conf/raspberrypi4/local.conf
@@ -301,6 +301,6 @@ MENDER_BOOT_PART_SIZE_MB = "40"
 do_image_sdimg[depends] += " rpi-bootfiles:do_populate_sysroot"
 
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
-IMAGE_FSTYPES:remove += " rpi-sdimg"
+IMAGE_FSTYPES:remove = " rpi-sdimg"
 
 ENABLE_UART = "1"


### PR DESCRIPTION
Gets the rid of:
```
WARNING: IMAGE_FSTYPES:remove += is not a recommended operator combination, please replace it.
```
