### PR TITLE
Allow to use Label with Partuuid

### DIFF
--- a/meta-mender-core/classes/mender-maybe-setup.bbclass
+++ b/meta-mender-core/classes/mender-maybe-setup.bbclass
@@ -78,8 +78,8 @@ python() {
         # Use PARTUUID to set fixed drive locations.
         'mender-partuuid',
 
-        # Use PARTLABEL to avoid hardcoded drive device path.
-        'mender-partlabel',
+        # Use LABEL to avoid hardcoded drive device path.
+        'mender-fslabel',
 
         # Setup the systemd machine ID to be persistent across OTA updates.
         'mender-persist-systemd-machine-id',

--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -39,12 +39,12 @@ mender_update_fstab_file() {
     local tmpDataPart="${MENDER_DATA_PART}"
     local partuuid="${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}"
     local partlabel="${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}"
-    if [ ${partuuid} = "true" ]; then
-        tmpBootPart="PARTUUID=${@mender_get_partuuid_from_device(d, '${MENDER_BOOT_PART}')}"
-        tmpDataPart="PARTUUID=${@mender_get_partuuid_from_device(d, '${MENDER_DATA_PART}')}"
-    elif [ ${partlabel} = "true" ]; then
+    if [ ${partlabel} = "true" ]; then
         tmpBootPart="LABEL=${MENDER_BOOT_PART_LABEL}"
         tmpDataPart="LABEL=${MENDER_DATA_PART_LABEL}"
+    elif [ ${partuuid} = "true" ]; then
+        tmpBootPart="PARTUUID=${@mender_get_partuuid_from_device(d, '${MENDER_BOOT_PART}')}"
+        tmpDataPart="PARTUUID=${@mender_get_partuuid_from_device(d, '${MENDER_DATA_PART}')}"
     fi
 
     if ! ${@bb.utils.contains('MENDER_FEATURES', 'mender-image-ubi', 'true', 'false', d)}; then

--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -38,8 +38,8 @@ mender_update_fstab_file() {
     local tmpBootPart="${MENDER_BOOT_PART}"
     local tmpDataPart="${MENDER_DATA_PART}"
     local partuuid="${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}"
-    local partlabel="${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}"
-    if [ ${partlabel} = "true" ]; then
+    local fslabel="${@bb.utils.contains('MENDER_FEATURES', 'mender-fslabel', 'true', 'false', d)}"
+    if [ ${fslabel} = "true" ]; then
         tmpBootPart="LABEL=${MENDER_BOOT_PART_LABEL}"
         tmpDataPart="LABEL=${MENDER_DATA_PART_LABEL}"
     elif [ ${partuuid} = "true" ]; then

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -262,7 +262,7 @@ python mender_sanity_handler() {
     if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-uboot', True, False, d):
         bb.fatal("mender-partuuid is not supported with mender-uboot.")
 
-    if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partlabel', True, False, d):
+    if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-fslabel', True, False, d):
         bb.note("mender-partuuid will be only used for GPT and bootloader.")
 }
 

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -263,7 +263,7 @@ python mender_sanity_handler() {
         bb.fatal("mender-partuuid is not supported with mender-uboot.")
 
     if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partlabel', True, False, d):
-        bb.fatal("mender-partuuid is not supported with mender-partlabel.")
+        bb.note("mender-partuuid will be only used for GPT and bootloader.")
 }
 
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -10,7 +10,7 @@ DEPENDS:class-native = ""
 PACKAGES:append = " mender-modules-gen"
 
 RDEPENDS:${PN}:append:mender-growfs-data:mender-systemd = " parted util-linux-fdisk"
-RDEPENDS:${PN}:append:mender-growfs-data:mender-systemd:mender-partlabel = " util-linux-blkid"
+RDEPENDS:${PN}:append:mender-growfs-data:mender-systemd:mender-fslabel = " util-linux-blkid"
 RDEPENDS:${PN}:append:mender-growfs-data:mender-systemd:mender-partuuid = " util-linux-blkid"
 RDEPENDS:mender-modules-gen = "bash"
 
@@ -346,7 +346,7 @@ do_install:append:class-target:mender-image:mender-systemd() {
 
 do_install:append:class-target:mender-growfs-data:mender-systemd() {
 
-    if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
+    if ${@bb.utils.contains('MENDER_FEATURES', 'mender-fslabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
             ${WORKDIR}/mender-client-resize-data-part.sh.in
     elif ${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}; then


### PR DESCRIPTION
Hi,

At the moment, we don't allow to use both PartUUID and PartLabel (which is a bad name choose by me :( because it's based on Label and not PartLabel)

But It can make sense in case a user want to use the label on /etc/fstab and boot linux with the cmdline root=PARTUUID=XXX 

Also in my case it makes sense I have already shipped some hardware where the PARTUUID in the GPT are random but the LABEL are properly set, I want to be able to support this machine so I need to keep my artifact to use the LABEL in the /etc/fstab and mender-grow-data-part but I want my next machine to have a proper PartUUID feature for booting so in the grub.cfg and mender.conf (see: https://hub.mender.io/t/qemu-kvm-vs-hyper-v-dev-sdx-or-dev-vdx/5254).

Hope it's clear,
BR  