### PR TITLE
perf(update-firmware-state-script) Improve robustness

### DIFF
--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
@@ -10,6 +10,17 @@ trap trap_exit EXIT
 MENDER_ROOTFS_PART_A="@@MENDER_ROOTFS_PART_A@@"
 MENDER_ROOTFS_PART_B="@@MENDER_ROOTFS_PART_B@@"
 
+safe_copy() {
+  if [ $# -gt 2 ]; then
+    echo "safe_copy can only handle one file copy at a time" >&2
+    exit 2
+  fi
+  cp -a "$1" "$2".tmp || return $?
+  sync "$2".tmp || return $?
+  mv "$2".tmp "$2" || return $?
+  sync "$(dirname "$2")" || return $?
+}
+
 if mount | grep ${MENDER_ROOTFS_PART_A}; then
   inactive_part="${MENDER_ROOTFS_PART_B}"
 else
@@ -23,16 +34,14 @@ mount -o ro ${inactive_part} /tmp/inactive_part
 # render the device unusable.
 
 # Copy 'core' firmware files first
-find /tmp/inactive_part/boot/firmware/ -maxdepth 1 -type f | xargs -I {} cp -v {} /uboot/
-
-# Synchronize before trying to copy the rest of the files
-sync
+for f in $(find /tmp/inactive_part/boot/firmware/ -maxdepth 1 -type f); do
+  safe_copy $f /uboot/$(basename $f)
+done
 
 # Copy overlays
-find /tmp/inactive_part/boot/firmware/overlays/ -maxdepth 1 -type f | xargs -I {} cp -v {} /uboot/overlays/
-
-# Synchronize to ensure all files are written before leaving the ArtifactInstall state
-sync
+for f in $(find /tmp/inactive_part/boot/firmware/overlays/ -maxdepth 1 -type f); do
+  safe_copy $f /uboot/overlays/$(basename $f)
+done
 
 
 exit 0


### PR DESCRIPTION
Changelog: meta-mender-raspberrypi: update-firmware-state-script: Make
copies of firmware binaries safer. On VFAT file-systems `mv` is not
atomic, but still using it narrows the time window in which the files
could be corrupted.