### PR TITLE
test(update_control): fix the issue with /run logs filling up mem

### DIFF
--- a/tests/meta-mender-ci/recipes-core/systemd-conf/files/journald.conf
+++ b/tests/meta-mender-ci/recipes-core/systemd-conf/files/journald.conf
@@ -1,0 +1,11 @@
+[Journal]
+SyncIntervalSec=1m
+RateLimitBurst=1000
+SystemMaxUse=10M
+SystemKeepFree=150M
+SystemMaxFileSize=1M
+SystemMaxFiles=10
+RuntimeMaxUse=10M
+RuntimeKeepFree=150M
+RuntimeMaxFileSize=1M
+RuntimeMaxFiles=10

--- a/tests/meta-mender-ci/recipes-core/systemd-conf/files/journald.conf
+++ b/tests/meta-mender-ci/recipes-core/systemd-conf/files/journald.conf
@@ -9,3 +9,4 @@ RuntimeMaxUse=10M
 RuntimeKeepFree=150M
 RuntimeMaxFileSize=1M
 RuntimeMaxFiles=10
+ForwardToSyslog=yes

--- a/tests/meta-mender-ci/recipes-core/systemd-conf/systemd-conf_%.bbappend
+++ b/tests/meta-mender-ci/recipes-core/systemd-conf/systemd-conf_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend:mender-systemd := "${THISDIR}/files:"
+
+SRC_URI:append:mender-systemd = " \
+    file://journald.conf \
+"
+
+FILES:${PN}:append:mender-systemd = " \
+    ${sysconfdir}/systemd/journald.conf.d/00-journal-size.conf \
+"
+
+do_install:append:mender-systemd() {
+        install -d ${D}${sysconfdir}/systemd/journald.conf.d/
+        install -m 0644 ${WORKDIR}/journald.conf ${D}${sysconfdir}/systemd/journald.conf.d/00-journal-size.conf
+}


### PR DESCRIPTION
After a bit of digging, I discovered that when KVM is once again re-enabled in our acceptance test jobs, the client would run out of memory, as a result of the 'systemd-run' job filling up the `/run`, and hence the running memory of the QEMU instance.

The fix is to create a stricter journald config for our CI-layer.

The settings are pretty strict, but I don't necessarily see a big problem here.

With these settings a vacuum of the log is triggered at tighter intervals, so less logs are kept. But still plenty of MiB's available for log storage.

Ticket: QA-414

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

