### PR TITLE
fix: Set correct systemd installation dir.

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -33,6 +33,7 @@ MENDER_CLIENT ?= "mender-updated"
 
 # Don't download the googletest source in Mender CMakefiles.txt
 EXTRA_OECMAKE:append = " -DMENDER_DOWNLOAD_GTEST=NO"
+EXTRA_OECMAKE:append = " -DSYSTEMD_UNIT_DIR=${systemd_system_unitdir}"
 
 inherit cmake
 


### PR DESCRIPTION
This is important when usrmerge is enabled, which changes the systemd install location.

Changelog: Commit
Ticket: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
(cherry picked from commit 7bee5f74c6b807658c82668ecdca5674ffa08562)
