### PR TITLE
chore: Work around bug in interaction between pseudo and pycache.

### DIFF
--- a/tests/build-conf/beagleboneblack/local.conf
+++ b/tests/build-conf/beagleboneblack/local.conf
@@ -243,6 +243,10 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/qemux86-64-bios-grub-gpt/local.conf
+++ b/tests/build-conf/qemux86-64-bios-grub-gpt/local.conf
@@ -245,6 +245,10 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/qemux86-64-bios-grub/local.conf
+++ b/tests/build-conf/qemux86-64-bios-grub/local.conf
@@ -241,6 +241,10 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/qemux86-64-uefi-grub/local.conf
+++ b/tests/build-conf/qemux86-64-uefi-grub/local.conf
@@ -241,6 +241,10 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/raspberrypi3/local.conf
+++ b/tests/build-conf/raspberrypi3/local.conf
@@ -23,6 +23,10 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/raspberrypi4/local.conf
+++ b/tests/build-conf/raspberrypi4/local.conf
@@ -23,6 +23,10 @@ PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
 
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/vexpress-qemu-flash/local.conf
+++ b/tests/build-conf/vexpress-qemu-flash/local.conf
@@ -24,6 +24,10 @@ EXTRA_IMAGE_FEATURES="debug-tweaks"
 
 USER_CLASSES ?= "buildstats image-mklibs"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/vexpress-qemu-uboot-uefi-grub/local.conf
+++ b/tests/build-conf/vexpress-qemu-uboot-uefi-grub/local.conf
@@ -241,6 +241,10 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 

--- a/tests/build-conf/vexpress-qemu/local.conf
+++ b/tests/build-conf/vexpress-qemu/local.conf
@@ -241,6 +241,10 @@ BB_DISKMON_DIRS = "\
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# MEN-5857: Get rid of pseudo abort errors which happen because __pycache__
+# directories are created inside ${COREBASE}/bitbake/lib.
+PSEUDO_IGNORE_PATHS .= ",${COREBASE}/bitbake,${COREBASE}/meta"
+
 # Commercial components for Mender.
 LICENSE_FLAGS_WHITELIST_append = " commercial_mender-yocto-layer-license"
 


### PR DESCRIPTION
At the time of writing, this appears to affect dunfell only, not kirkstone, although the reason for this is unclear.

Ticket: MEN-5857

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
