### PR TITLE
chore(client): Remove/adapt last remaining `RDEPENDS:${PN}` references.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -1,7 +1,6 @@
 inherit mender-licensing
 
 BBCLASSEXTEND = "native"
-RDEPENDS:${PN}:class-native = ""
 DEPENDS:class-native = ""
 
 DESCRIPTION = "Mender tool for doing OTA software updates."
@@ -25,8 +24,6 @@ RRECOMMENDS:mender-update += "mender-flash"
 # rootfs-image module uses jq to parse the config file, but it is able to fall
 # back to line based parsing, which is less resilient.
 RRECOMMENDS:mender-update:append = "${@bb.utils.contains('PACKAGECONFIG', 'modules', ' jq', '', d)}"
-
-RDEPENDS:${PN}-dev:append = " mender-auth-dev"
 
 SYSTEMD_SERVICE:mender-update = "mender-updated.service"
 SYSTEMD_SERVICE:mender-auth = "mender-authd.service"

--- a/meta-mender-qemu/recipes-mender/mender-client/mender-client-test-files.inc
+++ b/meta-mender-qemu/recipes-mender/mender-client/mender-client-test-files.inc
@@ -8,10 +8,10 @@
 # * opensc: pkcs11-tool for initialization of token
 # * gnutls-bin: provides p11tool for getting the contents of the token
 DEPENDS:append:mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11"
-RDEPENDS:${PN}:append:mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11 gnutls-bin"
+RDEPENDS:mender-auth:append:mender-image:qemuall = " softhsm opensc gnutls p11-kit libp11 gnutls-bin"
 
 # Needed for the TestFaultTolerance tests in the integration repository.
-RDEPENDS:${PN}:append:mender-image:qemuall = " \
+RDEPENDS:mender-auth:append:mender-image:qemuall = " \
     kernel-module-ipt-reject \
     kernel-module-ts-bm \
     kernel-module-xt-string \


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 1b7ec65c64024a423868f98aa3814543225c9b1a)
