### PR TITLE
fix: Fix broken Git builds for mender-client < 4.0.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -7,7 +7,7 @@ PKGV = "${@'999+${PV}' if any(['${PV}'.startswith(p) for p in ['master', 'featur
 
 MENDER_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
-SRC_URI = "gitsm://github.com/mendersoftware/mender;protocol=https;branch=${MENDER_BRANCH}"
+SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=${MENDER_BRANCH}"
 
 # Disables the need for every dependency to be checked, for easier development.
 _MENDER_DISABLE_STRICT_LICENSE_CHECKING = "1"


### PR DESCRIPTION
For some reason `gitsm` has a different checkout location than `git`. It's probably related to how it interacts with the go class, but we don't need `gitsm` for the Golang client anyway, so just switch back to `git`.

Changelog: Title
Ticket: None
