### PR TITLE
fix: Amend D-Bus interface files path for the C++ client

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -139,7 +139,7 @@ FILES:mender-auth += "\
 "
 
 FILES:mender-auth-dev += "\
-    ${datadir}/dbus-1/interface/io.mender.Authentication1.xml \
+    ${datadir}/dbus-1/interfaces/io.mender.Authentication1.xml \
 "
 
 FILES:mender-update += "\

--- a/meta-mender-core/recipes-mender/mender-client/mender-client-go.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-go.inc
@@ -122,9 +122,9 @@ FILES:${PN} += "\
 
 
 FILES:${PN}-dev:append = " \
-    ${datadir}/dbus-1/interface \
-    /usr/share/dbus-1/interface/io.mender.Update1.xml \
-    /usr/share/dbus-1/interface/io.mender.Authentication1.xml \
+    ${datadir}/dbus-1/interfaces \
+    ${datadir}/dbus-1/interfaces/io.mender.Update1.xml \
+    ${datadir}/dbus-1/interfaces/io.mender.Authentication1.xml \
 "
 
 MENDER_CLIENT ?= "mender-client"


### PR DESCRIPTION
It should be `interfaces` according to:
* https://dbus.freedesktop.org/doc/dbus-api-design.html