### PR TITLE
QA-414: Handle the QEMU client running out of memory

### DIFF
--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -757,7 +757,7 @@ done
 
             # Constantly reinsert map over and over in the background, to force
             # state transitions.
-            connection.run("systemd-run sh /data/map-insert.sh")
+            connection.run("systemd-run -p LogLevelMax=3 sh /data/map-insert.sh")
 
             now = time.time()
 


### PR DESCRIPTION
The `map-insert` shell script fills up the running memory of the client, when run for long enough.

Simply fix this through logging `Error` and above.