### PR TITLE
feat(new-img): Add the mender-image-full-cmdline-rofs-commercial img

### DIFF
--- a/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb
+++ b/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb
@@ -1,0 +1,3 @@
+require recipes-extended/images/mender-image-full-cmdline-rofs.bb
+
+IMAGE_INSTALL:append = " mender-binary-delta"


### PR DESCRIPTION
This adds an image recipe for the `mender-image-full-cmdline-rofs-commercial` image, which provides a rofs with mender-binary-delta already installed.

NOTE: The mender-binary-delta sources still need to be present at build time. They are not downloaded automatically.

Changelog: None
Ticket: MEN-6004

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>

