### PR TITLE
ci: Fix `libp11` build by removing the pin on an old version

### DIFF
--- a/meta-mender-qemu/recipes-support/libp11/libp11_0.4.%.bbappend
+++ b/meta-mender-qemu/recipes-support/libp11/libp11_0.4.%.bbappend
@@ -1,3 +1,0 @@
-DEPENDS:append:mender-auth-install = " p11-kit"
-
-SRCREV:mender-auth-install = "e1210903291b1de9eabcad26e740a4b2fbcca692"


### PR DESCRIPTION
The build of `libp11` has recently started failing on `do_patch`, due to a change in upstream introducing a patch.

It is not completely known why we needed it to be pin to an specific version, tag 0.4.9, at the time of integrating it. In the commit message it says "libp11 bumped to latest source revision (align with OpenSSL 1.1.1d)", but by the time of that commit (2020-08) upstream was already using a newer version (0.4.10 as per 2019-05). See:
* https://github.com/mendersoftware/meta-mender/commit/f39dc0aeb482798ae86502d342f1e598901b265f
* https://git.openembedded.org/meta-openembedded/commit/?id=e9ffb7c6c09b9a7ca52801fb27dd1a057d15f7c1

In any case this was introduced by `dunfell` times, with OpenSSL 1.1, and we should not be requiring such an old version of this library to keep testing our integration with PKCS#11/SoftHSM.

Note that we remove the whole `.bbappend` because the dependency of `p11-kit` is already covered in (several) other places.