### PR TITLE
fix: circular task dependency with meta-mender and meta-secure-core

### DIFF
--- a/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
+++ b/meta-mender-core/recipes-bsp/grub/mender-grub-efi-impl.inc
@@ -46,5 +46,5 @@ fakeroot python do_cleanconfigs:class-target() {
 }
 fakeroot python do_cleanconfigs() {
 }
-addtask cleanconfigs after do_sign do_chownboot before deploy do_package
+addtask cleanconfigs after deploy before do_package
 do_cleanconfigs[depends] += "virtual/fakeroot-native:do_populate_sysroot"


### PR DESCRIPTION
Restructure task ordering to resolve a circular dependency between
do_deploy, do_sign, do_cleanconfigs, and do_chownboot. This loop
occurs when both meta-mender and meta-secure-core layers are present.

Moves do_cleanconfigs to run after do_deploy instead of after
do_sign and do_chownboot, breaking the cycle.

Changelog: Fix circular task dependency with meta-mender and
meta-secure-core
Ticket: None

Signed-off-by: Maxime Roussin-Bélanger
<maxime.roussinbelanger@gmail.com>