### PR TITLE
fix: pass prefix and systemd_unitdir to mender-configure installation

### DIFF
--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -44,6 +44,7 @@ do_install() {
     oe_runmake \
         -C ${S} \
         DESTDIR=${D} \
+        prefix=${D} \
         install-bin \
         install-demo \
         install-scripts
@@ -66,5 +67,7 @@ do_install:append:mender-systemd() {
     oe_runmake \
         -C ${S} \
         DESTDIR=${D} \
+        prefix=${D} \
+        systemd_unitdir=${systemd_unitdir} \
         install-systemd
 }


### PR DESCRIPTION
The mender-configure installation process now supports the prefix and systemd_unitdire directories being passed in. This is required for the ongoign usrmerge effort.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
