### PR TITLE
QA-945: Remove now unused testing image for `mender-gateway`

### DIFF
--- a/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb
+++ b/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb
@@ -1,3 +1,0 @@
-require recipes-extended/images/core-image-full-cmdline.bb
-
-IMAGE_INSTALL:append = " mender-gateway"

--- a/meta-mender-demo/conf/layer.conf
+++ b/meta-mender-demo/conf/layer.conf
@@ -11,7 +11,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILES_DYNAMIC += "\
   mender-commercial:${LAYERDIR}/mender-commercial/mender-monitor/mender-monitor*.bbappend \
   mender-commercial:${LAYERDIR}/mender-commercial/mender-gateway/mender-gateway*.bbappend \
-  mender-commercial:${LAYERDIR}/mender-commercial/images/mender-gateway-image-full-cmdline.bbappend \
 "
 
 BBFILE_COLLECTIONS += "mender-demo"

--- a/meta-mender-demo/mender-commercial/images/mender-gateway-image-full-cmdline.bbappend
+++ b/meta-mender-demo/mender-commercial/images/mender-gateway-image-full-cmdline.bbappend
@@ -1,1 +1,0 @@
-IMAGE_INSTALL:append = " mender-gateway-doc"


### PR DESCRIPTION
A follow-up from where we removed the use of this image in integration tests suites.