### PR TITLE
fix: Use correct resize script name

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/files/mender-grow-data.service
+++ b/meta-mender-core/recipes-mender/mender-client/files/mender-grow-data.service
@@ -7,7 +7,7 @@ Before=mender-systemd-growfs-data.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/mender-client-resize-data-part
+ExecStart=/usr/bin/mender-resize-data-part
 
 [Install]
 WantedBy=data.mount


### PR DESCRIPTION
'client' was dropped from the resize script name. Update the service file accordingly.

Changelog: None
Ticket: None

