### PR TITLE
fix: use gitsm:// fetcher for mender-client_git

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -7,7 +7,7 @@ PKGV = "${@'999+${PV}' if any(['${PV}'.startswith(p) for p in ['master', 'featur
 
 MENDER_BRANCH = "${@mender_branch_from_preferred_version(d)}"
 
-SRC_URI = "git://github.com/mendersoftware/mender;protocol=https;branch=${MENDER_BRANCH}"
+SRC_URI = "gitsm://github.com/mendersoftware/mender;protocol=https;branch=${MENDER_BRANCH}"
 
 # Disables the need for every dependency to be checked, for easier development.
 _MENDER_DISABLE_STRICT_LICENSE_CHECKING = "1"


### PR DESCRIPTION
When building from git master, it is necessary to also fetch the vendored submodules. Switching the recipe to the gitsm:// fetcher fixes this process.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
