### PR TITLE
fix: add coreutils as a runtime dependency for Mender monitor

### DIFF
--- a/meta-mender-commercial/conditional/mender-monitor/mender-monitor.inc
+++ b/meta-mender-commercial/conditional/mender-monitor/mender-monitor.inc
@@ -2,7 +2,8 @@ inherit mender-licensing
 
 inherit systemd
 
-RDEPENDS:${PN} = "bash mender-auth lmdb"
+RDEPENDS:${PN} = "bash mender-auth lmdb coreutils"
+
 
 FILES:${PN} = " \
     ${bindir}/mender-monitord \


### PR DESCRIPTION
If the image is built with a busybox version of `df` Mender monitor will start giving errors for the disk usage case:

Setting a runtime dependency to coreutils provides a real version of df instead of a busybox one.

Ticket: None
Changelog: Title


