### PR TITLE
fix: boot-partition-devicetree QA license warning

### DIFF
--- a/meta-mender-commercial/conditional/mender-monitor/mender-monitor_git.bb
+++ b/meta-mender-commercial/conditional/mender-monitor/mender-monitor_git.bb
@@ -7,7 +7,7 @@ inherit mender-closed-source-utils
 LICENSE = "Mender-Yocto-Layer-License.md"
 LICENSE_FLAGS = "commercial_mender-yocto-layer-license"
 LIC_FILES_CHKSUM = " \
-    file://licenses/LICENSE.md;md5=66a40d48ea33620d1bb8d9a4204cde36 \
+    file://licenses/LICENSE.md;md5=bb7f3e9e79da87e010a807ecaa14f89c \
 "
 
 # Disables the need for every dependency to be checked, for easier development.

--- a/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
+++ b/meta-mender-core/recipes-kernel/linux/boot-partition-devicetree.bb
@@ -1,7 +1,7 @@
 # A recipe which installs all the DTB files from KERNEL_DEVICETREE into the
 # "dtb" folder of the boot partition.
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 
 FILES:${PN} = " ${MENDER_BOOT_PART_MOUNT_LOCATION}/dtb"
 


### PR DESCRIPTION
GPL-2.0 is no longer a valid license, avoid a warning by using GPL-2.0-only (which is the same as the kernel itself).

Changelog: boot-partition-devicetree use proper SPDX License GPL-2.0-only
Ticket: None

Signed-off-by: Tim Orling <tim.orling@konsulko.com>
(cherry picked from commit 12effd659ea64373704bbc82b3b5b48e3ff1ce21)
