### PR TITLE
chore: Fix syntax for test code figuring out the mender versions

### DIFF
--- a/meta-mender-commercial/classes/mender-closed-source-utils.bbclass
+++ b/meta-mender-commercial/classes/mender-closed-source-utils.bbclass
@@ -2,7 +2,7 @@
 def mender_closed_source_srcrev_from_src_uri(d, src_uri, repo_name):
     pref_version = d.getVar("PREFERRED_VERSION")
     if pref_version is None or pref_version == "":
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if pref_version and pref_version.find("-build") >= 0:
         # If "-build" is in the version, SRCREV won't be used for defining PV
         return ""
@@ -44,7 +44,7 @@ def mender_closed_source_srcrev_from_src_uri(d, src_uri, repo_name):
 def mender_closed_source_pv_from_preferred_version(d, srcrev):
     pref_version = d.getVar("PREFERRED_VERSION")
     if pref_version is None or pref_version == "":
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if pref_version is not None and pref_version.find("-build") >= 0:
         # If "-build" is in the version, use the version as is. This means that
         # we can build tags with "-build" in them from this recipe, but not

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -10,7 +10,7 @@ RDEPENDS:${PN} = "openssl"
 def mender_artifact_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
@@ -21,7 +21,7 @@ def mender_branch_from_preferred_version(d):
     import re
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if version is None:
         version = ""
     match = re.match(r"^[0-9]+\.[0-9]+\.", version)
@@ -40,7 +40,7 @@ def mender_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
     srcpv = d.getVar("SRCPV")
     if pref_version is None:
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client_git.inc
@@ -22,7 +22,7 @@ DEFAULT_PREFERENCE = "-1"
 def mender_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
@@ -32,7 +32,7 @@ def mender_branch_from_preferred_version(d):
     import re
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if version is None:
         version = ""
     match = re.match(r"^[0-9]+\.[0-9]+\.", version)
@@ -50,7 +50,7 @@ def mender_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
     srcpv = d.getVar("SRCPV")
     if pref_version is None:
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure_git.bb
@@ -7,7 +7,7 @@ require mender-configure.inc
 def mender_configure_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
@@ -18,7 +18,7 @@ def mender_configure_branch_from_preferred_version(d):
     import re
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if version is None:
         version = ""
     match = re.match(r"^[0-9]+\.[0-9]+\.", version)
@@ -37,7 +37,7 @@ def mender_configure_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
     srcpv = d.getVar("SRCPV")
     if pref_version is None:
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect_git.bb
@@ -7,7 +7,7 @@ require mender-connect.inc
 def mender_connect_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
@@ -18,7 +18,7 @@ def mender_connect_branch_from_preferred_version(d):
     import re
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if version is None:
         version = ""
     match = re.match(r"^[0-9]+\.[0-9]+\.", version)
@@ -37,7 +37,7 @@ def mender_connect_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
     srcpv = d.getVar("SRCPV")
     if pref_version is None:
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-flash/mender-flash_git.bb
+++ b/meta-mender-core/recipes-mender/mender-flash/mender-flash_git.bb
@@ -7,7 +7,7 @@ require mender-flash.inc
 def mender_flash_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
@@ -18,7 +18,7 @@ def mender_flash_branch_from_preferred_version(d):
     import re
     version = d.getVar("PREFERRED_VERSION")
     if version is None or version == "":
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if version is None:
         version = ""
     match = re.match(r"^[0-9]+\.[0-9]+\.", version)
@@ -37,7 +37,7 @@ def mender_flash_version_from_preferred_version(d):
     pref_version = d.getVar("PREFERRED_VERSION")
     srcpv = d.getVar("SRCPV")
     if pref_version is None:
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.

--- a/meta-mender-core/recipes-mender/mender-snapshot/mender-snapshot_git.bb
+++ b/meta-mender-core/recipes-mender/mender-snapshot/mender-snapshot_git.bb
@@ -7,7 +7,7 @@ require mender-snapshot.inc
 def mender_snapshot_autorev_if_git_version(d):
     version = d.getVar("PREFERRED_VERSION")
     if not version:
-        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+        version = d.getVar("PREFERRED_VERSION:%s" % d.getVar('PN'))
     if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
         return d.getVar("AUTOREV")
     else:
@@ -34,7 +34,7 @@ MENDER_SNAPSHOT_BRANCH = "${@mender_snapshot_branch_from_preferred_version(d)}"
 def mender_snapshot_version_from_preferred_version(d, srcpv):
     pref_version = d.getVar("PREFERRED_VERSION")
     if pref_version is None:
-        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+        pref_version = d.getVar("PREFERRED_VERSION:%s" % d.getVar("PN"))
     if pref_version is not None and pref_version.find("-git") >= 0:
         # If "-git" is in the version, remove it along with any suffix it has,
         # and then readd it with commit SHA.


### PR DESCRIPTION
These went unnoticed when we updated the syntax from kirkstone to scarthgap. All of them however relate to internal testing, so no real damage has been done elsewhere.