### PR TITLE
chore: Rename layer to `mender-ci`

### DIFF
--- a/tests/meta-mender-beaglebone-yocto-ci/conf/layer.conf
+++ b/tests/meta-mender-beaglebone-yocto-ci/conf/layer.conf
@@ -11,4 +11,4 @@ BBFILE_PRIORITY_meta-mender-beaglebone-yocto-ci = "99"
 
 LAYERSERIES_COMPAT_meta-mender-beaglebone-yocto-ci = "kirkstone"
 
-LAYERDEPENDS_meta-mender-beaglebone-yocto-ci:append = "meta-mender-ci"
+LAYERDEPENDS_meta-mender-beaglebone-yocto-ci:append = "mender-ci"

--- a/tests/meta-mender-ci/README
+++ b/tests/meta-mender-ci/README
@@ -1,5 +1,5 @@
 This README file contains information on the contents of the
-meta-mender-ci layer.
+mender-ci layer.
 
 Please see the corresponding sections below for details.
 

--- a/tests/meta-mender-ci/conf/layer.conf
+++ b/tests/meta-mender-ci/conf/layer.conf
@@ -5,11 +5,11 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 	${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "meta-mender-ci"
-BBFILE_PATTERN_meta-mender-ci = "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-mender-ci = "10"
+BBFILE_COLLECTIONS += "mender-ci"
+BBFILE_PATTERN_mender-ci = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-ci = "10"
 
-LAYERSERIES_COMPAT_meta-mender-ci = "kirkstone"
+LAYERSERIES_COMPAT_mender-ci = "kirkstone"
 
 # We need a bit more than the demo layer to fit test dependencies
 MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "708"
@@ -33,7 +33,7 @@ DBUS_WEBSOCKETS_TEST = "python3-profile python3-websockets python3-pydbus"
 # There isn't enough space to install this on vexpress-qemu-flash.
 DBUS_WEBSOCKETS_TEST:vexpress-qemu-flash = ""
 
-LAYERDEPENDS_meta-mender-ci:append = " mender"
+LAYERDEPENDS_mender-ci:append = " mender"
 
 IMAGE_CLASSES += "extrausers"
 EXTRA_USERS_PARAMS = "\

--- a/tests/meta-mender-raspberrypi3-ci/conf/layer.conf
+++ b/tests/meta-mender-raspberrypi3-ci/conf/layer.conf
@@ -13,4 +13,4 @@ IMAGE_BOOT_FILES:append = " boot-for-flashing.scr"
 
 LAYERSERIES_COMPAT_meta-mender-raspberrypi3-ci = "kirkstone"
 
-LAYERDEPENDS_meta-mender-raspberrypi3-ci:append = "meta-mender-ci"
+LAYERDEPENDS_meta-mender-raspberrypi3-ci:append = "mender-ci"


### PR DESCRIPTION
To follow the convention of the rest of the layers, where `meta-mender-qemu` dir defines `mender-qemu` or `meta-mender-demo` defines `mender-demo`.