### PR TITLE
fix: remove "mender.bmap" IMAGE_FSTYPE

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -1,4 +1,4 @@
-IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image', ' mender mender.bmap', '', d)}"
+IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image', ' mender', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-sd', ' sdimg sdimg.bmap', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-ubi', ' ubimg mtdimg ubimg.bmap', '', d)}"
 IMAGE_FSTYPES += "${@bb.utils.contains('MENDER_FEATURES', 'mender-image-uefi', ' uefiimg uefiimg.bmap', '', d)}"


### PR DESCRIPTION
The IMAGE_FSTYPE "mender.bmap" is added by default if the MENDER_FEATURES flag "mender-image" is set, but is has no valid use case. Hence, it can be removed.

Changelog: Title
Ticket: None

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
(cherry picked from commit a59a24803ac0bfd91880dcdb4f4a165ad049438a)
