### PR TITLE
chore: Update test systemd services with the new client names

### DIFF
--- a/meta-mender-demo/recipes-connectivity/qemu-connectivity-helper/files/qemu-connectivity-helper.service
+++ b/meta-mender-demo/recipes-connectivity/qemu-connectivity-helper/files/qemu-connectivity-helper.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prolong the shutdown, so that Qemu SLiRP TCP connections have time to be brought down.
 After=network-online.target
-Before=mender-client.service mender-gateway.service
+Before=mender-client.service mender-authd.service mender-updated.service mender-gateway.service
 
 [Service]
 ExecStart=/bin/true

--- a/meta-mender-demo/recipes-mender/mender-reboot-detector/files/mender-reboot-detector.service
+++ b/meta-mender-demo/recipes-mender/mender-reboot-detector/files/mender-reboot-detector.service
@@ -3,7 +3,7 @@
 ConditionPathExists=/data/mender/test.mender-reboot-detector.txt
 Requires=data.mount network-online.target sshd.socket
 After=data.mount network-online.target sshd.socket
-Before=mender-client.service
+Before=mender-client.service mender-authd.service mender-updated.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Adds the new client service names to `Before` list for `mender-reboot-detector` and `qemu-connectivity-helper`.