### PR TITLE
Add recipes from Mender Client and Mender Gateway releases

### DIFF
--- a/meta-mender-commercial/conditional/mender-monitor/mender-monitor_1.4.0.bb
+++ b/meta-mender-commercial/conditional/mender-monitor/mender-monitor_1.4.0.bb
@@ -1,0 +1,14 @@
+require mender-monitor.inc
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LICENSE = "Mender-Yocto-Layer-License.md"
+LICENSE_FLAGS = "commercial_mender-yocto-layer-license"
+LIC_FILES_CHKSUM = " \
+    file://licenses/LICENSE.md;md5=ddb0c461e9cc224aa6aff51b108f26b8 \
+"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+# DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_2.0.0.bb
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_2.0.0.bb
@@ -1,0 +1,29 @@
+require mender-gateway.inc
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below.
+LICENSE = "Mender-Yocto-Layer-License.md & Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LICENSE_FLAGS = "commercial_mender-yocto-layer-license"
+LIC_FILES_CHKSUM = " \
+    file://licenses/LICENSE.md;md5=ddb0c461e9cc224aa6aff51b108f26b8 \
+    file://licenses/vendor/github.com/mendersoftware/go-lib-micro/LICENSE;md5=b633dec416a3d32c67acb1f332964580 \
+    file://licenses/vendor/github.com/allegro/bigcache/v3/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e \
+    file://licenses/vendor/github.com/pkg/errors/LICENSE;md5=6fe682a02df52c6653f33bd0f7126b5a \
+    file://licenses/vendor/github.com/mendersoftware/filelock/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://licenses/vendor/github.com/fsnotify/fsnotify/LICENSE;md5=8bae8b116e2cfd723492b02d9a212fe2 \
+    file://licenses/vendor/github.com/google/uuid/LICENSE;md5=88073b6dd8ec00fe09da59e0b6dfded1 \
+    file://licenses/vendor/github.com/pmezard/go-difflib/LICENSE;md5=e9a2ebb8de779a07500ddecca806145e \
+    file://licenses/vendor/github.com/spf13/pflag/LICENSE;md5=1e8b7dc8b906737639131047a590f21d \
+    file://licenses/vendor/golang.org/x/sync/LICENSE;md5=7998cb338f82d15c0eff93b7004d272a \
+    file://licenses/vendor/golang.org/x/sys/LICENSE;md5=7998cb338f82d15c0eff93b7004d272a \
+    file://licenses/vendor/github.com/davecgh/go-spew/LICENSE;md5=c06795ed54b2a35ebeeb543cd3a73e56 \
+    file://licenses/vendor/github.com/sirupsen/logrus/LICENSE;md5=8dadfef729c08ec4e631c4f6fc5d43a0 \
+    file://licenses/vendor/github.com/stretchr/objx/LICENSE;md5=d023fd31d3ca39ec61eec65a91732735 \
+    file://licenses/vendor/github.com/stretchr/testify/LICENSE;md5=188f01994659f3c0d310612333d2a26f \
+    file://licenses/vendor/gopkg.in/yaml.v3/LICENSE;md5=3c91c17266710e16afdbb2b6d15c761c \
+"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+# DEFAULT_PREFERENCE = "-1"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_4.0.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_4.0.0.bb
@@ -1,0 +1,97 @@
+require mender-artifact.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=4.0.x"
+
+# Tag: 4.0.0
+SRCREV = "550e69f12699f615fc065b3490b738abe7373f1e"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+# DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+
+LIC_FILES_CHKSUM = " \
+    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/minio/sha256-simd/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/mendersoftware/progressbar/LICENSE;md5=dcac2e5bf81a6fe99b034aaaaf1b2019 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/genproto/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/genproto/googleapis/api/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/genproto/googleapis/rpc/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/grpc/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/appengine/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/cloud.google.com/go/kms/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/cloud.google.com/go/iam/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/cloud.google.com/go/compute/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/cloud.google.com/go/compute/metadata/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/go.opencensus.io/LICENSE;md5=175792518e4ac015ab6696d16c4f607e \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/golang/groupcache/LICENSE;md5=19cbd64715b51267a47bf3750cc6a8a5 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/mendersoftware/openssl/LICENSE;md5=19cbd64715b51267a47bf3750cc6a8a5 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/googleapis/enterprise-certificate-proxy/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/go-jose/go-jose/v3/json/LICENSE;md5=591778525c869cdde0ab5a1bf283cd81 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/go-jose/go-jose/v3/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/google/s2a-go/LICENSE.md;md5=3b83ef96387f14655fc854ddc3c6bd57 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/Keyfactor/signserver-go-client-sdk/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/pkg/errors/LICENSE;md5=6fe682a02df52c6653f33bd0f7126b5a \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/pmezard/go-difflib/LICENSE;md5=e9a2ebb8de779a07500ddecca806145e \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/sys/LICENSE;md5=7998cb338f82d15c0eff93b7004d272a \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/klauspost/compress/LICENSE;md5=d0fd9ebda39468b51ff4539c9fbb13a8 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/russross/blackfriday/v2/LICENSE.txt;md5=ecf8a8a60560c35a862a4a545f2db1b3 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/google/go-cmp/LICENSE;md5=4ac66f7dea41d8d116cb7fb28aeff2ab \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/net/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/oauth2/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/text/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/crypto/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/time/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/api/LICENSE;md5=a651bb3d8b1c412632e28823bb432b40 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/api/internal/third_party/uritemplates/LICENSE;md5=4ee4feb2b545c2231749e5c54ace343e \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/google.golang.org/protobuf/LICENSE;md5=02d4002e9171d41a8fad93aa7faf3956 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/golang/protobuf/LICENSE;md5=939cce1ec101726fa754e698ac871622 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/googleapis/gax-go/v2/LICENSE;md5=0dd48ae8103725bd7b401261520cdfbb \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/crypto/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/golang.org/x/time/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/klauspost/compress/internal/snapref/LICENSE;md5=b8b79c7d4cda128290b98c6a21f9aac6 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/ulikunitz/xz/LICENSE;md5=3c82255323cf3d48815acdbf9068b715 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/davecgh/go-spew/LICENSE;md5=c06795ed54b2a35ebeeb543cd3a73e56 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/stretchr/testify/LICENSE;md5=188f01994659f3c0d310612333d2a26f \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/urfave/cli/LICENSE;md5=75d9e324acacf92aca82397b81c225b0 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/sirupsen/logrus/LICENSE;md5=8dadfef729c08ec4e631c4f6fc5d43a0 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/klauspost/pgzip/LICENSE;md5=9ea3772c7ca56b5e8cbd5caf795588b5 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/cpuguy83/go-md2man/v2/LICENSE.md;md5=80794f9009df723bbc6fe19234c9f517 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/gopkg.in/yaml.v3/LICENSE;md5=3c91c17266710e16afdbb2b6d15c761c \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/mattn/go-isatty/LICENSE;md5=f509beadd5a11227c27b5d2ad6c9f2c6 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/klauspost/cpuid/v2/LICENSE;md5=00d6f962401947482d082858f7ba2ff3 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/mitchellh/go-homedir/LICENSE;md5=3f7765c3d4f58e1f84c4313cecf0f5bd \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/mitchellh/mapstructure/LICENSE;md5=3f7765c3d4f58e1f84c4313cecf0f5bd \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/ryanuber/go-glob/LICENSE;md5=d2c81b3028eb947731a58fb068c7dff4 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/cenkalti/backoff/v3/LICENSE;md5=1571d94433e3f3aa05267efd4dbea68b \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/klauspost/compress/zstd/internal/xxhash/LICENSE.txt;md5=802da049c92a99b4387d3f3d91b00fa9 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-secure-stdlib/strutil/LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-secure-stdlib/parseutil/LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/errwrap/LICENSE;md5=b278a92d2c1509760384428817710378 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/hcl/LICENSE;md5=b278a92d2c1509760384428817710378 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-cleanhttp/LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-rootcerts/LICENSE;md5=65d26fcc2f35ea6a181ac777e42db1ea \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-retryablehttp/LICENSE;md5=bffc21c92b5f3adcbbb06f8e0067e786 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-sockaddr/LICENSE;md5=9741c346eef56131163e13b9db1241b3 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/vault/api/LICENSE;md5=bffc21c92b5f3adcbbb06f8e0067e786 \
+    file://src/github.com/mendersoftware/mender-artifact/vendor/github.com/hashicorp/go-multierror/LICENSE;md5=d44fdeb607e2d2614db9464dbedd4094 \
+"
+
+DEPENDS += "xz openssl"
+RDEPENDS:${PN} = "openssl"

--- a/meta-mender-core/recipes-mender/mender-client/mender_5.0.0.bb
+++ b/meta-mender-core/recipes-mender/mender-client/mender_5.0.0.bb
@@ -1,0 +1,40 @@
+require mender-client-cpp.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "gitsm://github.com/mendersoftware/mender;protocol=https;branch=5.0.x"
+
+# Tag: 5.0.0
+SRCREV = "47313c6d30db1da2d24ee099b72e0917d2b82254"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+#DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LIC_FILES_CHKSUM = " \
+    file://LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
+    file://src/common/vendor/yaml-cpp/test/gtest-1.11.0/googlemock/scripts/generator/LICENSE;md5=2c0b90db7465231447cf2dd2e8163333 \
+    file://src/common/vendor/json/LICENSE.MIT;md5=67f35caa1c9c8d3d990356bfecf802fb \
+    file://src/common/vendor/json/docs/mkdocs/docs/home/license.md;md5=a30fca2d241ce1bc9c268fc2bb7cca74 \
+    file://src/common/vendor/tiny-process-library/LICENSE;md5=14d72bb1dc7487cee6c51cedd497eccd \
+    file://src/common/vendor/yaml-cpp/LICENSE;md5=6a8aaf0595c2efc1a9c2e0913e9c1a2c \
+    file://src/common/vendor/lmdbxx/UNLICENSE;md5=7246f848faa4e9c9fc0ea91122d6e680 \
+    file://src/common/vendor/expected/COPYING;md5=65d3616852dbf7b1a6d4b53b00626032 \
+    file://src/common/vendor/optional-lite/LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c \
+    file://src/common/vendor/yaml-cpp/test/gtest-1.11.0/LICENSE;md5=cbbd27594afd089daa160d3a16dd515a \
+"
+LICENSE = "Apache-2.0 & BSL-1.0 & CC0-1.0 & MIT & Unlicense"
+

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_2.3.0.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_2.3.0.bb
@@ -1,0 +1,47 @@
+require mender-connect.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-connect.git;protocol=https;branch=2.3.x"
+
+# Tag: 2.3.0
+SRCREV = "e7ea01fb7e264ed43e5a6be06d678bd2cd78186c"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+# DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT"
+LIC_FILES_CHKSUM = " \
+    file://src/github.com/mendersoftware/mender-connect/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/mendersoftware/go-lib-micro/LICENSE;md5=e33ec9ac79630c915f82b11a3d4545e9 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/pkg/errors/LICENSE;md5=6fe682a02df52c6653f33bd0f7126b5a \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/vmihailenco/msgpack/v5/LICENSE;md5=5de50b60705d666cd9542dd48d5e4b56 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/vmihailenco/tagparser/v2/LICENSE;md5=e9f573ea1e3d968278166de82cd36301 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/pmezard/go-difflib/LICENSE;md5=e9a2ebb8de779a07500ddecca806145e \
+    file://src/github.com/mendersoftware/mender-connect/vendor/golang.org/x/sys/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/golang.org/x/net/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/gorilla/websocket/LICENSE;md5=c30eee78985cf2584cded5f89ba3d787 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/davecgh/go-spew/LICENSE;md5=c06795ed54b2a35ebeeb543cd3a73e56 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/creack/pty/LICENSE;md5=93958070863d769117fa33b129020050 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/go-ozzo/ozzo-validation/v4/LICENSE;md5=da12d993f2ce14947ad6eec35520b081 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/satori/go.uuid/LICENSE;md5=ae4ba217c6e20c2d8f48f69966b9121b \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/sirupsen/logrus/LICENSE;md5=8dadfef729c08ec4e631c4f6fc5d43a0 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/stretchr/objx/LICENSE;md5=d023fd31d3ca39ec61eec65a91732735 \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/stretchr/testify/LICENSE;md5=188f01994659f3c0d310612333d2a26f \
+    file://src/github.com/mendersoftware/mender-connect/vendor/github.com/urfave/cli/v2/LICENSE;md5=c542707ca9fc0b7802407ba62310bd8f \
+    file://src/github.com/mendersoftware/mender-connect/vendor/gopkg.in/yaml.v3/LICENSE;md5=3c91c17266710e16afdbb2b6d15c761c \
+"


### PR DESCRIPTION
Changelog: Add recipe for `mender` 5.0.0
Changelog: Add recipe for `mender-gateway` 2.0.0
Changelog: Add recipe for `mender-connect` 2.3.0
Changelog: Add recipe for `mender-artifact` 4.0.0
Changelog: Add recipe for `mender-monitor` 1.4.0