### PR TITLE
systemd: Do not modify DISTRO_FEATURES_BACKFILE for mender-systemd config

### DIFF
--- a/meta-mender-core/classes/mender-setup-systemd.inc
+++ b/meta-mender-core/classes/mender-setup-systemd.inc
@@ -2,7 +2,6 @@
 # boot process while looking for devices. This is almost always because the
 # kernel feature CONFIG_FHANDLE is not enabled.
 
-DISTRO_FEATURES_BACKFILL:append = "${@mender_feature_is_enabled('mender-systemd', ' systemd', '', d)}"
 DISTRO_FEATURES_BACKFILL_CONSIDERED:append = "${@mender_feature_is_enabled('mender-systemd', ' sysvinit', '', d)}"
 VIRTUAL-RUNTIME_init_manager:mender-systemd = "systemd"
 VIRTUAL-RUNTIME_initscripts:mender-systemd = ""


### PR DESCRIPTION
Ultimately the root cause of the failure discussed in this post:
    https://hub.mender.io/t/toradex-verdin-imx8mm-error-building-the-sdk-with-mender/5654/3

is because mender-setup-systemd.inc adds "systemd" to DISTRO_FEATURES_BACKFILL. When building without the Mender layers, DISTRO_FEATURES differs when building a target recipe versus when building an SDK recipe:

    $ MACHINE=apalis-imx6 bitbake-getvar -r util-linux DISTRO_FEATURES --value
        acl alsa argp bluetooth debuginfod ext2 ipv4 ipv6 largefile pcmcia usbgadget usbhost wifi xattr \
        nfs zeroconf pci 3g nfc x11 vfat seccomp largefile opengl multiarch wayland vulkan bluez5 pam systemd \
        opengl wayland x11 polkit pulseaudio  gobject-introspection-data ldconfig

    $ MACHINE=apalis-imx6 bitbake-getvar -r nativesdk-util-linux DISTRO_FEATURES --value
        debuginfod opengl wayland x11 pulseaudio sysvinit gobject-introspection-data ldconfig

When systemd is not part of DISTRO_FEATURES, the logic in rm_systemd_unitdir()
  [https://github.com/openembedded/openembedded-core/blob/7df46e003ea76cf7d5b7263f23bd6e6a781bd22c/meta/classes/systemd.bbclass#L204]
takes care of cleaning up unneeded system service and timer files.  But since meta-mender adds systemd to DISTRO_FEATURES unconditionally (via DISTRO_FEATURES_BACKFILL) this cleanup does not happen and builds of SDKs will fail.

Note specifically that init-manager-systemd.inc
  [https://github.com/openembedded/openembedded-core/blob/kirkstone/meta/conf/distro/include/init-manager-systemd.inc]
does _not_ set DISTRO_FEATURES_BACKFILL. The best fix may be to set the INIT_MANAGER variable rather than explicitly setting all the other variables in mender-setup-systemd.inc but that is a much more invasive change that I have not tested.


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
