### PR TITLE
MEN-5845: feat: Add information about supported update modules in mender Artifacts

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -40,6 +40,22 @@ apply_arguments () {
     cmd=$res
 }
 
+artifact_provides_modules_arguments () {
+    local modules_provides=""
+    for module in $(ls ${IMAGE_ROOTFS}/${datadir}/mender/modules/v3); do
+        if [ -x "${IMAGE_ROOTFS}/${datadir}/mender/modules/v3/${module}" ]; then
+            modules_provides="${modules_provides} \
+                rootfs-image.update-module.${module}.version:${MENDER_ARTIFACT_NAME} \
+                rootfs-image.update-module.${module}.mender_update_module:${module} \
+            "
+        else
+            bbwarn "File ${datadir}/mender/modules/v3/${module} has no execution permissions, is it an Update Module?"
+        fi
+    done
+    cmd=""
+    apply_arguments "--provides" "${modules_provides}"
+}
+
 IMAGE_CMD:mender () {
     set -x
 
@@ -106,6 +122,10 @@ IMAGE_CMD:mender () {
         apply_arguments "--depends-groups" "${MENDER_ARTIFACT_DEPENDS_GROUPS}"
         extra_args="$extra_args $cmd"
     fi
+
+    cmd=""
+    artifact_provides_modules_arguments
+    extra_args="$extra_args $cmd"
 
     mender-artifact write rootfs-image \
         -n ${MENDER_ARTIFACT_NAME} \

--- a/meta-mender-core/classes/mender-bootstrap-artifact.bbclass
+++ b/meta-mender-core/classes/mender-bootstrap-artifact.bbclass
@@ -66,6 +66,10 @@ IMAGE_CMD:bootstrap-artifact() {
             bberror "The image checksum cannot be empty"
         fi
 
+        cmd=""
+        artifact_provides_modules_arguments
+        extra_args="$extra_args $cmd"
+
         # NOTE: We don't allow extra arguments from MENDER_ARTIFACT_EXTRA_ARGS
         mender-artifact write bootstrap-artifact \
             --artifact-name ${MENDER_ARTIFACT_NAME} \

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -691,8 +691,12 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
     @pytest.mark.only_with_image("sdimg", "uefiimg")
     @pytest.mark.min_mender_version("2.0.0")
     def test_module_install(
-        self, request, prepared_test_build, bitbake_path, latest_rootfs, bitbake_image
+        self, request, prepared_test_build, bitbake_path, bitbake_image
     ):
+        """Test that with PACKAGECONFIG "modules" switch in mender-client recipe the modules
+        are installed in the root filesystem, and the built mender Artifact(s) contain them
+        as "provides" keys."""
+
         # List of expected update modules
         default_update_modules = [
             "deb",
@@ -710,15 +714,86 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         else:
             originally_on = False
 
-        output = subprocess.check_output(
-            ["debugfs", "-R", "ls -p /usr/share/mender/modules/v3", latest_rootfs]
-        ).decode()
-        entries = [
-            elem.split("/")[5] for elem in output.split("\n") if elem.startswith("/")
-        ]
+        def _check_update_modules_present_in_filesystem(rootfs_image, expect_present):
+            output = subprocess.check_output(
+                ["debugfs", "-R", "ls -p /usr/share/mender/modules/v3", rootfs_image]
+            ).decode()
+            files_entries = [
+                elem.split("/")[5]
+                for elem in output.split("\n")
+                if elem.startswith("/")
+            ]
+
+            if expect_present:
+                assert all([e in files_entries for e in default_update_modules])
+            else:
+                assert not any([e in files_entries for e in default_update_modules])
+
+        def _check_update_modules_provided_in_artifact(mender_artifact, expect_present):
+            output = subprocess.check_output(
+                ["mender-artifact", "read", mender_artifact]
+            ).decode()
+            provides_entries = [
+                elem.strip().split(":")[0]
+                for elem in output.split("\n")
+                if "rootfs-image.update-module." in elem
+            ]
+
+            if expect_present:
+                assert all(
+                    [
+                        "rootfs-image.update-module." + e + ".mender_update_module"
+                        in provides_entries
+                        for e in default_update_modules
+                    ]
+                )
+                assert all(
+                    [
+                        "rootfs-image.update-module." + e + ".version"
+                        in provides_entries
+                        for e in default_update_modules
+                    ]
+                )
+            else:
+                assert not any(
+                    [
+                        "rootfs-image.update-module." + e + ".mender_update_module"
+                        in provides_entries
+                        for e in default_update_modules
+                    ]
+                )
+                assert not any(
+                    [
+                        "rootfs-image.update-module." + e + ".version"
+                        in provides_entries
+                        for e in default_update_modules
+                    ]
+                )
+
+        original_rootfs = latest_build_artifact(
+            request, os.environ["BUILDDIR"], "core-image*.ext[234]"
+        )
+        original_artifact = latest_build_artifact(
+            request, os.environ["BUILDDIR"], "core-image*.mender"
+        )
+        original_bootstrap_artifact = latest_build_artifact(
+            request, os.environ["BUILDDIR"], "core-image*.bootstrap-artifact",
+        )
 
         if originally_on:
-            assert all([e in entries for e in default_update_modules])
+            _check_update_modules_present_in_filesystem(original_rootfs, True)
+            _check_update_modules_provided_in_artifact(original_artifact, True)
+            _check_update_modules_provided_in_artifact(
+                original_bootstrap_artifact, True
+            )
+        else:
+            _check_update_modules_present_in_filesystem(original_rootfs, False)
+            _check_update_modules_provided_in_artifact(original_artifact, False)
+            _check_update_modules_provided_in_artifact(
+                original_bootstrap_artifact, False
+            )
+
+        if originally_on:
             build_image(
                 prepared_test_build["build_dir"],
                 prepared_test_build["bitbake_corebase"],
@@ -726,7 +801,6 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
                 ['PACKAGECONFIG:remove = "modules"'],
             )
         else:
-            assert not any([e in entries for e in default_update_modules])
             build_image(
                 prepared_test_build["build_dir"],
                 prepared_test_build["bitbake_corebase"],
@@ -735,20 +809,23 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             )
 
         new_rootfs = latest_build_artifact(
-            request, prepared_test_build["build_dir"], "core-image*.ext4"
+            request, prepared_test_build["build_dir"], "core-image*.ext[234]"
+        )
+        new_artifact = latest_build_artifact(
+            request, prepared_test_build["build_dir"], "core-image*.mender",
+        )
+        new_bootstrap_artifact = latest_build_artifact(
+            request, prepared_test_build["build_dir"], "core-image*.bootstrap-artifact",
         )
 
-        output = subprocess.check_output(
-            ["debugfs", "-R", "ls -p /usr/share/mender/modules/v3", new_rootfs]
-        ).decode()
-        entries = [
-            elem.split("/")[5] for elem in output.split("\n") if elem.startswith("/")
-        ]
-
         if originally_on:
-            assert not any([e in entries for e in default_update_modules])
+            _check_update_modules_present_in_filesystem(new_rootfs, False)
+            _check_update_modules_provided_in_artifact(new_artifact, False)
+            _check_update_modules_provided_in_artifact(new_bootstrap_artifact, False)
         else:
-            assert all([e in entries for e in default_update_modules])
+            _check_update_modules_present_in_filesystem(new_rootfs, True)
+            _check_update_modules_provided_in_artifact(new_artifact, True)
+            _check_update_modules_provided_in_artifact(new_bootstrap_artifact, True)
 
     @pytest.mark.only_with_image("sdimg", "uefiimg", "gptimg", "biosimg")
     @pytest.mark.min_mender_version("1.0.0")
@@ -940,7 +1017,9 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
                         l = [s.strip() for s in lines[k].split(": ")]
                         assert len(l) == 2, "Line should only contain a key value pair"
                         key, val = l[0], l[1]
-                        tmp[key] = val
+                        # Ignore all "provides" added with the installed update modules
+                        if not key.startswith("rootfs-image.update-module"):
+                            tmp[key] = val
                         k += 1
                     d.provides = tmp
 


### PR DESCRIPTION
And extend existing test to verify the new functionality.

Changelog: Mender Artifacts include now information about the installed Update Modules in the image. Specifically, the Artifacts `provide` two pair of keys for each module:
`rootfs-image.update-module.<UPDATE_MODULE>.version` and `rootfs-image.update-module.<UPDATE_MODULE>.mender_update_module`. This also applies to the bootstrap Artifact which gets installed on first boot.