### PR TITLE
fix: add coreutils as a runtime dependency for Mender monitor

### DIFF
--- a/meta-mender-commercial/conditional/mender-monitor/mender-monitor.inc
+++ b/meta-mender-commercial/conditional/mender-monitor/mender-monitor.inc
@@ -2,7 +2,8 @@ inherit mender-licensing
 
 inherit systemd
 
-RDEPENDS:${PN} = "bash mender-auth lmdb"
+RDEPENDS:${PN} = "bash mender-auth lmdb coreutils"
+
 
 FILES:${PN} = " \
     ${bindir}/mender-monitord \


### PR DESCRIPTION
If the image is built with a busybox version of `df` Mender monitor will start giving errors for the disk usage case:

May 22 17:07:07 qemux86-64 mender-monitord[235944]: Usage: df [-PkmhT] [-t TYPE] [FILESYSTEM]...
May 22 17:07:09 qemux86-64 mender-monitord[236060]: df: unrecognized option '--output=pcent'
May 22 17:07:09 qemux86-64 mender-monitord[236060]: BusyBox v1.35.0 () multi-call binary.
May 22 17:07:09 qemux86-64 mender-monitord[236060]: Usage: df [-PkmhT] [-t TYPE] [FILESYSTEM]...
May 22 17:07:11 qemux86-64 mender-monitord[236087]: df: unrecognized option '--output=pcent'

Setting a runtime dependency to coreutils provides a real version of df instead of a busybox one.

Ticket: None
Changelog: Title

Signed-off-by: Alan <alan.martinovic@northern.tech>
(cherry picked from commit 7cd22ee0ac21e69c4210a238cbaf1f0c0855b6c3)
