### PR TITLE
fix: Update to grub-mender-grubenv with lock fix.

### DIFF
--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,4 +1,4 @@
-GRUB_MENDER_GRUBENV_REV = "081c20bc7e047c6cd381e39919bdfbdd34f48849"
+GRUB_MENDER_GRUBENV_REV = "237750780c518043603b73a911b4a6de076c0437"
 GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -44,8 +44,8 @@ PACKAGECONFIG[force-grub-prompt] = ",,,"
 SRC_URI:append = "${@bb.utils.contains('PACKAGECONFIG', 'force-grub-prompt', ' file://06_mender_debug_force_grub_prompt_grub.cfg;subdir=git', '', d)}"
 PACKAGECONFIG[debug-log] = ",,,"
 
-RDEPENDS:${PN} = "grub-efi"
-RDEPENDS:${PN}:mender-bios = "grub"
+RDEPENDS:${PN} = "grub-efi util-linux-flock"
+RDEPENDS:${PN}:mender-bios = "grub util-linux-flock"
 
 PROVIDES = "${@mender_feature_is_enabled('mender-grub', "virtual/grub-bootconf", "", d)}"
 RPROVIDES:${PN} = "${@mender_feature_is_enabled('mender-grub', "virtual-grub-bootconf", "", d)}"

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
@@ -6,4 +6,4 @@ SRCREV = "${GRUB_MENDER_GRUBENV_REV}"
 PV = "1.3.0+git${SRCREV}"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081"


### PR DESCRIPTION
Changelog: grub-mender-grubenv: Add lock file to prevent data races when accessing boot environment concurrently.

Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
