### PR TITLE
fix: use INIT_MANAGER variable

### DIFF
--- a/meta-mender-core/classes/mender-setup-systemd.inc
+++ b/meta-mender-core/classes/mender-setup-systemd.inc
@@ -2,7 +2,4 @@
 # boot process while looking for devices. This is almost always because the
 # kernel feature CONFIG_FHANDLE is not enabled.
 
-DISTRO_FEATURES_BACKFILL:append = "${@mender_feature_is_enabled('mender-systemd', ' systemd', '', d)}"
-DISTRO_FEATURES_BACKFILL_CONSIDERED:append = "${@mender_feature_is_enabled('mender-systemd', ' sysvinit', '', d)}"
-VIRTUAL-RUNTIME_init_manager:mender-systemd = "systemd"
-VIRTUAL-RUNTIME_initscripts:mender-systemd = ""
+INIT_MANAGER:mender-systemd = "systemd"


### PR DESCRIPTION
Historically, the mechanism to use systemd as init manager in a Yocto build was to set the following variables, or at least some variation:

DISTRO_FEATURES:append = " systemd"
DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
VIRTUAL-RUNTIME_init_manager = "systemd"
VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"

Since a few releases, the canonical way is to set

INIT_MANAGER = "systemd"

Mender should reflect this, tied to the MENDER_FEATURES override.

Changelog: Title
Ticket: None

# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
