### PR TITLE
fix: Replace gpt partition type 8300 with full UUID

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -108,7 +108,7 @@ EOF
 
     # Used for all Linux filesystem partitions.
     if [ "$ptable_type" = "gpt" ]; then
-        part_type_params="--part-type 8300"
+        part_type_params="--part-type 0FC63DAF-8483-4772-8E79-3D69D8477DE4"
     else
         part_type_params=
     fi


### PR DESCRIPTION
Encountered an error with sfdisk where partition type 8300 created a "failed to set partition type" error.

Changelog: Replace gpt partition type 8300 with full UUID
Ticket: None

Signed-off-by: Chad Rockey <chadrockey@gmail.com>
(cherry picked from commit 161ce89264b46bd3422320d57e4a89f0a2e90a9e)

