### PR TITLE
fix: mv image files instead of install, to avoid corrupting the image.

### DIFF
--- a/meta-mender-core/classes/mender-bootimg.bbclass
+++ b/meta-mender-core/classes/mender-bootimg.bbclass
@@ -42,7 +42,8 @@ IMAGE_CMD:bootimg() {
                 $label_flag "${MENDER_BOOT_PART_LABEL}" \
                 ${MENDER_BOOT_PART_FSOPTS}
         fi
-        install -m 0644 "${WORKDIR}/boot.${MENDER_BOOT_PART_FSTYPE_TO_GEN}" "${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg"
+        chmod 0644 "${WORKDIR}/boot.${MENDER_BOOT_PART_FSTYPE_TO_GEN}"
+        mv "${WORKDIR}/boot.${MENDER_BOOT_PART_FSTYPE_TO_GEN}" "${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg"
     fi
 }
 

--- a/meta-mender-core/classes/mender-dataimg.bbclass
+++ b/meta-mender-core/classes/mender-dataimg.bbclass
@@ -30,11 +30,13 @@ IMAGE_CMD:dataimg() {
         sload.f2fs -f "${_MENDER_ROOTFS_COPY}" "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}"
     fi
 
-    install -m 0644 "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
+    chmod 0644 "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}"
+    mv "${WORKDIR}/data.${MENDER_DATA_PART_FSTYPE_TO_GEN}" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
 }
 IMAGE_CMD:dataimg:mender-image-ubi() {
     mkfs.ubifs -o "${WORKDIR}/data.ubifs" -r "${_MENDER_ROOTFS_COPY}" ${MKUBIFS_ARGS}
-    install -m 0644 "${WORKDIR}/data.ubifs" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
+    chmod 0644 "${WORKDIR}/data.ubifs"
+    mv "${WORKDIR}/data.ubifs" "${IMGDEPLOYDIR}/${IMAGE_NAME}.dataimg"
 }
 
 # We need the data contents intact.


### PR DESCRIPTION
coreutils 9.0 introduces a new behavior in the "install" tool. When used to install a sparse file, it now looks for holes and may insert new holes. Using "mv" instead of install ensures that images do not lose significant information.
This fix is beneficial to the use of bmaptool to write images to a device, especially if the image contains a FAT filesystem.

Changelog: Title


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
