### PR TITLE
feat: add mender-prepopulate-inactive-partition feature

### DIFF
--- a/meta-mender-core/classes/mender-maybe-setup.bbclass
+++ b/meta-mender-core/classes/mender-maybe-setup.bbclass
@@ -100,6 +100,9 @@ python() {
 
         # Enable the testing/* layers and functionality
         'mender-testing-enabled',
+
+        # Enable prepopulation of second root partition
+        'mender-prepopulate-inactive-partition',
     }
 
     # Verify that all 'mender-' features are added using MENDER_FEATURES_ENABLE

--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -124,9 +124,11 @@ EOF
         bbwarn "MENDER_BOOT_PART_SIZE_MB is set to zero, but IMAGE_BOOT_FILES is not empty. The files are being omitted from the image."
     fi
 
-    # 'squashfs' fstype doesn't support empty partitions. For all others we make
-    # it empty to save compression space.
-    if [ "${ARTIFACTIMG_FSTYPE}" = "squashfs" ]; then
+    # By default the inactive partition filesystem is empty to allow for more efficient compression.
+    # A full filesystem is populated if one of the following applies
+    # - ARTIFACTIMG_FSTYPE is squashfs, because it doesn not allow empty partitions.
+    # - the "mender-prepopulate-inactive-partition" MENDER_FEATURE is enabled
+    if [ "${ARTIFACTIMG_FSTYPE}" = "squashfs" || ${@bb.utils.contains('MENDER_FEATURES', 'mender-prepopulate-inactive-partition', 'true', 'false', d)} ]; then
         part2_content="--source rawcopy --sourceparams=\"file=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${ARTIFACTIMG_FSTYPE}\""
     else
         part2_content=


### PR DESCRIPTION
Add mender-prepopulate-inactive-partition MENDER_FEATURE. Disabled by default for more efficient compression, it can be enabled to have the inactive partition populated with the same contents of the active one.

This allows to check the bootloader integrations (A/B switching, A/B update, A/B rollback) directly on the generated images without additional modifications or processing.

Ticket: None
Changelog: Commit

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
(cherry picked from commit 46f7b9d76fe81bc2f79ff6ee260c9178011fc1df) (cherry picked from commit e468d57e4fd5c997c0065a9b4416c325098bd39a)


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
