### PR TITLE
[scarthgap] chase persistent machine id renames

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -114,9 +114,9 @@ FILES:mender-update:append:mender-growfs-data:mender-systemd = " \
 "
 
 FILES:mender-update:append:mender-persist-systemd-machine-id = " \
-    ${systemd_unitdir}/system/mender-client-systemd-machine-id.service \
-    ${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/mender-client-systemd-machine-id.service \
-    ${bindir}/mender-client-set-systemd-machine-id.sh \
+    ${systemd_unitdir}/system/mender-systemd-machine-id.service \
+    ${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/mender-systemd-machine-id.service \
+    ${bindir}/mender-set-systemd-machine-id.sh \
 "
 
 FILES:mender-config += "\
@@ -326,11 +326,11 @@ do_install:append:class-target:mender-growfs-data:mender-systemd() {
 }
 
 do_install:append:class-target:mender-persist-systemd-machine-id() {
-    install -m 644 ${WORKDIR}/mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/
+    install -m 644 ${WORKDIR}/mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/
     install -d -m 755 ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants
-    ln -sf ../mender-client-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/
+    ln -sf ../mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/
     install -d -m 755 ${D}${bindir}
-    install -m 755 ${WORKDIR}/mender-client-set-systemd-machine-id.sh ${D}${bindir}/
+    install -m 755 ${WORKDIR}/mender-set-systemd-machine-id.sh ${D}${bindir}/
 }
 
 do_install() {


### PR DESCRIPTION
Commit bca6bf7 included part of the required fixed.  This contains the rest. There may be others, but this allows me to build the C++ client.

Left as an exercise for the maintainers: enabling this features somewhere in the official test matrix, so this kind of breakage gets detected sooner. :grin: