### PR TITLE
QA-487: test: Split out cross-platform tests

### DIFF
--- a/tests/acceptance/commercial/test_delta_update_module.py
+++ b/tests/acceptance/commercial/test_delta_update_module.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -33,13 +33,15 @@ from utils.common import (
 from utils.helpers import Helpers
 
 
+@pytest.mark.cross_platform
 @pytest.mark.commercial
 @pytest.mark.min_mender_version("2.1.0")
 class TestDeltaUpdateModule:
     @pytest.mark.only_with_image("ext4")
-    def test_build_and_run_module(
+    def test_build_module(
         self, request, bitbake_variables, prepared_test_build, bitbake_image
     ):
+        """Test that the update module is installed in the rootfs image"""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -121,9 +123,7 @@ class TestDeltaUpdateModule:
     ):
         """Check that the checksum of the running root filesystem is what we
         expect. This is important in order for it to match when applying a delta
-        update.
-
-        """
+        update."""
 
         if (
             "read-only-rootfs"
@@ -177,9 +177,7 @@ class TestDeltaUpdateModule:
         use_s3,
         s3_address,
     ):
-        """Perform a delta update.
-
-        """
+        """Perform a delta update."""
 
         if (
             "read-only-rootfs"

--- a/tests/acceptance/commercial/test_mender_gateway.py
+++ b/tests/acceptance/commercial/test_mender_gateway.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ from utils.common import (
 )
 
 
+@pytest.mark.cross_platform
 @pytest.mark.commercial
 @pytest.mark.min_mender_version("3.3.0")
 class TestMenderGateway:

--- a/tests/acceptance/commercial/test_monitor_addon.py
+++ b/tests/acceptance/commercial/test_monitor_addon.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ from utils.common import (
 )
 
 
+@pytest.mark.cross_platform
 @pytest.mark.commercial
 @pytest.mark.min_mender_version("3.1.0")
 class TestMonitorAddon:

--- a/tests/acceptance/test_bootstrap_artifact.py
+++ b/tests/acceptance/test_bootstrap_artifact.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -107,6 +107,7 @@ def boot_device_with_bootstrap_image(
     session_connection.run("rm -f image.dat")
 
 
+@pytest.mark.cross_platform
 @pytest.mark.min_mender_version("3.5.0")
 @pytest.mark.min_yocto_version("dunfell")
 @pytest.mark.only_with_image("ext4", "ext3", "ext2")

--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ def extract_partition(img, number, dstdir):
 
 
 class TestBuild:
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_default_server_certificate(self):
         """Test that the md5sum we have on record matches the server certificate.
@@ -81,6 +82,7 @@ class TestBuild:
             shell=True,
         )
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.5.0")
     def test_certificate_split(self, request, bitbake_image, prepared_test_build):
         """Test that the certificate added in the mender-server-certificate
@@ -165,6 +167,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
         os.close(original)
         os.close(embedded)
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("1.0.0")
     def test_image_rootfs_extra_space(
@@ -189,6 +192,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
             == int(bitbake_variables["MENDER_CALC_ROOTFS_SIZE"]) * 1024
         )
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("1.0.0")
     def test_tenant_token(self, request, prepared_test_build, bitbake_image):
@@ -204,7 +208,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
             ],
         )
 
-        built_rootfs = latest_build_artifact(
+        built_dataimg = latest_build_artifact(
             request, prepared_test_build["build_dir"], "core-image*.dataimg"
         )
 
@@ -214,13 +218,14 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
                     "debugfs",
                     "-R",
                     f"dump -p /etc/mender/mender.conf {mender_conf.name}",
-                    built_rootfs,
+                    built_dataimg,
                 ]
             )
 
             data = json.load(mender_conf)
             assert data["TenantToken"] == "authtentoken"
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("1.1.0")
     def test_artifact_signing_keys(
@@ -232,7 +237,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
         bitbake_image,
     ):
         """Test that MENDER_ARTIFACT_SIGNING_KEY and MENDER_ARTIFACT_VERIFY_KEY
-        works correctly."""
+        work correctly."""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -269,6 +274,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
             ).decode()
             assert output.find("Signature: signed and verified correctly") >= 0
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("1.2.0")
     def test_state_scripts(
@@ -405,6 +411,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
                 target="-c clean example-state-scripts",
             )
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     # The extra None elements are to check for no preferred version,
     # e.g. latest.
@@ -435,8 +442,8 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
     )
     def test_preferred_versions(self, prepared_test_build, recipe, version):
         """Most CI builds build with PREFERRED_VERSION set, because we want to
-        build from a specific SHA. This test tests that we can change that or
-        turn it off and the build still works."""
+        build from a specific SHA. Test that we can change that or turn it off
+        and the build still works."""
 
         old_file = get_local_conf_orig_path(prepared_test_build["build_dir"])
         new_file = get_local_conf_path(prepared_test_build["build_dir"])
@@ -480,6 +487,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
             )
             run_verbose("%s && bitbake %s" % (init_env_cmd, recipe))
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.1.0")
     def test_multiple_device_types_compatible(
         self,
@@ -489,7 +497,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
         bitbake_variables,
         bitbake_image,
     ):
-        """Tests that we can include multiple device_types in the artifact."""
+        """Test that we can include multiple device_types in the artifact."""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -590,7 +598,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
     def test_various_mtd_combinations(
         self, request, test_case_name, test_case, prepared_test_build, bitbake_image
     ):
-        """Tests that we can build with various combinations of MTD variables,
+        """Test that we can build with various combinations of MTD variables,
         and that they receive the correct values."""
 
         try:
@@ -616,8 +624,8 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
     def test_boot_partition_population(
         self, request, prepared_test_build, bitbake_path, bitbake_image
     ):
-        # Notice in particular a mix of tabs, newlines and spaces. All there to
-        # check that whitespace it treated correctly.
+        """Test IMAGE_BOOT_FILES population in the boot partition. Notice in particular a mix of
+        tabs, newlines and spaces. All there to check that whitespace it treated correctly."""
 
         build_image(
             prepared_test_build["build_dir"],
@@ -685,6 +693,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             except subprocess.CalledProcessError:
                 pass
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("sdimg", "uefiimg")
     @pytest.mark.min_mender_version("2.0.0")
     def test_module_install(
@@ -1064,6 +1073,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         ),
     ]
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.3.0")
     @pytest.mark.parametrize("dependsprovides", test_cases)
     def test_build_artifact_depends_and_provides(
@@ -1110,6 +1120,8 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
     def test_extra_parts(
         self, request, latest_part_image, prepared_test_build, bitbake_image
     ):
+        """Test extra partitions setup with MENDER_EXTRA_PARTS and MENDER_EXTRA_PARTS_FSTAB."""
+
         sdimg = latest_part_image.endswith(".sdimg")
         uefiimg = latest_part_image.endswith(".uefiimg")
         gptimg = latest_part_image.endswith(".gptimg")
@@ -1218,6 +1230,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
         assert re.search(test3_re, fstab, flags=re.MULTILINE) is not None
         assert re.search(test4_re, fstab, flags=re.MULTILINE) is not None
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_build_nodbus(self, request, prepared_test_build, bitbake_path):
         """Test that we can remove dbus from PACKAGECONFIG, and that this causes the
@@ -1272,6 +1285,7 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
                 target="-c clean mender-client",
             )
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.5.0")
     @pytest.mark.only_with_image("ext4")
     def test_mender_inventory_network_scripts(
@@ -1332,12 +1346,13 @@ deployed-test-dir9/*;renamed-deployed-test-dir9/ \
             b"mender-inventory-geo" not in output
         ), "mender-inventory-network-scripts unexpectedly a part of the image"
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.7.0")
     def test_mender_dbus_interface_file(
         self, request, prepared_test_build, bitbake_image, bitbake_path
     ):
         """
-        Test the D-Bus interface file is provided by the mender-client-dev package,
+        Test that the D-Bus interface files are provided by the mender-client-dev package,
         but not installed by default.
         """
 

--- a/tests/acceptance/test_dbus.py
+++ b/tests/acceptance/test_dbus.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -26,9 +26,11 @@ from utils.common import (
 )
 
 
+@pytest.mark.cross_platform
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 @pytest.mark.not_for_machine("vexpress-qemu-flash")
 class TestDBus:
+
     # this is a portion of the JWT token served by the Mender mock server:
     # see: meta-mender-ci/recipes-testing/mender-mock-server/mender-mock-server.py
     JWT_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9."
@@ -84,7 +86,7 @@ class TestDBus:
     def test_dbus_get_jwt_token(
         self, request, bitbake_variables, connection, setup_mock_server
     ):
-        """Test the JWT token can be retrieved using D-Bus."""
+        """Test that the JWT token can be retrieved using D-Bus."""
 
         try:
             # bootstrap the client
@@ -130,7 +132,7 @@ class TestDBus:
     def test_dbus_fetch_jwt_token(
         self, request, bitbake_variables, connection, setup_mock_server
     ):
-        """Test the JWT token can be fetched using D-Bus."""
+        """Test that the JWT token can be fetched using D-Bus."""
 
         # bootstrap the client
         result = connection.run("mender bootstrap --forcebootstrap")

--- a/tests/acceptance/test_inventory.py
+++ b/tests/acceptance/test_inventory.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ class TestInventory:
                 "Unknown platform combination. Please add a test case for this combination."
             )
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.0.0")
     def test_inventory_os(self, bitbake_variables, connection):
         """Test that "os" inventory attribute is reported correctly by the

--- a/tests/acceptance/test_mender-artifact.py
+++ b/tests/acceptance/test_mender-artifact.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -88,9 +88,10 @@ def versioned_mender_image(
 
 @pytest.mark.only_with_image("mender")
 class TestMenderArtifact:
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_order(self, versioned_mender_image):
-        """Test that order of components inside update is correct."""
+        """Test that order of components inside the Artifact is correct."""
 
         version = versioned_mender_image[0]
         mender_image = versioned_mender_image[1]
@@ -157,6 +158,7 @@ class TestMenderArtifact:
 
         assert meta_data_found
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_files_list_integrity(self, versioned_mender_image):
         """Test that the list of files in the manifest is the same as the actual
@@ -189,6 +191,7 @@ class TestMenderArtifact:
 
         assert sorted(manifest_list) == sorted(tar_list)
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_files_checksum_integrity(self, versioned_mender_image):
         """Test that the checksum of each file is correct."""
@@ -234,9 +237,10 @@ class TestMenderArtifact:
 
             assert hasher.hexdigest() == recorded_hash, "%s doesn't match" % file
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_artifacts_validation(self, versioned_mender_image, bitbake_path):
-        """Test that the mender-artifact tool validates the update successfully."""
+        """Test that the mender-artifact tool validates the Artifact successfully."""
 
         mender_image = versioned_mender_image[1]
 

--- a/tests/acceptance/test_mender-connect.py
+++ b/tests/acceptance/test_mender-connect.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -181,6 +181,7 @@ def wait_for_string_in_log(connection, since, timeout, search_string):
     return output
 
 
+@pytest.mark.cross_platform
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 @pytest.mark.not_for_machine("vexpress-qemu-flash")
 class TestMenderConnect:

--- a/tests/acceptance/test_snapshot.py
+++ b/tests/acceptance/test_snapshot.py
@@ -35,10 +35,10 @@ def get_ssh_args_mender_artifact(conn):
     return "-S " + common_args
 
 
+@pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestSnapshot:
     @pytest.mark.min_mender_version("2.2.0")
-    @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     @pytest.mark.parametrize("compression", [("", ">"), ("-C gzip", "| gunzip -c >")])
     def test_basic_snapshot(self, compression, bitbake_variables, connection):
         try:
@@ -64,7 +64,6 @@ class TestSnapshot:
             connection.run("umount /mnt || true")
 
     @pytest.mark.min_mender_version("2.2.0")
-    @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     def test_snapshot_device_file(self, bitbake_variables, connection):
         try:
             (active, passive) = determine_active_passive_part(
@@ -89,7 +88,6 @@ class TestSnapshot:
             connection.run("umount /mnt || true")
 
     @pytest.mark.min_mender_version("2.2.0")
-    @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     def test_snapshot_inactive(self, bitbake_variables, connection):
         try:
             (_, passive) = determine_active_passive_part(bitbake_variables, connection)
@@ -114,7 +112,6 @@ class TestSnapshot:
             connection.run("rm -f /data/snapshot-test")
 
     @pytest.mark.min_mender_version("2.2.0")
-    @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     def test_snapshot_avoid_deadlock(self, connection):
         loop = None
         try:
@@ -161,7 +158,6 @@ class TestSnapshot:
             connection.run("rm -f /data/tmp-file-system")
 
     @pytest.mark.min_mender_version("2.2.0")
-    @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     # Make sure we run both with and without terminal. Many signal bugs lurk in
     # different corners of the console code.
     @pytest.mark.parametrize("terminal", ["", "screen -D -m -L -Logfile %%"])
@@ -201,7 +197,6 @@ class TestSnapshot:
             assert re.search(r"size: *%s" % partsize, output) is not None
 
     @pytest.mark.min_mender_version("2.5.0")
-    @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
     # Make sure we run both with and without terminal. Many signal bugs lurk in
     # different corners of the console code.
     @pytest.mark.parametrize("terminal", ["", "screen -D -m -L -Logfile %%"])

--- a/tests/acceptance/test_snapshot.py
+++ b/tests/acceptance/test_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ def get_ssh_args_mender_artifact(conn):
     return "-S " + common_args
 
 
+@pytest.mark.cross_platform
 @pytest.mark.only_with_image("uefiimg", "sdimg", "biosimg", "gptimg")
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestSnapshot:

--- a/tests/acceptance/test_update_control.py
+++ b/tests/acceptance/test_update_control.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -150,7 +150,9 @@ def wait_for_state(connection, state_to_wait_for):
     return log
 
 
+@pytest.mark.cross_platform
 class TestUpdateControl:
+
     test_update_control_maps_cases = [
         {
             "name": "Empty map",


### PR DESCRIPTION
    Update image-tests submodule to bring the split functionality.
    
    Mark all tests accordingly. Along the way, minor tests doc improvements
    have been made.