### PR TITLE
fix: mender-configure: Don't break if libdir is set to `lib64`.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -24,13 +24,17 @@ FILES:${PN}:append:mender-systemd = " \
 
 SYSTEMD_SERVICE:${PN}:mender-systemd = "mender-configure-apply-device-config.service"
 
+# Note: Do not use ${libdir} below. It can be set to lib64, but the mender-configure sources are
+# hardcoded to /usr/lib. Ideally this should be organized better, but changing it may have some side
+# effects, so let's hardcode it for now.
 FILES:${PN}-demo = " \
-    ${libdir}/mender-configure/apply-device-config.d/mender-demo-raspberrypi-led \
+    /usr/lib/mender-configure/apply-device-config.d/mender-demo-raspberrypi-led \
     /data/mender-configure/device-config.json \
 "
 
+# Note: Do not use ${libdir} below. See above comment.
 FILES:${PN}-scripts = " \
-    ${libdir}/mender-configure/apply-device-config.d/timezone \
+    /usr/lib/mender-configure/apply-device-config.d/timezone \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Originally from Mender Hub:
https://hub.mender.io/t/mender-configure-files-installed-but-not-shipped/3289

Changelog: Title
Ticket: None
