### PR TITLE
mender-helpers: Copy dirs when merging IMAGE_BOOT_FILES

### DIFF
--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -306,7 +306,11 @@ mender_merge_bootfs_and_image_boot_files() {
                     bbfatal "$destfile already exists in boot partition. Please verify that packages do not put files in the boot partition that conflict with IMAGE_BOOT_FILES."
                 fi
             else
-                cp "$file" "$destfile"
+                if [ -d "$file" ]; then
+                    cp -a "$file" "$destfile"
+                else
+                    cp "$file" "$destfile"
+                fi
             fi
         done
     done


### PR DESCRIPTION
## Description

Handle directory entries (e.g. bootfiles/overlays) during `mender_merge_bootfs_and_image_boot_files` by using `cp -a` for dirs.

Fixes the following build error when a directory is present:

```
| cp: -r not specified; omitting directory 'deploy/images/raspberrypi4-64/bootfiles/overlays'
```

## How has this been tested?

In my `recipes-bsp/bootfiles/rpi-bootfiles.bbappend`, i do:

```bitbake
do_deploy:append() {
    # Deploy Raspberry Pi DT overlays (needed for dtoverlay=i2c4 / i2c5, etc.)
    install -d "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/overlays"

    # Copy the firmware overlays we need
    install -m 0644 "${S}/overlays/i2c4.dtbo" "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/overlays/"
    install -m 0644 "${S}/overlays/i2c5.dtbo"  "${DEPLOYDIR}/${BOOTFILES_DIR_NAME}/overlays/"
}
```

This creates the `overlays` directory. However, the mender-helpers class can't handle folders present in the boot directory. I get the above error.

With the fix in the PR, the directory is correctly copied, and the build no longer fails.

Testing on my Pi 4 verifies that all I2C devices show up on /dev/i2c4 after the build succeeds.