### PR TITLE
feat: add recipe for the Application Update Module

### DIFF
--- a/meta-mender-core/recipes-update-modules/mender-app-update-module/mender-app-update-module_git.bb
+++ b/meta-mender-core/recipes-update-modules/mender-app-update-module/mender-app-update-module_git.bb
@@ -1,0 +1,68 @@
+DESCRIPTION = "Mender Application Update Module for supporting containerized application updates on devices including related tools."
+
+HOMEPAGE = "https://mender.io"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081"
+
+SRC_URI = "git://github.com/mendersoftware/app-update-module;branch=master;protocol=https"
+
+SRCREV = "15025d9f1e21eafcbf1325b2a5034b2606e1d719"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} = "jq mender-client xdelta3"
+
+PACKAGECONFIG ?= ""
+PACKAGECONFIG[docker-compose] = ",,,docker-compose"
+PACKAGECONFIG[k3s] = ",,,packagegroup-k3s-node"
+PACKAGECONFIG[k8s] = ",,,kubectl"
+
+inherit allarch
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    if ! ${@bb.utils.contains('PACKAGECONFIG', 'docker-compose', 'true', 'false', d)} && \
+       ! ${@bb.utils.contains('PACKAGECONFIG', 'k3s', 'true', 'false', d)} && \
+       ! ${@bb.utils.contains('PACKAGECONFIG', 'k8s', 'true', 'false', d)}; then
+        bbwarn "PACKAGECONFIG for mender-app-update-module is empty or invalid. Please specify either 'docker-compose', 'k3s' or 'k8s' unless you know what you are doing."
+    fi
+}
+
+do_install:class-target() {
+    # install the Application Update Module
+    install -d ${D}/${datadir}/mender/app-modules/v1
+    install -d ${D}/${datadir}/mender/modules/v3
+    install -m 755 ${S}/src/app ${D}/${datadir}/mender/modules/v3/app
+
+    # install the configuration files
+    install -d ${D}/${sysconfdir}/mender
+    install -m 755 ${S}/conf/mender-app.conf ${D}/${sysconfdir}/mender/mender-app.conf
+
+    # install the Docker Compose Module
+    if ${@bb.utils.contains('PACKAGECONFIG', 'docker-compose', 'true', 'false', d)}; then
+        install -m 755 ${S}/src/app-modules/docker-compose ${D}/${datadir}/mender/app-modules/v1/docker-compose
+        install -m 755 ${S}/conf/mender-app-docker-compose.conf ${D}/${sysconfdir}/mender/mender-app-docker-compose.conf
+    fi
+
+    # install the K8S Module
+    if ${@bb.utils.contains('PACKAGECONFIG', 'k3s', 'true', 'false', d)} || ${@bb.utils.contains('PACKAGECONFIG', 'k8s', 'true', 'false', d)}; then
+        install -m 755 ${S}/src/app-modules/k8s ${D}/${datadir}/mender/app-modules/v1/k8s
+        install -m 755 ${S}/conf/mender-app-k8s.conf ${D}/${sysconfdir}/mender/mender-app-k8s.conf
+    fi
+}
+
+do_install:class-native() {
+    install -d ${D}/${bindir}
+    install -m 755 ${S}/gen/app-gen ${D}/${bindir}/app-gen
+}
+
+FILES:${PN} += "${datadir}/mender/modules/v3/app"
+FILES:${PN} += "${datadir}/mender/app-modules/v1"
+FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'docker-compose', '${datadir}/mender/app-modules/v1/docker-compose', '', d)}"
+FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'k3s', '${datadir}/mender/app-modules/v1/k8s', '', d)}"
+FILES:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'k8s', '${datadir}/mender/app-modules/v1/k8s', '', d)}"
+
+FILES:${PN}-class-native += "${bindir}/app-gen"
+
+BBCLASSEXTEND = "native"

--- a/tests/acceptance/test_app_update_module.py
+++ b/tests/acceptance/test_app_update_module.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+# Copyright 2023 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import subprocess
+
+import pytest
+
+from utils.common import (
+    build_image,
+    latest_build_artifact,
+)
+
+
+class TestAppUpdateModule:
+    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.only_with_image("ext4")
+    def test_build_app_update_module(self, request, prepared_test_build, bitbake_image):
+        build_image(
+            prepared_test_build["build_dir"],
+            prepared_test_build["bitbake_corebase"],
+            bitbake_image,
+            ['IMAGE_INSTALL:append = " mender-app-update-module"'],
+        )
+        image = latest_build_artifact(
+            request, prepared_test_build["build_dir"], "core-image*.ext4"
+        )
+
+        for expected_node in ("/usr/share/mender/modules/v3/app",):
+            output = subprocess.check_output(
+                ["debugfs", "-R", "stat %s" % expected_node, image]
+            ).decode()
+
+            # The nodes are either files or symlinks
+            assert "Type: regular" in output or "Type: symlink" in output


### PR DESCRIPTION
The app-updates Update Module provides an API for orchestrated application level updates, and currently two user implementation for docker-compose and k8s.

The recipe installs the Update Module and dependencies for deploying such docker-compose and k8s artifacts. The implementation is in shell script and therefore architecture agnostic.

Changelog: Title
Ticket: MEN-6084