### PR TITLE
test: Skip unstable test while we work on the workaround

### DIFF
--- a/tests/acceptance/test_build.py
+++ b/tests/acceptance/test_build.py
@@ -461,6 +461,7 @@ b524b8b3f13902ef8014c0af7aa408bc  ./usr/local/share/ca-certificates/mender/serve
         + [("mender-flash", version) for version in versions_of_recipe("mender-flash")]
         + [("mender-flash", None)],
     )
+    @pytest.mark.skip(reason="QA-784")
     def test_preferred_versions(self, prepared_test_build, recipe, version):
         """Most CI builds build with PREFERRED_VERSION set, because we want to
         build from a specific SHA. Test that we can change that or turn it off


### PR DESCRIPTION
Both attempts to fix have been problematic:
* https://github.com/mendersoftware/meta-mender/pull/2181#discussion_r1803013671
* https://github.com/mendersoftware/meta-mender/pull/2190

Disabling the test for the time being.