### PR TITLE
chore: Fix warnings

### DIFF
--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -13,8 +13,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import distutils.spawn
-from distutils.version import LooseVersion
 import os
 import re
 import shutil
@@ -30,6 +28,7 @@ from utils.common import (
     run_after_connect,
     determine_active_passive_part,
     make_tempdir,
+    version_is_minimum,
 )
 from utils.helpers import Helpers
 
@@ -188,7 +187,7 @@ class TestDeltaUpdateModule:
         ):
             pytest.skip("Only works when using read-only-rootfs IMAGE_FEATURE")
 
-        if distutils.spawn.find_executable("mender-binary-delta-generator") is None:
+        if shutil.which("mender-binary-delta-generator") is None:
             pytest.fail("mender-binary-delta-generator not found in PATH")
 
         built_artifact = self.do_install_mender_binary_delta(
@@ -203,10 +202,7 @@ class TestDeltaUpdateModule:
             s3_address,
         )
 
-        binary_delta_vars = get_bitbake_variables(
-            request, "mender-binary-delta", prepared_test_build
-        )
-        if LooseVersion(binary_delta_vars["PV"]) < LooseVersion("1.3.0"):
+        if not version_is_minimum(bitbake_variables, "mender-binary-delta", "1.3.0"):
             pytest.skip(
                 "This version of mender-binary-delta does not support grub-mender-grubenv-print and friends."
             )

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -984,7 +984,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
 
                 if "Provides group:" in line:
                     s = line[line.index(":") + 1 :].strip()
-                    if s is not "":
+                    if s != "":
                         d.provides_group = s
 
                 if "Depends on one of artifact" in line:


### PR DESCRIPTION
* chore(test_delta_update_module.py): Migrate from deprecated distutils
    Clears `DeprecationWarning`. See:
    https://peps.python.org/pep-0632/#migration-advice

* chore(test_build.py): Fix syntax with a literal
    Clears `SyntaxWarning`: "is not" with a literal.