### PR TITLE
QA-1017: chore(CODEOWNERS): Remove global ownership and redundant entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,10 @@
-# Default owners for everything
-* @mendersoftware/client-dependabot-reviewers
+# Dependency updates
+go.mod @mendersoftware/client-dependabot-reviewers
+go.sum @mendersoftware/client-dependabot-reviewers
+Dockerfile* @mendersoftware/client-dependabot-reviewers
+*requirements*.txt @mendersoftware/client-dependabot-reviewers
+package.json @mendersoftware/client-dependabot-reviewers
+package-lock.json @mendersoftware/client-dependabot-reviewers
 
-# Test and docker directories
-/tests/acceptance/ @mendersoftware/client-dependabot-reviewers
-/meta-mender-qemu/docker/ @mendersoftware/client-dependabot-reviewers
+# Git submodules
+/tests/acceptance/image-tests @mendersoftware/client-dependabot-reviewers


### PR DESCRIPTION
Remove the global wildcard ownership from CODEOWNERS file and any redundant
specific path entries that had the same owner. Replace with targeted dependency
file ownership rules.

The purpose is to ensure only dependency-related changes are reviewed by the
@mendersoftware/client-dependabot-reviewers team, removing unnecessary global code ownership.

Ticket: QA-1017