### PR TITLE
mender-connect: fix systemd DISTRO_FEATURES handling

### DIFF
--- a/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
+++ b/meta-mender-core/recipes-mender/mender-connect/mender-connect.inc
@@ -58,12 +58,12 @@ do_install:append() {
     # Install configuration
     mkdir -p ${D}/${sysconfdir}/mender
     install -m 0600 ${B}/mender-connect.conf ${D}/${sysconfdir}/mender/mender-connect.conf
-}
 
-do_install:append:mender-systemd() {
-    # Install systemd service
-    install -m 755 -d ${D}${systemd_unitdir}/system
-    install -m 0644 ${B}/src/${GO_IMPORT}/support/mender-connect.service ${D}${systemd_unitdir}/system/
+    # Install service if systemd is configured
+    if [ "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}" ]; then
+        install -m 755 -d ${D}${systemd_unitdir}/system
+        install -m 0644 ${B}/src/${GO_IMPORT}/support/mender-connect.service ${D}${systemd_unitdir}/system/
+    fi
 }
 
 FILES:${PN}:append = "\


### PR DESCRIPTION
The mender-connect.service unit should be installed if the resulting distribution is using systemd, and not only if the `mender-systemd` flag is set in `MENDER_FEATURES`.

Otherwise installing mender-connect is broken in cases where no full Mender integration is present.


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
