### PR TITLE
Fix building with Mender disabled

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
@@ -28,6 +28,8 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
+MENDER_EFI_LOADER ?= ""
+
 require ${@'uboot_version_logic.inc' if d.getVar('MENDER_EFI_LOADER').startswith('u-boot') else ''}
 
 DEPENDS:append = " ${MENDER_EFI_LOADER}"


### PR DESCRIPTION
# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

### Description

When the meta-mender stack is included but the distro is building without Mender (such as for testing), an error is raised. This is due to a variable being used, but never defined because some of the Mender conf isn't visited.

By setting the base default to "" it lets later code use the variable without all conf being processed.

## Motivation and context.

While testing, I had the Mender layer included, but I was building without Mender to hunt down a U-boot issue with the Raspberry Pi 5. This change at least let me get stuck in U-boot.

## How has this been tested?

In my local.conf, I have:

```
################################################################################
# Distribution features
################################################################################

# Set to "0" to disable Mender
ENABLE_MENDER = "1"

# Set to "0" to disable graphical features (OpenGL, windowing, Gnome, etc)
ENABLE_GRAPHICS = "1"
```

Before, when I set `ENABLE_MENDER` to 0, I got the error:

```
  ERROR: ExpansionError during parsing grub-efi-mender-precompiled_2.04.bb
  Traceback (most recent call last):
    File "<expansion>", line 1, in <module>
  bb.data_smart.ExpansionError: Failure expanding expression ${@'uboot_version_logic.inc' if d.getVar('MENDER_EFI_LOADER').startswith('u-boot') else ''} which triggered exception AttributeError: 'NoneType' object has no attribute 'startswith'
```

After, the build succeeds with `ENABLE_MENDER="0"`, and I can boot into Linux on the RPi 4 with Mender disabled.