### PR TITLE
boot-partition-devicetree: proper SPDX License

### DIFF
--- a/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
+++ b/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
@@ -1,7 +1,7 @@
 # A recipe which installs all the DTB files from KERNEL_DEVICETREE into the
 # "dtb" folder of the boot partition.
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 
 FILES:${PN} = " ${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb"
 


### PR DESCRIPTION
```
fix: boot-partition-devicetree QA warning about obsolete license (GPL-2.0)

Changelog: boot-partition-devicetree use proper SPDX License GPL-2.0-only
```
### Description
GPL-2.0 is no longer a valid license, avoid a warning by using GPL-2.0-only (which is the same as the kernel itself).
