### PR TITLE
fix: missing dependency to mender-artifact-info for all mender-client…

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client.inc
@@ -108,7 +108,7 @@ PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-client-i
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-uboot', ' u-boot', '', d)}"
 PACKAGECONFIG_append = "${@bb.utils.contains('DISTRO_FEATURES', 'mender-grub', ' grub', '', d)}"
 
-PACKAGECONFIG[mender-client-install] = ",,,ca-certificates"
+PACKAGECONFIG[mender-client-install] = ",,,mender-artifact-info ca-certificates"
 PACKAGECONFIG[u-boot] = ",,,libubootenv-bin"
 PACKAGECONFIG[grub] = ",,,grub-editenv grub-mender-grubenv"
 # The docker module depends on bash, and of course on docker. However, docker is

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_3.3.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_3.3.0.bb
@@ -29,5 +29,3 @@ LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8 & Op
 
 DEPENDS += "xz openssl"
 RDEPENDS_${PN} += "liblzma openssl"
-
-RDEPENDS_${PN} += "mender-artifact-info"


### PR DESCRIPTION
… versions

With the latest changes, dependency to mender-artifact-info was removed for all mender-client versions besides 3.3.0. This causes a broken OTA-feature as mender-client is not able to install any further artifact when file /etc/mender/mender_artifact_info is missing.

This change reverts changes from commit
222532bf36d3ac195d62e11e5cfd06df0ae5a1c0. As i don't understand the whole purpose of this commit, the change needs be checked if any other functionality is broken now.

Signed-off-by: Ruben Schwarz <r.schwarz@sotec.eu>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
