### PR TITLE
fix: wic-tools does not need grub when using uboot

### DIFF
--- a/meta-mender-core/recipes-core/meta/wic-tools.bbappend
+++ b/meta-mender-core/recipes-core/meta/wic-tools.bbappend
@@ -1,1 +1,2 @@
 DEPENDS:remove:mender-systemd-boot = "grub grub-efi grub-efi-native"
+DEPENDS:remove:mender-uboot = "grub grub-efi grub-efi-native"


### PR DESCRIPTION
This avoids building grub-related packages when using u-boot, just like what was done for systemd-boot.  In some cases, these dependencies actually interfere with the expected use of u-boot, and this fixes those issues.