### PR TITLE
fix: Do not provide the mender-client 3.3.1 as the branch default

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_3.3.1.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_3.3.1.bb
@@ -16,7 +16,7 @@ SRCREV = "5b0d98945a46da4b4d9abdd3c5e5eb7086b8c131"
 # Enable this in Betas, and in branches that cannot carry this major version as
 # default.
 # Downprioritize this recipe in version selections.
-# DEFAULT_PREFERENCE = "-1"
+DEFAULT_PREFERENCE = "-1"
 
 ################################################################################
 


### PR DESCRIPTION
Ticket: MEN-6122
Changelog: Fix the regression in which Dunfell started providing the 3.3.x
client as the default. This was an unintentional change, and this
re-downprioritizes it, so that the `2.x` client is once again the default.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>