### PR TITLE
ci: enforce the use of KVM in our CI

### DIFF
--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -123,8 +123,15 @@ $QEMU_SYSTEM --version || exit 1
 
 echo "--- starting qemu"
 
+USE_KVM=' -enable-kvm ""'
+if [ -n "${GITLAB_CI}" ]; then
+    # Enforce kvm in our CI
+    USE_KVM=' -enable-kvm'
+fi
+
+
 ret=0
-for maybe_kvm in -enable-kvm ""; do
+for maybe_kvm in ${USE_KVM}; do
     if QEMU_AUDIO_DRV=none \
             $QEMU_SYSTEM \
             -m 256M \


### PR DESCRIPTION
This will only try and run QEMU with kvm enabled.

If KVM is not enabled, the script will fail, and we will be able to catch that something is amiss with the CI setup of test slaves.

Ticket: QA-414

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

