### PR TITLE
fix: Update pseudo db when excluding content from rootfs

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -104,7 +104,7 @@ python prepare_excluded_directories() {
         bb.debug(1, "'IMAGE_ROOTFS_EXCLUDE_PATH' is set but 'respect_exclude_path' variable flag is 0 for this image type, so ignoring it")
         return
 
-    import shutil
+    import subprocess
     from oe.path import copyhardlinktree
 
     exclude_list = exclude_var.split()
@@ -115,7 +115,7 @@ python prepare_excluded_directories() {
     new_rootfs = os.path.realpath(os.path.join(d.getVar("WORKDIR"), "rootfs.%s" % taskname))
 
     if os.path.lexists(new_rootfs):
-        shutil.rmtree(os.path.join(new_rootfs))
+        subprocess.check_call(["rm", "-rf", new_rootfs])
 
     copyhardlinktree(rootfs_orig, new_rootfs)
 
@@ -141,12 +141,12 @@ python prepare_excluded_directories() {
             for entry in os.listdir(full_path):
                 full_entry = os.path.join(full_path, entry)
                 if os.path.isdir(full_entry) and not os.path.islink(full_entry):
-                    shutil.rmtree(full_entry)
+                    subprocess.check_call(["rm", "-rf", full_entry])
                 else:
-                    os.remove(full_entry)
+                    subprocess.check_call(["rm", "-f", full_entry])
         else:
             # Delete whole directory.
-            shutil.rmtree(full_path)
+            subprocess.check_call(["rm", "-rf", full_path])
 
     # Save old value for cleanup later.
     d.setVar('IMAGE_ROOTFS_ORIG', rootfs_orig)
@@ -157,6 +157,8 @@ python cleanup_excluded_directories() {
     exclude_var = d.getVar('IMAGE_ROOTFS_EXCLUDE_PATH')
     if not exclude_var:
         return
+
+    import subprocess
 
     taskname = d.getVar("BB_CURRENTTASK")
 
@@ -171,7 +173,7 @@ python cleanup_excluded_directories() {
     # directory in the prepare function.
     assert rootfs_dirs_excluded != rootfs_orig
 
-    shutil.rmtree(rootfs_dirs_excluded)
+    subprocess.check_call(["rm", "-rf", rootfs_dirs_excluded])
     d.setVar('IMAGE_ROOTFS', rootfs_orig)
 }
 

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -109,6 +109,14 @@ class TestDBus:
             assert f'string "{self.JWT_TOKEN}' in output
             if version_is_minimum(bitbake_variables, "mender-client", "3.3.1"):
                 assert 'string "http://127.0.0.1:' in output
+                # Check that this really is the only port we're listening on.
+                lines = connection.run("netstat -t -u -l -p -n").stdout.split("\n")
+                lines = [line for line in lines if line.strip().endswith("/mender")]
+                assert len(lines) == 1
+                address_and_port_index = 3
+                listen = lines[0].split()[address_and_port_index]
+                assert listen.startswith("127.0.0.1:")
+                assert f'string "http://{listen}"' in output
             elif version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
                 assert 'string "http://localhost:' in output
             else:

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -107,7 +107,7 @@ class TestDBus:
                 time.sleep(5)
 
             assert f'string "{self.JWT_TOKEN}' in output
-            if version_is_minimum(bitbake_variables, "mender-client", "3.4.0"):
+            if version_is_minimum(bitbake_variables, "mender-client", "3.3.1"):
                 assert 'string "http://127.0.0.1:' in output
             elif version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
                 assert 'string "http://localhost:' in output
@@ -180,7 +180,7 @@ class TestDBus:
 
                 output = result.stdout.strip()
                 assert f'string "{self.JWT_TOKEN}' in output
-                if version_is_minimum(bitbake_variables, "mender-client", "3.4.0"):
+                if version_is_minimum(bitbake_variables, "mender-client", "3.3.1"):
                     assert 'string "http://127.0.0.1:' in output
                 elif version_is_minimum(bitbake_variables, "mender-client", "3.2.0"):
                     assert 'string "http://localhost:' in output


### PR DESCRIPTION
This commit is inspired the commit below from poky: https://git.yoctoproject.org/poky/commit/?id=f85a4a1462bc2105f7c62f2b09c1d092c7677ada

Although the code is different, it is applying the exact same type of fix, and therefore I'm also reusing (most of) their commit message below:

---

To exclude content from the rootfs, the prefunc makes a copy (using hardlinks if possible) of the rootfs directory and associated pseudo db, then removes files & directories as needed. However if these files and directories are removed using the python functions os.remove and shutil.rmtree, the copied pseudo db will not be updated correctly. For files copied from the original rootfs, if hardlinks were used successfully when copying the rootfs this should mean that the relevant inodes can't be reused and so the risk of pseudo aborts should be avoided. However, this logic doesn't apply for directories (as they can't be hardlinked) and so there remains some risk of inodes being reused and the pseudo db becoming corrupted.

To fix this, use the 'rm' command under pseudo when removing files & directories from the copied rootfs to ensure that the copied pseudo db is updated.

Changelog: Fix occasional pseudo abort issue when building certain images, especially in parallel. The symptom was this message:
```
abort()ing pseudo client by server request.
See https://wiki.yoctoproject.org/wiki/Pseudo_Abort for more details on this
```

Ticket: MEN-5857

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

(cherry picked from commit 1e1996875b6bc5c0edfb3f7f7c694272a07c5b80)
