### PR TITLE
fix: Update pseudo db when excluding content from rootfs

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -109,7 +109,7 @@ python prepare_excluded_directories() {
         bb.debug(1, "'IMAGE_ROOTFS_EXCLUDE_PATH' is set but 'respect_exclude_path' variable flag is 0 for this image type, so ignoring it")
         return
 
-    import shutil
+    import subprocess
     from oe.path import copyhardlinktree
 
     exclude_list = exclude_var.split()
@@ -120,7 +120,7 @@ python prepare_excluded_directories() {
     new_rootfs = os.path.realpath(os.path.join(d.getVar("WORKDIR"), "rootfs.%s" % taskname))
 
     if os.path.lexists(new_rootfs):
-        shutil.rmtree(os.path.join(new_rootfs))
+        subprocess.check_call(["rm", "-rf", new_rootfs])
 
     copyhardlinktree(rootfs_orig, new_rootfs)
 
@@ -146,12 +146,12 @@ python prepare_excluded_directories() {
             for entry in os.listdir(full_path):
                 full_entry = os.path.join(full_path, entry)
                 if os.path.isdir(full_entry) and not os.path.islink(full_entry):
-                    shutil.rmtree(full_entry)
+                    subprocess.check_call(["rm", "-rf", full_entry])
                 else:
-                    os.remove(full_entry)
+                    subprocess.check_call(["rm", "-f", full_entry])
         else:
             # Delete whole directory.
-            shutil.rmtree(full_path)
+            subprocess.check_call(["rm", "-rf", full_path])
 
     # Save old value for cleanup later.
     d.setVar('IMAGE_ROOTFS_ORIG', rootfs_orig)
@@ -162,6 +162,8 @@ python cleanup_excluded_directories() {
     exclude_var = d.getVar('IMAGE_ROOTFS_EXCLUDE_PATH')
     if not exclude_var:
         return
+
+    import subprocess
 
     taskname = d.getVar("BB_CURRENTTASK")
 
@@ -176,7 +178,7 @@ python cleanup_excluded_directories() {
     # directory in the prepare function.
     assert rootfs_dirs_excluded != rootfs_orig
 
-    shutil.rmtree(rootfs_dirs_excluded)
+    subprocess.check_call(["rm", "-rf", rootfs_dirs_excluded])
     d.setVar('IMAGE_ROOTFS', rootfs_orig)
 }
 


### PR DESCRIPTION
This commit is inspired the commit below from poky: https://git.yoctoproject.org/poky/commit/?id=f85a4a1462bc2105f7c62f2b09c1d092c7677ada

Although the code is different, it is applying the exact same type of fix, and therefore I'm also reusing (most of) their commit message below:

---

To exclude content from the rootfs, the prefunc makes a copy (using hardlinks if possible) of the rootfs directory and associated pseudo db, then removes files & directories as needed. However if these files and directories are removed using the python functions os.remove and shutil.rmtree, the copied pseudo db will not be updated correctly. For files copied from the original rootfs, if hardlinks were used successfully when copying the rootfs this should mean that the relevant inodes can't be reused and so the risk of pseudo aborts should be avoided. However, this logic doesn't apply for directories (as they can't be hardlinked) and so there remains some risk of inodes being reused and the pseudo db becoming corrupted.

To fix this, use the 'rm' command under pseudo when removing files & directories from the copied rootfs to ensure that the copied pseudo db is updated.

Changelog: Fix occasional pseudo abort issue when building certain images, especially in parallel. The symptom was this message:
```
abort()ing pseudo client by server request.
See https://wiki.yoctoproject.org/wiki/Pseudo_Abort for more details on this
```

Ticket: MEN-5857

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
