### PR TITLE
fix: Fix `mender-binary-delta` configuration

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta.inc
@@ -49,7 +49,7 @@ do_configure() {
 
     if [ -n "${MENDER_FLASH_TOOL}" ]; then
         cat >>${WORKDIR}/mender-binary-delta.conf <<EOF
-   "FlashTool": "mender-flash",
+   "FlashTool": "${MENDER_FLASH_TOOL}",
 EOF
     fi
 


### PR DESCRIPTION
Amends commit: 5e31f7eb2789291c6a26e6670018e5062476c8aa

Ticket: None
Changelog: Fix autogeneration of `mender-binary-delta.conf` so that the user value for `MENDER_FLASH` is respected, instead of the previously wrongly hard-coded value of `mender-flash`. Without this fix `mender-binary-delta` won't still work on UBI file systems.