### PR TITLE
fix: bump the grub-mender-grubenv version

### DIFF
--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,7 +1,7 @@
-GRUB_MENDER_GRUBENV_REV = "4acc526f0fc93d12eebf0f2902736fa8b487c941"
+GRUB_MENDER_GRUBENV_REV = "081c20bc7e047c6cd381e39919bdfbdd34f48849"
 GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \
                 efi_gop iso9660 configfile search loadenv test \
                 cat echo gcry_sha256 halt hashsum sleep reboot regexp \
-                loadenv test"
+                loadenv test xfs"

--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
@@ -22,7 +22,7 @@ URL_BASE ?= "https://downloads.mender.io/grub-mender-grubenv/grub-efi"
 
 SRC_URI = " \
     ${GRUB_MENDER_GRUBENV_SRC_URI} \
-    ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-efi-${EFI_BOOT_IMAGE};md5sum=7ec4b336f333f45abec86f6193326226 \
+    ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-efi-${EFI_BOOT_IMAGE};md5sum=63c8f8570b763b59dd2a26f372e03155 \
     ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-editenv;md5sum=2c5e943a0acc4a6bd385a9d3f72b637b \
 "
 


### PR DESCRIPTION
Ticket: ME-6
Changelog: Upgrade grub-mender-grubenv to include the XFS module in the default installation.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
