### PR TITLE
QA-487: test: Split between platform and software tests

### DIFF
--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -36,10 +36,12 @@ from utils.helpers import Helpers
 @pytest.mark.commercial
 @pytest.mark.min_mender_version("2.1.0")
 class TestDeltaUpdateModule:
+    @pytest.mark.platform_test
     @pytest.mark.only_with_image("ext4")
-    def test_build_and_run_module(
+    def test_build_module(
         self, request, bitbake_variables, prepared_test_build, bitbake_image
     ):
+        """Test that the update module is installed in the rootfs image"""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -104,6 +106,7 @@ class TestDeltaUpdateModule:
 
         return image
 
+    @pytest.mark.software_test
     @pytest.mark.only_with_image("ext4")
     def test_runtime_checksum(
         self,
@@ -121,9 +124,7 @@ class TestDeltaUpdateModule:
     ):
         """Check that the checksum of the running root filesystem is what we
         expect. This is important in order for it to match when applying a delta
-        update.
-
-        """
+        update."""
 
         if (
             "read-only-rootfs"
@@ -158,6 +159,7 @@ class TestDeltaUpdateModule:
         artifact_sum = match.group(1)
         assert rootfs_sum == artifact_sum
 
+    @pytest.mark.software_test
     # Not testable on QEMU/ARM combination currently. See MEN-4297.
     @pytest.mark.not_for_machine("vexpress-qemu")
     # mender-binary-delta 1.2.0 requires mender-artifact 3.5.0
@@ -177,9 +179,7 @@ class TestDeltaUpdateModule:
         use_s3,
         s3_address,
     ):
-        """Perform a delta update.
-
-        """
+        """Perform a delta update."""
 
         if (
             "read-only-rootfs"

--- a/tests/acceptance/commercial/test_mender_gateway.py
+++ b/tests/acceptance/commercial/test_mender_gateway.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ from utils.common import (
 )
 
 
+@pytest.mark.platform_test
 @pytest.mark.commercial
 @pytest.mark.min_mender_version("3.3.0")
 class TestMenderGateway:

--- a/tests/acceptance/commercial/test_monitor_addon.py
+++ b/tests/acceptance/commercial/test_monitor_addon.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ from utils.common import (
 )
 
 
+@pytest.mark.platform_test
 @pytest.mark.commercial
 @pytest.mark.min_mender_version("3.1.0")
 class TestMonitorAddon:

--- a/tests/acceptance/test_bootimg.py
+++ b/tests/acceptance/test_bootimg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import pytest
 from utils.common import build_image, latest_build_artifact
 
 
+@pytest.mark.platform_test
 class TestBootImg:
     @pytest.mark.min_mender_version("1.0.0")
     def test_bootimg_creation(

--- a/tests/acceptance/test_bootstrap_artifact.py
+++ b/tests/acceptance/test_bootstrap_artifact.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -107,6 +107,8 @@ def boot_device_with_bootstrap_image(
     session_connection.run("rm -f image.dat")
 
 
+@pytest.mark.platform_test
+@pytest.mark.software_test
 @pytest.mark.min_mender_version("3.5.0")
 @pytest.mark.min_yocto_version("dunfell")
 @pytest.mark.only_with_image("ext4", "ext3", "ext2")

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ def extract_partition(img, number, dstdir):
     )
 
 
+@pytest.mark.platform_test
 class TestBuild:
     @pytest.mark.min_mender_version("1.0.0")
     def test_default_server_certificate(self):
@@ -204,7 +205,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
             ],
         )
 
-        built_rootfs = latest_build_artifact(
+        built_dataimg = latest_build_artifact(
             request, prepared_test_build["build_dir"], "core-image*.dataimg"
         )
 
@@ -214,7 +215,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
                     "debugfs",
                     "-R",
                     f"dump -p /etc/mender/mender.conf {mender_conf.name}",
-                    built_rootfs,
+                    built_dataimg,
                 ]
             )
 
@@ -232,7 +233,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
         bitbake_image,
     ):
         """Test that MENDER_ARTIFACT_SIGNING_KEY and MENDER_ARTIFACT_VERIFY_KEY
-        works correctly."""
+        work correctly."""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -435,8 +436,8 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
     )
     def test_preferred_versions(self, prepared_test_build, recipe, version):
         """Most CI builds build with PREFERRED_VERSION set, because we want to
-        build from a specific SHA. This test tests that we can change that or
-        turn it off and the build still works."""
+        build from a specific SHA. TESt that we can change that or turn it off
+        and the build still works."""
 
         old_file = get_local_conf_orig_path(prepared_test_build["build_dir"])
         new_file = get_local_conf_path(prepared_test_build["build_dir"])
@@ -489,7 +490,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
         bitbake_variables,
         bitbake_image,
     ):
-        """Tests that we can include multiple device_types in the artifact."""
+        """Test that we can include multiple device_types in the artifact."""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -590,7 +591,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
     def test_various_mtd_combinations(
         self, request, test_case_name, test_case, prepared_test_build, bitbake_image
     ):
-        """Tests that we can build with various combinations of MTD variables,
+        """Test that we can build with various combinations of MTD variables,
         and that they receive the correct values."""
 
         try:
@@ -616,8 +617,8 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
     def test_boot_partition_population(
         self, request, prepared_test_build, bitbake_path, bitbake_image
     ):
-        # Notice in particular a mix of tabs, newlines and spaces. All there to
-        # check that whitespace it treated correctly.
+        """Test IMAGE_BOOT_FILES population in the boot partition. Notice in particular a mix of
+        tabs, newlines and spaces. All there to check that whitespace it treated correctly."""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -1110,6 +1111,8 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
     def test_extra_parts(
         self, request, latest_part_image, prepared_test_build, bitbake_image
     ):
+        """Test extra partitions setup with MENDER_EXTRA_PARTS and MENDER_EXTRA_PARTS_FSTAB."""
+
         sdimg = latest_part_image.endswith(".sdimg")
         uefiimg = latest_part_image.endswith(".uefiimg")
         gptimg = latest_part_image.endswith(".gptimg")
@@ -1337,7 +1340,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         self, request, prepared_test_build, bitbake_image, bitbake_path
     ):
         """
-        Test the D-Bus interface file is provided by the mender-client-dev package,
+        Test that the D-Bus interface files are provided by the mender-client-dev package,
         but not installed by default.
         """
 

--- a/tests/acceptance/test_dataimg.py
+++ b/tests/acceptance/test_dataimg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import pytest
 from utils.common import build_image, latest_build_artifact, make_tempdir
 
 
+@pytest.mark.platform_test
 class TestDataImg:
     @pytest.mark.min_mender_version("1.0.0")
     def test_dataimg_creation(

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -26,9 +26,11 @@ from utils.common import (
 )
 
 
+@pytest.mark.software_test
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 @pytest.mark.not_for_machine("vexpress-qemu-flash")
 class TestDBus:
+
     # this is a portion of the JWT token served by the Mender mock server:
     # see: meta-mender-ci/recipes-testing/mender-mock-server/mender-mock-server.py
     JWT_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
@@ -84,7 +86,7 @@ class TestDBus:
     def test_dbus_get_jwt_token(
         self, request, bitbake_variables, connection, setup_mock_server
     ):
-        """Test the JWT token can be retrieved using D-Bus."""
+        """Test that the JWT token can be retrieved using D-Bus."""
 
         try:
             # bootstrap the client
@@ -130,7 +132,7 @@ class TestDBus:
     def test_dbus_fetch_jwt_token(
         self, request, bitbake_variables, connection, setup_mock_server
     ):
-        """Test the JWT token can be fetched using D-Bus."""
+        """Test that the JWT token can be fetched using D-Bus."""
 
         # bootstrap the client
         result = connection.run("mender bootstrap --forcebootstrap")

--- a/tests/acceptance/test_inventory.py
+++ b/tests/acceptance/test_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import pytest
 from utils.common import put_no_sftp
 
 
+@pytest.mark.software_test
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestInventory:
     @pytest.mark.min_mender_version("1.6.0")

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -88,9 +88,10 @@ def versioned_mender_image(
 
 @pytest.mark.only_with_image("mender")
 class TestMenderArtifact:
+    @pytest.mark.software_test
     @pytest.mark.min_mender_version("1.0.0")
     def test_order(self, versioned_mender_image):
-        """Test that order of components inside update is correct."""
+        """Test that order of components inside the Artifact is correct."""
 
         version = versioned_mender_image[0]
         mender_image = versioned_mender_image[1]
@@ -157,6 +158,7 @@ class TestMenderArtifact:
 
         assert meta_data_found
 
+    @pytest.mark.software_test
     @pytest.mark.min_mender_version("1.0.0")
     def test_files_list_integrity(self, versioned_mender_image):
         """Test that the list of files in the manifest is the same as the actual
@@ -189,6 +191,7 @@ class TestMenderArtifact:
 
         assert sorted(manifest_list) == sorted(tar_list)
 
+    @pytest.mark.software_test
     @pytest.mark.min_mender_version("1.0.0")
     def test_files_checksum_integrity(self, versioned_mender_image):
         """Test that the checksum of each file is correct."""
@@ -234,14 +237,16 @@ class TestMenderArtifact:
 
             assert hasher.hexdigest() == recorded_hash, "%s doesn't match" % file
 
+    @pytest.mark.software_test
     @pytest.mark.min_mender_version("1.0.0")
     def test_artifacts_validation(self, versioned_mender_image, bitbake_path):
-        """Test that the mender-artifact tool validates the update successfully."""
+        """Test that the mender-artifact tool validates the Artifact successfully."""
 
         mender_image = versioned_mender_image[1]
 
         subprocess.check_call(["mender-artifact", "validate", mender_image])
 
+    @pytest.mark.platform_test
     @pytest.mark.min_mender_version("1.0.0")
     def test_artifacts_rootfs_size(
         self, versioned_mender_image, bitbake_path, bitbake_variables

--- a/tests/acceptance/test_mender-connect.py
+++ b/tests/acceptance/test_mender-connect.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -181,6 +181,7 @@ def wait_for_string_in_log(connection, since, timeout, search_string):
     return output
 
 
+@pytest.mark.software_test
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 @pytest.mark.not_for_machine("vexpress-qemu-flash")
 class TestMenderConnect:

--- a/tests/acceptance/test_os_integration.py
+++ b/tests/acceptance/test_os_integration.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import time
 import pytest
 
 
+@pytest.mark.software_test
 class TestOsIntegration:
     @pytest.mark.min_mender_version("2.2.1")
     def test_syslogger(self, setup_board, connection):

--- a/tests/acceptance/test_snapshot.py
+++ b/tests/acceptance/test_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ def get_ssh_args_mender_artifact(conn):
     return "-S " + common_args
 
 
+@pytest.mark.software_test
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestSnapshot:
     @pytest.mark.min_mender_version("2.2.0")

--- a/tests/acceptance/test_ubimg.py
+++ b/tests/acceptance/test_ubimg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2021 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -192,6 +192,7 @@ def ubimg_without_uboot_env(request, latest_ubimg, prepared_test_build, bitbake_
     return tmpimg
 
 
+@pytest.mark.platform_test
 @pytest.mark.only_with_image("ubimg")
 @pytest.mark.min_mender_version("1.2.0")
 class TestUbimg:

--- a/tests/acceptance/test_uboot_automation.py
+++ b/tests/acceptance/test_uboot_automation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ from utils.common import (
 )
 
 
+@pytest.mark.platform_test
 @pytest.mark.only_with_mender_feature("mender-uboot")
 class TestUbootAutomation:
     @staticmethod

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -150,7 +150,9 @@ def wait_for_state(connection, state_to_wait_for):
     return log
 
 
+@pytest.mark.software_test
 class TestUpdateControl:
+
     test_update_control_maps_cases = [
         {
             "name": "Empty map",


### PR DESCRIPTION
Update image-tests submodule to bring the split functionality.

Mark all tests accordingly. Along the way, minor tests doc improvements have been made.