### PR TITLE
fix: Make `read-only-rootfs` tweaks dependent on `mender-image` feature flag.

### DIFF
--- a/meta-mender-commercial/conf/layer.conf
+++ b/meta-mender-commercial/conf/layer.conf
@@ -17,4 +17,4 @@ LAYERDEPENDS_mender-commercial = "mender"
 
 # See https://tracker.mender.io/browse/MEN-3513 and
 # https://tracker.mender.io/browse/MEN-3912
-EXTRA_IMAGECMD_ext4_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"
+EXTRA_IMAGECMD_ext4_mender-image_append = "${@bb.utils.contains('IMAGE_FEATURES', 'read-only-rootfs', ' -O ^64bit -O ^has_journal', '', d)}"


### PR DESCRIPTION
This is to avoid altering the build just by adding the layer.

Changelog: Title
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
