### PR TITLE
fix: remove `_MENDER_FLASH_TOOL_DEFAULT` from mender-binary-delta 1.5.0

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.5.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_1.5.0.bb
@@ -14,6 +14,3 @@ LIC_FILES_CHKSUM = " \
 # default.
 # Downprioritize this recipe in version selections.
 # DEFAULT_PREFERENCE = "-1"
-
-# Not used in this version.
-_MENDER_FLASH_TOOL_DEFAULT = ""


### PR DESCRIPTION
Changelog: None
Ticket: MEN-6938