### PR TITLE
mender-artifactimg: Remove old IMAGE_ID usage

### DIFF
--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -135,6 +135,6 @@ IMAGE_CMD:mender () {
         -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender
 }
 
-IMAGE_CMD:mender[vardepsexclude] += "IMAGE_ID"
+IMAGE_CMD:mender[vardepsexclude] += "MENDER_ARTIFACT_NAME"
 # We need to have the filesystem image generated already.
 IMAGE_TYPEDEP:mender:append = " ${ARTIFACTIMG_FSTYPE}"


### PR DESCRIPTION
When this variable was removed this place was missed.

Fixes: b23ec02 ("MEN-763: Split and rename artifact-info and trim information.")