### PR TITLE
properly get the SRCPV inside the function

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -34,8 +34,9 @@ def mender_branch_from_preferred_version(d):
         return "master"
 MENDER_ARTIFACT_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
-def mender_version_from_preferred_version(d, srcpv):
+def mender_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
+    srcpv = d.getVar("SRCPV")
     if pref_version is None:
         pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
@@ -50,7 +51,7 @@ def mender_version_from_preferred_version(d, srcpv):
     else:
         # Else return the default "master-git".
         return "master-git%s" % srcpv
-PV = "${@mender_version_from_preferred_version(d, '${SRCPV}')}"
+PV = "${@mender_version_from_preferred_version(d)}"
 
 SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=${MENDER_ARTIFACT_BRANCH}"
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.bb
@@ -1,3 +1,3 @@
 require mender-client_git.inc
 
-PV = "${@mender_version_from_preferred_version(d, d.getVar('SRCPV'))}"
+PV = "${@mender_version_from_preferred_version(d)}"

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -55,8 +55,9 @@ def mender_branch_from_preferred_version(d):
         return "master"
 MENDER_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
-def mender_version_from_preferred_version(d, srcpv):
+def mender_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
+    srcpv = d.getVar("SRCPV")
     if pref_version is None:
         pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
@@ -31,8 +31,9 @@ def mender_configure_branch_from_preferred_version(d):
         return "master"
 MENDER_CONFIGURE_BRANCH = "${@mender_configure_branch_from_preferred_version(d)}"
 
-def mender_configure_version_from_preferred_version(d, srcpv):
+def mender_configure_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
+    srcpv = d.getVar("SRCPV")
     if pref_version is None:
         pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
@@ -47,7 +48,7 @@ def mender_configure_version_from_preferred_version(d, srcpv):
     else:
         # Else return the default "master-git".
         return "master-git%s" % srcpv
-PV = "${@mender_configure_version_from_preferred_version(d, '${SRCPV}')}"
+PV = "${@mender_configure_version_from_preferred_version(d)}"
 
 SRC_URI = "git://github.com/mendersoftware/mender-configure-module.git;protocol=https;branch=${MENDER_CONFIGURE_BRANCH}"
 

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -41,8 +41,9 @@ def mender_connect_branch_from_preferred_version(d):
         return "master"
 MENDER_CONNECT_BRANCH = "${@mender_connect_branch_from_preferred_version(d)}"
 
-def mender_connect_version_from_preferred_version(d, srcpv):
+def mender_connect_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
+    srcpv = d.getVar("SRCPV")
     if pref_version is None:
         pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
@@ -57,7 +58,7 @@ def mender_connect_version_from_preferred_version(d, srcpv):
     else:
         # Else return the default "master-git".
         return "master-git%s" % srcpv
-PV = "${@mender_connect_version_from_preferred_version(d, '${SRCPV}')}"
+PV = "${@mender_connect_version_from_preferred_version(d)}"
 
 SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=${MENDER_CONNECT_BRANCH}"
 


### PR DESCRIPTION
@kacf related to https://github.com/mendersoftware/meta-mender/commit/b31ab892d6ccdbec7b880c73f0e2d795e9866e34

Switch to 'd.getVar()' style, since this now fails on kirkstone and later.

We can get it directly inside the function

Changelog: None

Signed-off-by: Clément Péron <peron.clem@gmail.com>