### PR TITLE
QA-768: Learn more about what is happening in `mender-connect` on failures

### DIFF
--- a/tests/acceptance/test_mender-connect.py
+++ b/tests/acceptance/test_mender-connect.py
@@ -264,6 +264,9 @@ class TestMenderConnect:
                 "Connection established with http://localhost:6000",
             )
 
+        except:
+            connection.run("journalctl --unit mender-connect --output cat")
+
         finally:
             connection.run(
                 "systemctl --job-mode=ignore-dependencies stop mender-connect || true"


### PR DESCRIPTION
By printing the journal when the test fails