### PR TITLE
chore: Update licenses checksums for git recipes

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -65,7 +65,7 @@ def mender_license(branch):
                "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & MPL-2.0",
     }
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
+    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
 "
 LICENSE = "${@mender_license(d.getVar('MENDER_ARTIFACT_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
@@ -62,7 +62,7 @@ def mender_configure_license(branch):
                "license": "Apache-2.0",
     }
 LIC_FILES_CHKSUM = " \
-    file://LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
+    file://LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
 "
 LICENSE = "${@mender_configure_license(d.getVar('MENDER_CONFIGURE_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -62,7 +62,7 @@ def mender_connect_license(branch):
                "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT",
     }
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
+    file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
 "
 LICENSE = "${@mender_connect_license(d.getVar('MENDER_CONNECT_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-flash/mender-flash_git.bb
+++ b/meta-mender-core/recipes-mender/mender-flash/mender-flash_git.bb
@@ -62,7 +62,7 @@ def mender_flash_license(branch):
                "license": "Apache-2.0",
     }
 LIC_FILES_CHKSUM = " \
-    file://LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
+    file://LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
 "
 LICENSE = "${@mender_flash_license(d.getVar('MENDER_FLASH_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-snapshot/mender-snapshot_git.bb
+++ b/meta-mender-core/recipes-mender/mender-snapshot/mender-snapshot_git.bb
@@ -60,7 +60,7 @@ def mender_snapshot_license(branch):
     return {
                "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & MIT",
     }
-LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081"
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0"
 LICENSE = "${@mender_snapshot_license(d.getVar('MENDER_SNAPSHOT_BRANCH'))['license']}"
 
 # Downprioritize this recipe in version selections.


### PR DESCRIPTION
Following up from the copyright year update in the license files

See:
* https://github.com/mendersoftware/mender-artifact/pull/576
* https://github.com/mendersoftware/mender-configure-module/pull/105
* https://github.com/mendersoftware/mender-connect/pull/126
* https://github.com/mendersoftware/mender-flash/pull/10
* https://github.com/mendersoftware/mender-snapshot/pull/18