### PR TITLE
[Cherry](dunfell) fix: bump the grub-mender-grubenv version

### DIFF
--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,7 +1,7 @@
-GRUB_MENDER_GRUBENV_REV = "f39c2c7ec7c9c24aae0108a9b04a0e6e61a3e96b"
+GRUB_MENDER_GRUBENV_REV = "081c20bc7e047c6cd381e39919bdfbdd34f48849"
 GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \
                 efi_gop iso9660 configfile search loadenv test \
                 cat echo gcry_sha256 halt hashsum sleep reboot regexp \
-                loadenv test"
+                loadenv test xfs"

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
@@ -6,4 +6,4 @@ SRCREV = "${GRUB_MENDER_GRUBENV_REV}"
 PV = "1.3.0+git${SRCREV}"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=7fd64609fe1bce47db0e8f6e3cc6a11d"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87"

--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
@@ -22,7 +22,7 @@ URL_BASE ?= "https://d1b0l86ne08fsf.cloudfront.net/grub-mender-grubenv/grub-efi"
 
 SRC_URI = " \
     ${GRUB_MENDER_GRUBENV_SRC_URI} \
-    ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-efi-${EFI_BOOT_IMAGE};md5sum=7ec4b336f333f45abec86f6193326226 \
+    ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-efi-${EFI_BOOT_IMAGE};md5sum=63c8f8570b763b59dd2a26f372e03155 \
     ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-editenv;md5sum=2c5e943a0acc4a6bd385a9d3f72b637b \
 "
 


### PR DESCRIPTION
Ticket: ME-6
Changelog: Upgrade grub-mender-grubenv to include the XFS module in the default installation.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
(cherry picked from commit 8975a58ea8ef3353f7c0d82560d24b64f29923e0)
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
