### PR TITLE
fix: Don't use `MENDER_FEATURES_ENABLE` variable directly.

### DIFF
--- a/meta-mender-core/classes/mender-maybe-setup.bbclass
+++ b/meta-mender-core/classes/mender-maybe-setup.bbclass
@@ -1,13 +1,7 @@
 def mender_feature_is_enabled(feature, if_true, if_false, d):
-    in_enable = bb.utils.contains('MENDER_FEATURES_ENABLE', feature, True, False, d)
-    in_disable = bb.utils.contains('MENDER_FEATURES_DISABLE', feature, True, False, d)
+    return if_true if feature in mender_features_list(d) else if_false
 
-    if in_enable and not in_disable:
-        return if_true
-    else:
-        return if_false
-
-def mender_features(d, separator=" "):
+def mender_features_list(d):
     enabled = d.getVar('MENDER_FEATURES_ENABLE')
     if enabled is None:
         return ""
@@ -20,7 +14,10 @@ def mender_features(d, separator=" "):
     else:
         disabled = disabled.split()
 
-    return separator.join([feature for feature in enabled if feature not in disabled])
+    return [feature for feature in enabled if feature not in disabled]
+
+def mender_features(d, separator=" "):
+    return separator.join(mender_features_list(d))
 
 MENDER_FEATURES = "${@mender_features(d)}"
 DISTROOVERRIDES:append = ":${@mender_features(d, separator=':')}"

--- a/meta-mender-core/classes/mender-setup.bbclass
+++ b/meta-mender-core/classes/mender-setup.bbclass
@@ -261,13 +261,13 @@ python() {
 addhandler mender_sanity_handler
 mender_sanity_handler[eventmask] = "bb.event.ParseCompleted"
 python mender_sanity_handler() {
-    if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and d.getVar('MENDER_STORAGE_DEVICE', True) != "":
+    if bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', True, False, d) and d.getVar('MENDER_STORAGE_DEVICE', True) != "":
         bb.warn("MENDER_STORAGE_DEVICE is ignored when mender-partuuid is enabled. Clear MENDER_STORAGE_DEVICE to remove this warning.")
 
-    if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-uboot', True, False, d):
+    if bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES', 'mender-uboot', True, False, d):
         bb.fatal("mender-partuuid is not supported with mender-uboot.")
 
-    if bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-partlabel', True, False, d):
+    if bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', True, False, d) and bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', True, False, d):
         bb.fatal("mender-partuuid is not supported with mender-partlabel.")
 }
 


### PR DESCRIPTION
We should use `MENDER_FEATURES` because this is the final result of calculating the features, otherwise we can miss feature toggles that have special handling.

This fixes an issue where `mender-update-install` was not added correctly, leading to boot issues on RPi.

No changelog for this, because it was never in a tagged release.

Changelog: None
Ticket: MEN-7039
