### PR TITLE
test(test-connect): Fix the mender-connect spurious failure tests

### DIFF
--- a/tests/acceptance/test_mender-connect.py
+++ b/tests/acceptance/test_mender-connect.py
@@ -22,6 +22,7 @@ import pytest
 from utils.common import (
     cleanup_mender_state,
     put_no_sftp,
+    qemu_system_time,
 )
 
 
@@ -165,7 +166,7 @@ def dbus_set_token_and_url_and_emit_signal(connection, token, server_url):
 
 def wait_for_string_in_log(connection, since, timeout, search_string):
     output = ""
-    while time.time() < since + timeout:
+    while qemu_system_time(connection) < since + timeout:
         print("Searching for '%s' in mender-connect's journal:" % search_string)
         output = connection.run(
             "journalctl --unit mender-connect --since '%s'"
@@ -180,7 +181,6 @@ def wait_for_string_in_log(connection, since, timeout, search_string):
     return output
 
 
-@pytest.mark.skip(reason="See QA-483")
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 @pytest.mark.not_for_machine("vexpress-qemu-flash")
 class TestMenderConnect:
@@ -194,7 +194,7 @@ class TestMenderConnect:
             dbus_set_token_and_url(connection, "token1", "http://localhost:5000")
 
             # start the mender-connect service
-            startup_time = time.time()
+            startup_time = qemu_system_time(connection)
             connection.run(
                 "systemctl --job-mode=ignore-dependencies start mender-connect"
             )
@@ -208,7 +208,7 @@ class TestMenderConnect:
             )
 
             # 1. Change token
-            signal_time = time.time()
+            signal_time = qemu_system_time(connection)
             dbus_set_token_and_url_and_emit_signal(
                 connection, "token2", "http://localhost:5000"
             )
@@ -220,7 +220,7 @@ class TestMenderConnect:
             )
 
             # 2. Change url
-            signal_time = time.time()
+            signal_time = qemu_system_time(connection)
             dbus_set_token_and_url_and_emit_signal(
                 connection, "token2", "http://localhost:6000"
             )
@@ -232,7 +232,7 @@ class TestMenderConnect:
             )
 
             # 3. Change token and url
-            signal_time = time.time()
+            signal_time = qemu_system_time(connection)
             dbus_set_token_and_url_and_emit_signal(
                 connection, "token3", "http://localhost:5000"
             )
@@ -244,7 +244,7 @@ class TestMenderConnect:
             )
 
             # 4. Unauthorize and re-authorize
-            signal_time = time.time()
+            signal_time = qemu_system_time(connection)
             dbus_set_token_and_url_and_emit_signal(connection, "", "")
             _ = wait_for_string_in_log(
                 connection,
@@ -278,7 +278,7 @@ class TestMenderConnect:
             dbus_set_token_and_url(connection, "badtoken", "http://localhost:12345")
 
             # start the mender-connect service
-            startup_time = time.time()
+            startup_time = qemu_system_time(connection)
             connection.run(
                 "systemctl --job-mode=ignore-dependencies start mender-connect"
             )
@@ -292,7 +292,7 @@ class TestMenderConnect:
             )
 
             # Set correct parameters
-            signal_time = time.time()
+            signal_time = qemu_system_time(connection)
             dbus_set_token_and_url_and_emit_signal(
                 connection, "goodtoken", "http://localhost:5000"
             )
@@ -304,7 +304,7 @@ class TestMenderConnect:
             )
 
             dbus_set_token_and_url(connection, "", "")
-            kill_time = time.time()
+            kill_time = qemu_system_time(connection)
             # kill the server and wait for error
             with_mock_servers[1].kill()
             _ = wait_for_string_in_log(
@@ -312,7 +312,7 @@ class TestMenderConnect:
             )
 
             # Signal the other server
-            signal_time = time.time()
+            signal_time = qemu_system_time(connection)
             dbus_set_token_and_url_and_emit_signal(
                 connection, "goodtoken", "http://localhost:6000"
             )


### PR DESCRIPTION
This fixes the mender-connect spurious failure tests.

The issue turned out to be that the time is passed in between the host and the QEMU instance, and is being used as a single source of truth.

This created a window of opportunity in which the test would get the system time on the host, then pass it into the QEMU instance to use as a timestamp in `since=<time>` when filtering the logs with `journald`.

Hence, mender-connect would actually behave, but log the correct output in the window of time which arose in between the host time, and QEMU's time, and it was simple filtered out.

The fix is dead simple: Use the QEMU instance time as the single source of truth

Ticket: QA-483

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>
