### PR TITLE
MEN-7447: Update Docker base image to latest Alpine

### DIFF
--- a/meta-mender-qemu/docker/qemux86-64/Dockerfile
+++ b/meta-mender-qemu/docker/qemux86-64/Dockerfile
@@ -25,7 +25,7 @@
 #       Copy the configuration file for mender-gateway
 #       Note that the file needs to be mounted into the Docker container
 
-FROM python:3.11.3-alpine3.16
+FROM python:3.12.5-alpine3.20
 
 # Install packages
 RUN apk add --no-cache util-linux multipath-tools \


### PR DESCRIPTION
Which, apparently, fixes the issue with scarthgap images not booting in QEMU in unprivileged Docker containers.