### PR TITLE
feat: Make the build succeed if gateway examples aren't present

### DIFF
--- a/meta-mender-demo/mender-commercial/mender-gateway/mender-gateway_%.bbappend
+++ b/meta-mender-demo/mender-commercial/mender-gateway/mender-gateway_%.bbappend
@@ -10,5 +10,5 @@ def examples_dir_from_s_dir(d, s):
 EXAMPLES = "${@examples_dir_from_s_dir(d, '${S}')}"
 
 do_install:append() {
-    cp -R --no-dereference --preserve=mode,links -v ${EXAMPLES}/* ${D}
+    cp -R --no-dereference --preserve=mode,links -v ${EXAMPLES}/* ${D} || bbwarn "No gateway examples present. Continuing without them."
 }


### PR DESCRIPTION
If you have meta-mender-demo enabled for other reasons than the gateway, the build will fail if you didn't get the examples tar. This makes it a warning not a hard build fail.

Changelog: Title
Ticket: None

Signed-off-by: Alan <alan.martinovic@northern.tech>
(cherry picked from commit e6c0f10394f89840555c479711e779e9cb3429af)
