### PR TITLE
test: Remove awscli from _test_ requirements

### DIFF
--- a/tests/acceptance/requirements_deb.txt
+++ b/tests/acceptance/requirements_deb.txt
@@ -1,6 +1,5 @@
 autoconf
 automake
-awscli
 bash
 bc
 build-essential


### PR DESCRIPTION
This package does not exist anymore in recent Ubuntu, where awscli has been moved to an snap.

Strictly speaking is not a test requirement anyway, it is used by CI to to save artifacts after the tests, so if needed we can install it there.