### PR TITLE
fix: use Canonical SPDX license name in dosfstools recipe

### DIFF
--- a/meta-mender-core/recipes-devtools/dosfstools/dosfstools_4.2.bb
+++ b/meta-mender-core/recipes-devtools/dosfstools/dosfstools_4.2.bb
@@ -6,7 +6,7 @@ SUMMARY = "DOS FAT Filesystem Utilities"
 HOMEPAGE = "https://github.com/dosfstools/dosfstools"
 
 SECTION = "base"
-LICENSE = "GPLv3"
+LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
 SRC_URI = "https://github.com/dosfstools/dosfstools/releases/download/v${PV}/${BP}.tar.gz \


### PR DESCRIPTION
GPL Canonical SPDX license names changed in hardknott (3.3). This warning is produced:

    WARNING: dosfstools-4.2-r0 do_package_qa: QA Issue: Recipe LICENSE
    includes obsolete licenses GPLv3 [obsolete-license]

Changelog: None
Ticket: None

Signed-off-by: corey cothrum <contact@coreycothrum.com>


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
