### PR TITLE
Replace GPT partition type 8300 with the full UUID value

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -108,7 +108,7 @@ EOF
 
     # Used for all Linux filesystem partitions.
     if [ "$ptable_type" = "gpt" ]; then
-        part_type_params="--part-type 8300"
+        part_type_params="--part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4"
     else
         part_type_params=
     fi


### PR DESCRIPTION
### Description

Tested with kirkstone release.

When building a gptimg I was seeing an error related to the partition type.

The context command is:

`ERROR: _exec_cmd: export PATH=....:$PATH;export BLK_DEFAULT_SECTOR_SIZE=512; sfdisk --part-type ......-20230409232256-gptimg/tmp.wic.ecrqtv27/mender-gptimg-202304092323-mmcblk0.direct 1 8300 returned '1' instead of 0
| output: sfdisk: ....-20230409232256-gptimg/tmp.wic.ecrqtv27/mender-gptimg-202304092323-mmcblk0.direct: partition 1: failed to set partition type`

I couldn't find any changes or reasoning for sfdisk why the shorthand format isn't supported, assuming it worked when this line was last touched.  I was able to resolve the error by replacing the shorthand 8300 with the full UUID or by removing this if/else block entirely.