### PR TITLE
fix: mender-part-images handling of inactive partition

### DIFF
--- a/meta-mender-core/classes/mender-part-images.bbclass
+++ b/meta-mender-core/classes/mender-part-images.bbclass
@@ -128,7 +128,7 @@ EOF
     # A full filesystem is populated if one of the following applies
     # - ARTIFACTIMG_FSTYPE is squashfs, because it doesn not allow empty partitions.
     # - the "mender-prepopulate-inactive-partition" MENDER_FEATURE is enabled
-    if [ "${ARTIFACTIMG_FSTYPE}" = "squashfs" || ${@bb.utils.contains('MENDER_FEATURES', 'mender-prepopulate-inactive-partition', 'true', 'false', d)} ]; then
+    if [ "${ARTIFACTIMG_FSTYPE}" = "squashfs" ] || ${@bb.utils.contains('MENDER_FEATURES', 'mender-prepopulate-inactive-partition', 'true', 'false', d)}; then
         part2_content="--source rawcopy --sourceparams=\"file=${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${ARTIFACTIMG_FSTYPE}\""
     else
         part2_content=


### PR DESCRIPTION
In 24d2fe0c the mender-prepopulate-inactive-partition feature was added. This is meant to trigger behaviour which up to then was already present, but only for the squashfs filesystem type.

The addition broke the conditional logic, this commit fixes the squashfs case.

Changelog: Title
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
