### PR TITLE
fix: remove "mender.bmap" IMAGE_FSTYPE

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -1,4 +1,4 @@
-IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image', ' mender mender.bmap', '', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image', ' mender', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-sd', ' sdimg sdimg.bmap', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-ubi', ' ubimg mtdimg ubimg.bmap', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-uefi', ' uefiimg uefiimg.bmap', '', d)}"


### PR DESCRIPTION
The IMAGE_FSTYPE "mender.bmap" is added by default if the MENDER_FEATURES flag "mender-image" is set, but is has no valid use case. Hence, it can be removed.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
