### PR TITLE
fix(mender): Fix incorrect licenses and license checksums.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -70,15 +70,25 @@ def mender_version_from_preferred_version(d):
 def mender_license(branch):
     import re
     if branch.startswith("1."):
+        # Golang client
         return {
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+            "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+            "license_file": "file://src/github.com/mendersoftware/mender/LICENSE",
+        }
+    elif branch.startswith("2.") or branch.startswith("3."):
+        # Golang client
+        return {
+            "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+            "license_file": "file://src/github.com/mendersoftware/mender/LICENSE",
         }
     else:
+        # C++ client
         return {
-                   "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & OLDAP-2.8",
+            "license": "Apache-2.0 & MIT & Unlicense",
+            "license_file": "file://LICENSE",
         }
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender/LICENSE;md5=b4b4cfdaea6d61aa5793b92efd42e081 \
+    ${@mender_license(d.getVar('MENDER_BRANCH'))['license_file']};md5=30b4554c64108561c0cb1c57e8a044f0 \
 "
 LICENSE = "${@mender_license(d.getVar('MENDER_BRANCH'))['license']}"
 

--- a/meta-mender-core/recipes-mender/mender-client/mender_git.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender_git.bb
@@ -1,13 +1,4 @@
 require mender-client-cpp.inc
 require mender-client_git.inc
 
-LICENSE = "Apache-2.0 & BSD-3-Clause"
-
-LIC_FILES_CHKSUM = " \
-    file://LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
-    file://vendor/json/LICENSE.MIT;md5=f969127d7b7ed0a8a63c2bbeae002588 \
-    file://vendor/json/docs/mkdocs/docs/home/license.md;md5=970ea048f6ea7d04eeb3ba3ef9ebca40 \
-    file://vendor/lmdbxx/UNLICENSE;md5=7246f848faa4e9c9fc0ea91122d6e680 \
-"
-
 PV = "${@mender_version_from_preferred_version(d)}"


### PR DESCRIPTION
The licenses of the C++ client was wrong, and the checksum for the Golang client when building with Git was also wrong. Fix both, and consolidate licenses in one file.

Changelog: None
Ticket: None
