### PR TITLE
fix: Remove grub.efi resource files using pseudo.

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
+++ b/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
@@ -33,7 +33,7 @@ CONFFILES_${PN}_remove = " \
 "
 
 # Allow the cfg and signature files to be installed by grub-mender-grubenv
-python do_cleanconfigs_class-target() {
+fakeroot python do_cleanconfigs_class-target() {
     if bb.utils.contains('DISTRO_FEATURES', 'mender-grub', True, False, d) and \
         bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', True, False, d):
             ext = d.getVar("SB_FILE_EXT")
@@ -44,6 +44,7 @@ python do_cleanconfigs_class-target() {
                 if os.path.exists(filebase + ext):
                     os.remove(filebase + ext)
 }
-python do_cleanconfigs() {
+fakeroot python do_cleanconfigs() {
 }
 addtask cleanconfigs after do_sign do_chownboot before deploy do_package
+do_cleanconfigs[depends] += "virtual/fakeroot-native:do_populate_sysroot"


### PR DESCRIPTION
We have a device that uses both "meta-mender" and "meta-efi-secure-boot". We have been having problems with [pseudo aborting](https://wiki.yoctoproject.org/wiki/Pseudo_Abort) during the "do_package" task of the "grub-efi" recipe. The pseudo log file contains entries similar to the following:
```
path mismatch [2 links]: ino 156950073 db '/build/justin.verble/pc/tmp/work/corei7-64-poky-linux/grub-efi/2.04-r0/image/boot/efi/EFI/BOOT/grub.cfg' req '/build/justin.verble/pc/tmp/work/corei7-64-poky-linux/grub-efi/2.04-r0/packages-split/grub-efi-dbg/usr'.
```
Resource files are installed by the appended "grub-efi" recipe in "meta-efi-secure-boot". This happens during the "do_install" task which uses pseudo by default. The appended "grub-efi" recipe in "meta-mender" removes these files without using pseudo. These files are the same ones referenced in the pseudo log when the abort occurs.
