### PR TITLE
MEN-7854: Restore GRUB integration for ARMv7 boards (Beaglebone Black)

### DIFF
--- a/meta-mender-core/classes/grub-mender-grubenv.bbclass
+++ b/meta-mender-core/classes/grub-mender-grubenv.bbclass
@@ -1,4 +1,4 @@
-GRUB_MENDER_GRUBENV_REV = "eeb7ebd9e6558cf6bbe661b4f2e4e45d52efa305"
+GRUB_MENDER_GRUBENV_REV ?= "eeb7ebd9e6558cf6bbe661b4f2e4e45d52efa305"
 GRUB_MENDER_GRUBENV_SRC_URI ?= "git://github.com/mendersoftware/grub-mender-grubenv;protocol=https;branch=master;rev=${GRUB_MENDER_GRUBENV_REV}"
 
 GRUB_BUILDIN = "boot linux ext2 fat serial part_msdos part_gpt normal \

--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled.inc
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled.inc
@@ -1,0 +1,73 @@
+################################################################################
+# A recipe that provides precompiled binaries for ARMv5 for:
+# * The grub-efi-bootarm.efi EFI bootloader
+#
+# The motivation for this recipe is that GRUB doesn't compile correctly under
+# some ARM configurations, most notable ARMv7. However an ARMv5 binary will run
+# just fine even on ARMv7, but is difficult to compile using an ARMv7 toolchain.
+# Hence this recipe.
+#
+# The actual binaries are maintained in the grub-mender-grubenv repository, so
+# look there for ways to rebuild them.
+################################################################################
+require conf/image-uefi.conf
+inherit grub-mender-grubenv
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+LICENSE = "GPL-3.0-or-later"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
+
+URL_BASE ?= "https://downloads.mender.io/grub-mender-grubenv/grub-efi"
+
+S = "${WORKDIR}/git"
+
+MENDER_EFI_LOADER ?= ""
+
+require ${@'uboot_version_logic.inc' if d.getVar('MENDER_EFI_LOADER').startswith('u-boot') else ''}
+
+DEPENDS:append = " ${MENDER_EFI_LOADER}"
+
+PROVIDES = "grub-efi grub-editenv"
+RPROVIDES:${PN} = "grub-efi grub-editenv"
+
+COMPATIBLE_HOST = "arm|aarch64"
+
+FILES:${PN} = " \
+    ${EFI_FILES_PATH}/${EFI_BOOT_IMAGE} \
+    ${bindir}/grub-editenv \
+"
+
+do_configure() {
+    if [ "${KERNEL_IMAGETYPE}" = "uImage" ]; then
+        bbfatal "GRUB is not compatible with KERNEL_IMAGETYPE = uImage. Please change it to either zImage or bzImage."
+    fi
+
+    # Check that the prebuilt binaries have the same set of modules as the ones
+    # set in the Bitbake environment.
+    . ${S}/grub-efi/grub.inc
+    for module in $GRUB_MODULES; do
+        echo $module
+    done | sort > ${WORKDIR}/grub-mender-grubenv-modules.txt
+    for module in ${GRUB_BUILDIN}; do
+        echo $module
+    done | sort > ${WORKDIR}/bitbake-modules.txt
+    if ! diff -u ${WORKDIR}/grub-mender-grubenv-modules.txt ${WORKDIR}/bitbake-modules.txt; then
+        bbfatal "The list of GRUB modules is not the same in the prebuilt binaries as in the Bitbake environment. Either correct the Bitbake environment or update the prebuilt binaries."
+    fi
+}
+
+do_compile() {
+    # No-op, so just override the poky "smart" version.
+    :
+}
+
+do_install() {
+    install -d -m 755 ${D}${EFI_FILES_PATH}
+    install -m 644 ${WORKDIR}/grub-efi-${EFI_BOOT_IMAGE} ${D}${EFI_FILES_PATH}/${EFI_BOOT_IMAGE}
+
+    install -d -m 755 ${D}${bindir}
+    install -m 755 ${WORKDIR}/grub-editenv ${D}${bindir}/
+}
+
+INSANE_SKIP:${PN} = "already-stripped"

--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.04.bb
@@ -1,79 +1,10 @@
-################################################################################
-# A recipe that provides precompiled binaries for ARMv5 for:
-# * The grub-efi-bootarm.efi EFI bootloader
-#
-# The motivation for this recipe is that GRUB doesn't compile correctly under
-# some ARM configurations, most notable ARMv7. However an ARMv5 binary will run
-# just fine even on ARMv7, but is difficult to compile using an ARMv7 toolchain.
-# Hence this recipe.
-#
-# The actual binaries are maintained in the grub-mender-grubenv repository, so
-# look there for ways to rebuild them.
-################################################################################
-require conf/image-uefi.conf
-inherit grub-mender-grubenv
+require grub-efi-mender-precompiled.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-
-LICENSE = "GPL-3.0-or-later"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-3.0-or-later;md5=1c76c4cc354acaac30ed4d5eefea7245"
-
-URL_BASE ?= "https://downloads.mender.io/grub-mender-grubenv/grub-efi"
+# Grub version 2.04
+GRUB_MENDER_GRUBENV_REV = "eeb7ebd9e6558cf6bbe661b4f2e4e45d52efa305"
 
 SRC_URI = " \
     ${GRUB_MENDER_GRUBENV_SRC_URI} \
     ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-efi-${EFI_BOOT_IMAGE};md5sum=63c8f8570b763b59dd2a26f372e03155 \
     ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-editenv;md5sum=2c5e943a0acc4a6bd385a9d3f72b637b \
 "
-
-S = "${WORKDIR}/git"
-
-MENDER_EFI_LOADER ?= ""
-
-require ${@'uboot_version_logic.inc' if d.getVar('MENDER_EFI_LOADER').startswith('u-boot') else ''}
-
-DEPENDS:append = " ${MENDER_EFI_LOADER}"
-
-PROVIDES = "grub-efi grub-editenv"
-RPROVIDES:${PN} = "grub-efi grub-editenv"
-
-COMPATIBLE_HOST = "arm|aarch64"
-
-FILES:${PN} = " \
-    ${EFI_FILES_PATH}/${EFI_BOOT_IMAGE} \
-    ${bindir}/grub-editenv \
-"
-
-do_configure() {
-    if [ "${KERNEL_IMAGETYPE}" = "uImage" ]; then
-        bbfatal "GRUB is not compatible with KERNEL_IMAGETYPE = uImage. Please change it to either zImage or bzImage."
-    fi
-
-    # Check that the prebuilt binaries have the same set of modules as the ones
-    # set in the Bitbake environment.
-    . ${S}/grub-efi/grub.inc
-    for module in $GRUB_MODULES; do
-        echo $module
-    done | sort > ${WORKDIR}/grub-mender-grubenv-modules.txt
-    for module in ${GRUB_BUILDIN}; do
-        echo $module
-    done | sort > ${WORKDIR}/bitbake-modules.txt
-    if ! diff -u ${WORKDIR}/grub-mender-grubenv-modules.txt ${WORKDIR}/bitbake-modules.txt; then
-        bbfatal "The list of GRUB modules is not the same in the prebuilt binaries as in the Bitbake environment. Either correct the Bitbake environment or update the prebuilt binaries."
-    fi
-}
-
-do_compile() {
-    # No-op, so just override the poky "smart" version.
-    :
-}
-
-do_install() {
-    install -d -m 755 ${D}${EFI_FILES_PATH}
-    install -m 644 ${WORKDIR}/grub-efi-${EFI_BOOT_IMAGE} ${D}${EFI_FILES_PATH}/${EFI_BOOT_IMAGE}
-
-    install -d -m 755 ${D}${bindir}
-    install -m 755 ${WORKDIR}/grub-editenv ${D}${bindir}/
-}
-
-INSANE_SKIP:${PN} = "already-stripped"

--- a/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.12.bb
+++ b/meta-mender-core/recipes-bsp/grub/grub-efi-mender-precompiled_2.12.bb
@@ -1,0 +1,10 @@
+require grub-efi-mender-precompiled.inc
+
+# Grub version 2.12
+GRUB_MENDER_GRUBENV_REV = "089c619e3b52b95fd14dc664cf4f6c243c840b94"
+
+SRC_URI = " \
+    ${GRUB_MENDER_GRUBENV_SRC_URI} \
+    ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-efi-${EFI_BOOT_IMAGE};md5sum=3cdc5695de01804044e3b5606a9dc889 \
+    ${URL_BASE}/${PV}-grub-mender-grubenv-${GRUB_MENDER_GRUBENV_REV}/${HOST_ARCH}/grub-editenv;md5sum=a7191248afae6f6ae680bf51b91e8d76 \
+"


### PR DESCRIPTION
By adding recipe for `grub-efi-precompiled` for GRUB v2.12

Update the precompiled version for GRUB, used on ARMv7 boards like
BeableBone Black, so that they can boot (and update) correctly with the
latest filesystem features. See:
* https://github.com/mendersoftware/grub-mender-grubenv/pull/39

From Yocto `scarthgap` release on, `mke2fs` enables the feature
`metadata_csum_seed` by default, which is not understood in the
previous GRUB version. See:
* Bug report: http://savannah.gnu.org/bugs/?56897
* Fix: https://git.savannah.gnu.org/cgit/grub.git/commit/?id=7fd5feff97c4b1f446f8fcf6d37aca0c64e7c763
* mke2fs release notes: https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git/tree/doc/RelNotes/v1.47.0.txt

To upgrade with Mender (or any other means, really) from `kirkstone` to
`scarthgap` the new features need to be disabled. See:
* https://docs.mender.io/development/troubleshoot/yocto-project-runtime#upgrading-to-scarthgap-from-grub-2-04-fails-with-disk-not-found