### PR TITLE
MEN-7275 (follow-up): Prefer static linkage for `mender-connect` and `mender-snapshot`

### DIFF
--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
@@ -20,6 +20,9 @@ inherit systemd
 
 GO_IMPORT = "github.com/mendersoftware/mender-connect"
 
+# Prefer static linkage (golang's default)
+GO_LINKSHARED = ""
+
 python do_prepare_mender_connect_conf() {
     import json
 

--- a/meta-mender-core/recipes-mender/mender-snapshot/mender-snapshot.inc
+++ b/meta-mender-core/recipes-mender/mender-snapshot/mender-snapshot.inc
@@ -11,6 +11,9 @@ inherit go-ptest
 
 GO_IMPORT = "github.com/mendersoftware/mender-snapshot"
 
+# Prefer static linkage (golang's default)
+GO_LINKSHARED = ""
+
 # Set the version of mender-snapshot by passing it as an extra ldflag to go.bbclass
 # This is equivalent to how it's set in the Makefile
 GO_EXTRA_LDFLAGS:append = "-X github.com/mendersoftware/mender-snapshot/conf.Version=$(git describe --tags --dirty --exact-match 2>/dev/null || git rev-parse --short HEAD)"


### PR DESCRIPTION
This is a follow-up from 0b85500.

By switching to `go.bbclass` definitions for compile and install tasks, we have also switched from static linking (golang's default) to dynamic linking (by passing `-linkshared` to the go commands - see `go.bbclass` source code).

While using shared linkage on golang binaries have benefits (and presumably is preferred in Yocto), we didn't intend to change the linkage of Mender binaries in the commit mentioned above.

(Note that `mender-connect` is actually dynamically linked for other dependencies, but at least the runtime and stdlib shall be statically linked).