### PR TITLE
fix: Add full version of wget for mender inventory mender-inventory-geo

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -63,6 +63,7 @@ RRECOMMENDS:mender-update:append = "${@bb.utils.contains('PACKAGECONFIG', 'modul
 RRECOMMENDS:mender-update:append = "${@bb.utils.contains('PACKAGECONFIG', 'modules', ' mender-flash', '', d)}"
 
 PACKAGECONFIG[inventory-network-scripts] = ",,,"
+RDEPENDS:mender-update:append = "${@bb.utils.contains('PACKAGECONFIG', 'inventory-network-scripts', ' wget', '', d)}"
 
 # NOTE: Splits the mender.conf file by default into a transient and a persistent config. Needs to be
 # explicitly disabled if this is not to apply.


### PR DESCRIPTION

### Description

mender-inventory-geo need --tires for wget.
wget in busybox doesn't have this option therefore need a full verion of wget to work
