### PR TITLE
fix: Update to grub-mender-grubenv with lock fix.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 Northern.tech AS
+Copyright 2023 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,4 +1,4 @@
-1033348db7606a7e61b6484f293847cf8d7a35766efebb97e304d4bd5d7f3f6b  LICENSE
+52b2497ce07650b825015e80ca7a5d40c360c04c530234ca6d950b0f98bca23a  LICENSE
 b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  meta-mender-core/recipes-mender/mender-client-migrate-configuration/files/LICENSE
 b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  meta-mender-core/recipes-mender/mender-wait-for-timesync/files/LICENSE
 beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  meta-mender-core/recipes-core/lsb-ld/files/LICENSE

--- a/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb
+++ b/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb
@@ -1,0 +1,3 @@
+require recipes-extended/images/mender-image-full-cmdline-rofs.bb
+
+IMAGE_INSTALL:append = " mender-binary-delta"

--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_git.bb
@@ -7,7 +7,7 @@ inherit mender-closed-source-utils
 LICENSE = "Mender-Yocto-Layer-License.md & Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
 LICENSE_FLAGS = "commercial_mender-yocto-layer-license"
 LIC_FILES_CHKSUM = " \
-    file://licenses/LICENSE.md;md5=66a40d48ea33620d1bb8d9a4204cde36 \
+    file://licenses/LICENSE.md;md5=bb7f3e9e79da87e010a807ecaa14f89c \
 "
 
 # Disables the need for every dependency to be checked, for easier development.

--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,4 +1,4 @@
-GRUB_MENDER_GRUBENV_REV = "081c20bc7e047c6cd381e39919bdfbdd34f48849"
+GRUB_MENDER_GRUBENV_REV = "237750780c518043603b73a911b4a6de076c0437"
 GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv.inc
@@ -44,8 +44,8 @@ PACKAGECONFIG[force-grub-prompt] = ",,,"
 SRC_URI:append = "${@bb.utils.contains('PACKAGECONFIG', 'force-grub-prompt', ' file://06_mender_debug_force_grub_prompt_grub.cfg;subdir=git', '', d)}"
 PACKAGECONFIG[debug-log] = ",,,"
 
-RDEPENDS:${PN} = "grub-efi"
-RDEPENDS:${PN}:mender-bios = "grub"
+RDEPENDS:${PN} = "grub-efi util-linux-flock"
+RDEPENDS:${PN}:mender-bios = "grub util-linux-flock"
 
 PROVIDES = "${@mender_feature_is_enabled('mender-grub', "virtual/grub-bootconf", "", d)}"
 RPROVIDES:${PN} = "${@mender_feature_is_enabled('mender-grub', "virtual-grub-bootconf", "", d)}"

--- a/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
+++ b/meta-mender-core/recipes-bsp/grub-mender-grubenv/grub-mender-grubenv_git.bb
@@ -6,4 +6,4 @@ SRCREV = "${GRUB_MENDER_GRUBENV_REV}"
 PV = "1.3.0+git${SRCREV}"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -63,7 +63,7 @@ def mender_license(branch):
                "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & MPL-2.0",
     }
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87 \
+    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
 "
 LICENSE = "${@mender_license(d.getVar('MENDER_ARTIFACT_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -88,7 +88,7 @@ def mender_license(branch):
                    "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
         }
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender/LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87 \
+    file://src/github.com/mendersoftware/mender/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
 "
 LICENSE = "${@mender_license(d.getVar('MENDER_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
@@ -60,7 +60,7 @@ def mender_configure_license(branch):
                "license": "Apache-2.0",
     }
 LIC_FILES_CHKSUM = " \
-    file://LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87 \
+    file://LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
 "
 LICENSE = "${@mender_configure_license(d.getVar('MENDER_CONFIGURE_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -70,7 +70,7 @@ def mender_connect_license(branch):
                "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
     }
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=4cd0c347af5bce5ccf3b3d5439a2ea87 \
+    file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
 "
 LICENSE = "${@mender_connect_license(d.getVar('MENDER_CONNECT_BRANCH'))['license']}"
 


### PR DESCRIPTION
Changelog: grub-mender-grubenv: Add lock file to prevent data races when accessing boot environment concurrently.

Changelog: grub-mender-grubenv: Fail execution if both environments are corrupt.

Changelog: grub-mender-grubenv: Recompute checksum after restoring environment (new versions of grub-editenv add extra data).

Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 59af6d462f32d307385659c940ebf64bec397298)
