### PR TITLE
MEN-5834: fix: cmdline.txt generation in meta-mender-raspberrypi

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline-mender.inc
+++ b/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline-mender.inc
@@ -1,0 +1,2 @@
+CMDLINE_ROOTFS:remove = "root=/dev/mmcblk0p2"
+CMDLINE_ROOTFS:append = " root=\${mender_kernel_root} "

--- a/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline-mender.inc
+++ b/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline-mender.inc
@@ -1,2 +1,12 @@
 CMDLINE_ROOTFS:remove = "root=/dev/mmcblk0p2"
-CMDLINE_ROOTFS:append = " root=\${mender_kernel_root} "
+
+do_compile:append() {
+    # Modify cmdline.txt after its creation to append root=... parameter
+    #
+    # We cannot use CMDLINE_ROOTFS:append = " root=\${mender_kernel_root} "
+    # because ${...} cannot be properly escaped and do_compile then breaks
+    # with bad substitution
+    # See https://github.com/agherzan/meta-raspberrypi/blob/master/recipes-bsp/bootfiles/rpi-cmdline.bb
+
+    sed -i 's,$, root=\${mender_kernel_root},' "${WORKDIR}/cmdline.txt"
+}

--- a/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,1 @@
+include ${@mender_feature_is_enabled("mender-client-install","rpi-cmdline-mender.inc","",d)}

--- a/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi-mender.inc
+++ b/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi-mender.inc
@@ -1,2 +1,0 @@
-CMDLINE:remove = "root=/dev/mmcblk0p2"
-CMDLINE:append = " root=\${mender_kernel_root} "

--- a/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,1 +1,0 @@
-include ${@mender_feature_is_enabled("mender-client-install","linux-raspberrypi-mender.inc","",d)}


### PR DESCRIPTION
    fix: cmdline.txt generation in meta-mender-raspberrypi
    
    The generation of cmdline.txt has been moved upstream to a new recipe,
    so our bbappend was not being applied.
    
    See:
    https://github.com/agherzan/meta-raspberrypi/commit/8827040d9c218f68ae3ee6a5814929888ed61581
    
    Ticket: MEN-5834
    Changelog: None


    fix(rpi-cmdline-mender.inc): Fix cmdline.txt after generation
    
    Due to an implementation detail, we cannot use the standard syntax for
    appending, see inline comment.
    
    Ticket: MEN-5834
    Changelog: None
