### PR TITLE
chore: update topology path in mender-orchestrator recipe

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-orchestrator/mender-orchestrator.inc
+++ b/meta-mender-commercial/recipes-mender/mender-orchestrator/mender-orchestrator.inc
@@ -50,8 +50,7 @@ do_install() {
     install -d -m 755 ${D}${localstatedir}/lib/
     ln -s /data/mender-orchestrator ${D}${localstatedir}/lib/mender-orchestrator
 
-    install -d -m 755 ${D}/data/mender-orchestrator/manifests
-    install -m 755 ${WORKDIR}/topology.yaml ${D}/data/mender-orchestrator/manifests/topology.yaml
+    install -m 755 ${WORKDIR}/topology.yaml ${D}/data/mender-orchestrator/topology.yaml
 }
 
 do_install:append:mender-update-install() {

--- a/tests/acceptance/commercial/test_mender-orchestrator.py
+++ b/tests/acceptance/commercial/test_mender-orchestrator.py
@@ -54,7 +54,7 @@ class TestMenderOrchestrator:
 
         for file in (
             "/usr/bin/mender-orchestrator",
-            "/data/mender-orchestrator/manifests/topology.yaml",
+            "/data/mender-orchestrator/topology.yaml",
             "/usr/share/mender/inventory/mender-inventory-orchestrator-inventory",
         ):
             output = subprocess.check_output(


### PR DESCRIPTION
We moved the topology path from the manifest store to its own store.

Ticket: MEN-8771

Follow-up from https://github.com/mendersoftware/mender-orchestrator/pull/154
