### PR TITLE
fix: persistent machine id support files renamed

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -90,8 +90,8 @@ SRC_URI:append:mender-image:mender-systemd = " \
 "
 
 SRC_URI:append:mender-persist-systemd-machine-id = " \
-    file://mender-client-systemd-machine-id.service \
-    file://mender-client-set-systemd-machine-id.sh \
+    file://mender-systemd-machine-id.service \
+    file://mender-set-systemd-machine-id.sh \
 "
 
 SRC_URI:append:mender-growfs-data:mender-systemd = " \


### PR DESCRIPTION
The script to write a persistent systemd machine id
along with the correlating systemd service unit have
been renamed. Adjust the filenames in mender-client-cpp.inc
accordingly.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
