### PR TITLE
Support Yocto LTS Release Wrynose 6.0

### DIFF
--- a/meta-mender-core/classes/mender-bootstrap-artifact.bbclass
+++ b/meta-mender-core/classes/mender-bootstrap-artifact.bbclass
@@ -13,6 +13,8 @@ MENDER_ARTIFACT_DEPENDS_GROUPS_FINAL = "${MENDER_ARTIFACT_DEPENDS_GROUPS} ${MEND
 MENDER_ARTIFACT_NAME_BOOTSTRAP ?= "${MENDER_ARTIFACT_NAME}"
 MENDER_ARTIFACT_NAME_DEPENDS_BOOTSTRAP ?= "${MENDER_ARTIFACT_NAME_DEPENDS}"
 
+PSEUDO_INCLUDE_PATHS:append = ",${WORKDIR}/data.copy.image_dataimg"
+
 IMAGE_CMD:bootstrap-artifact() {
 
     # Write a simple hardcoded bootstrap-artifact first, which we use to detect

--- a/meta-mender-core/classes/mender-helpers.bbclass
+++ b/meta-mender-core/classes/mender-helpers.bbclass
@@ -275,7 +275,7 @@ mender_merge_bootfs_and_image_boot_files() {
     W="${WORKDIR}/bootfs"
     rm -rf "$W"
 
-    cp -a "${IMAGE_ROOTFS}/${MENDER_BOOT_PART_MOUNT_LOCATION}" "$W"
+    cp -R "${IMAGE_ROOTFS}/${MENDER_BOOT_PART_MOUNT_LOCATION}" "$W"
 
     # Put in variable to avoid expansion and ';' being parsed by shell.
     image_boot_files="${IMAGE_BOOT_FILES}"

--- a/meta-mender-core/conf/layer.conf
+++ b/meta-mender-core/conf/layer.conf
@@ -18,7 +18,7 @@ BBFILE_PRIORITY_mender = "6"
 INHERIT += "mender-maybe-setup"
 INHERIT += "mender-client-version-inventory-script-conflicts"
 
-LAYERSERIES_COMPAT_mender = "scarthgap"
+LAYERSERIES_COMPAT_mender = "wrynose"
 LAYERDEPENDS_mender = "core"
 
 # See https://northerntech.atlassian.net/browse/MEN-3513 and

--- a/meta-mender-core/recipes-bsp/systemd-mender-config/systemd-mender-config.bb
+++ b/meta-mender-core/recipes-bsp/systemd-mender-config/systemd-mender-config.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://ab_setup.py \
     "
 
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 
 do_compile() {
     :
@@ -16,7 +16,7 @@ do_compile() {
 
 do_install() {
     install -d ${D}${sbindir}
-    install -m 0755 "${WORKDIR}/ab_setup.py" "${D}${sbindir}"
+    install -m 0755 "${UNPACKDIR}/ab_setup.py" "${D}${sbindir}"
 
     ln -s "../..${sbindir}/ab_setup.py" "${D}${sbindir}/systemd-boot-printenv"
     ln -s "../..${sbindir}/ab_setup.py" "${D}${sbindir}/systemd-boot-setenv"

--- a/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_patch.sh
+++ b/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_patch.sh
@@ -353,8 +353,8 @@ patch_all_candidates_sdimg() {
         'CONFIG_ENV_OFFSET_REDUND' \
         "$CONFIG_ENV_OFFSET_REDUND"
     replace_definition \
-        'CONFIG_SYS_REDUNDAND_ENVIRONMENT' \
-        'CONFIG_SYS_REDUNDAND_ENVIRONMENT'
+        'CONFIG_ENV_REDUNDANT' \
+        'CONFIG_ENV_REDUNDANT'
 
     # Remove all of the below entries.
     replace_definition \
@@ -410,8 +410,8 @@ patch_all_candidates_ubi() {
         'CONFIG_ENV_IS_IN_UBI'
 
     replace_definition \
-        'CONFIG_SYS_REDUNDAND_ENVIRONMENT' \
-        'CONFIG_SYS_REDUNDAND_ENVIRONMENT'
+        'CONFIG_ENV_REDUNDANT' \
+        'CONFIG_ENV_REDUNDANT'
 
     # And remove volume definitions of environment so Mender can configure them.
     replace_definition \

--- a/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/meta-mender-core/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -12,9 +12,9 @@ do_compile:append:mender-uboot() {
     fi
 
     if [ ! -e ${DEPLOY_DIR_IMAGE}/fw_env.config.default ]; then
-        mender_create_fw_env_config_file ${WORKDIR}/fw_env.config
+        mender_create_fw_env_config_file ${UNPACKDIR}/fw_env.config
     else
-        cp ${DEPLOY_DIR_IMAGE}/fw_env.config.default ${WORKDIR}/fw_env.config
+        cp ${DEPLOY_DIR_IMAGE}/fw_env.config.default ${UNPACKDIR}/fw_env.config
     fi
 }
 do_compile[depends] += "u-boot:do_deploy"
@@ -24,5 +24,5 @@ do_install:append:mender-uboot() {
     ln -sf /data/u-boot/fw_env.config ${D}${sysconfdir}/fw_env.config
 
     install -d ${D}/data/u-boot
-    install -m 0644 ${WORKDIR}/fw_env.config ${D}/data/u-boot/fw_env.config
+    install -m 0644 ${UNPACKDIR}/fw_env.config ${D}/data/u-boot/fw_env.config
 }

--- a/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0001-Generic-boot-code-for-Mender.patch
@@ -58,8 +58,8 @@ index 0000000000..3377ab0a1b
 +# error CONFIG_BOOTCOUNT_ENV is required for Mender to work. Make sure that: 1) All the instructions at https://docs.mender.io/system-updates-yocto-project/board-integration/bootloader-support/u-boot have been followed. 2) All required layers are included in bblayers.conf, including any board specific layers such as meta-mender-<board>
 +#endif
 +
-+#ifndef CONFIG_SYS_REDUNDAND_ENVIRONMENT
-+# error CONFIG_SYS_REDUNDAND_ENVIRONMENT is required for Mender to work. Make sure that: 1) All the instructions at https://docs.mender.io/system-updates-yocto-project/board-integration/bootloader-support/u-boot have been followed. 2) All required layers are included in bblayers.conf, including any board specific layers such as meta-mender-<board>. Check also https://docs.mender.io/troubleshoot/yocto-project-build for Known Issues when upgrading.
++#ifndef CONFIG_ENV_REDUNDANT
++# error CONFIG_ENV_REDUNDANT is required for Mender to work. Make sure that: 1) All the instructions at https://docs.mender.io/system-updates-yocto-project/board-integration/bootloader-support/u-boot have been followed. 2) All required layers are included in bblayers.conf, including any board specific layers such as meta-mender-<board>. Check also https://docs.mender.io/troubleshoot/yocto-project-build for Known Issues when upgrading.
 +#endif
 +
 +#ifdef MENDER_UBI

--- a/meta-mender-core/recipes-bsp/u-boot/patches/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/meta-mender-core/recipes-bsp/u-boot/patches/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -1,4 +1,4 @@
-From 502df6c13d964b4e27e896e75420efa137c39f30 Mon Sep 17 00:00:00 2001
+From dab38a8309407104ff94d8b48bd13de5ef435bae Mon Sep 17 00:00:00 2001
 From: Marcin Pasinski <marcin.pasinski@northern.tech>
 Date: Wed, 31 Jan 2018 18:10:04 +0100
 Subject: [PATCH] Integration of Mender boot code into U-Boot.
@@ -8,16 +8,17 @@ Upstream-Status: Inappropriate [Mender specific]
 Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
 Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
 Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
 ---
  include/env_default.h     | 3 +++
  scripts/Makefile.autoconf | 3 ++-
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/include/env_default.h b/include/env_default.h
-index 2ca4a087d3..7db7be7b6a 100644
+index 7f8dc1c35a7..f75a48b1ad7 100644
 --- a/include/env_default.h
 +++ b/include/env_default.h
-@@ -12,6 +12,8 @@
+@@ -13,6 +13,8 @@
  
  #include <generated/environment.h>
  
@@ -26,20 +27,20 @@ index 2ca4a087d3..7db7be7b6a 100644
  #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
  env_t embedded_environment __UBOOT_ENV_SECTION__(environment) = {
  	ENV_CRC,	/* CRC Sum */
-@@ -26,6 +28,7 @@ char default_environment[] = {
+@@ -27,6 +29,7 @@ char default_environment[] = {
  #else
  const char default_environment[] = {
  #endif
 +	MENDER_ENV_SETTINGS
- #ifndef CONFIG_USE_DEFAULT_ENV_FILE
+ #ifndef CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE
  #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
  	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
 diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
-index 0ade91642a..c653f1afaa 100644
+index c1eab2f3a1d..646374f7800 100644
 --- a/scripts/Makefile.autoconf
 +++ b/scripts/Makefile.autoconf
 @@ -116,7 +116,8 @@ define filechk_config_h
- 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
+ 	$(if $(CONFIG_SYS_CONFIG_NAME),echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\> ;) \
  	echo \#include \<asm/config.h\>;				\
  	echo \#include \<linux/kconfig.h\>;				\
 -	echo \#include \<config_fallbacks.h\>;)

--- a/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
+++ b/meta-mender-core/recipes-bsp/u-boot/u-boot-mender.inc
@@ -37,7 +37,7 @@ do_provide_mender_defines() {
     # Since the libubootenv recipe will typically not have access to the proper
     # BOOTENV_SIZE, let's create the fw_env.config file here, so that it can
     # pick it from the deploy directory.
-    mender_create_fw_env_config_file ${WORKDIR}/fw_env.config.default
+    mender_create_fw_env_config_file ${UNPACKDIR}/fw_env.config.default
 
     if [ ${MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART} -eq "0" ]; then
         # Only check reserved space for bootloader data when the bootloader data is saved to the user partition of the MMC.
@@ -306,7 +306,7 @@ do_mender_uboot_auto_configure() {
         bbwarn 'Detected previously applied Mender patch on top of U-Boot. Probably U-Boot will either produce compile errors or misbehave. It is advised to either remove any Mender specific patches, or disable the auto-patching by setting MENDER_UBOOT_AUTO_CONFIGURE = "0" somewhere in the U-Boot recipe.'
     fi
 
-    cd ${WORKDIR}
+    cd ${B}
 
     # This is for diffing and displaying the patch later, if necessary.
     rm -rf ${MENDER_UBOOT_OLD_SRC}
@@ -371,9 +371,9 @@ do_deploy:append() {
 }
 do_deploy:append:mender-uboot() {
     # Copy script to the deploy area with u-boot, uImage, and rootfs
-    if [ -e ${WORKDIR}/uEnv.txt ] ; then
+    if [ -e ${UNPACKDIR}/uEnv.txt ] ; then
         install -d ${DEPLOYDIR}
-        install -m 0444 ${WORKDIR}/uEnv.txt ${DEPLOYDIR}
+        install -m 0444 ${UNPACKDIR}/uEnv.txt ${DEPLOYDIR}
     fi
 
     # Creates the blob that will be the U-Boot environment, with proper
@@ -383,10 +383,10 @@ do_deploy:append:mender-uboot() {
     # Note: We cannot use a sparse file here, even though it's filled with
     # zeros, because the build process uses "du" to determine the size of this
     # file.
-    dd if=/dev/zero of=${WORKDIR}/uboot.env bs=${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} count=1
-    install -m 644 ${WORKDIR}/uboot.env ${DEPLOYDIR}/uboot.env
+    dd if=/dev/zero of=${UNPACKDIR}/uboot.env bs=${MENDER_BOOTENV_TOTAL_ALIGNED_SIZE} count=1
+    install -m 644 ${UNPACKDIR}/uboot.env ${DEPLOYDIR}/uboot.env
 
-    install -m 644 ${WORKDIR}/fw_env.config.default ${DEPLOYDIR}/fw_env.config.default
+    install -m 644 ${UNPACKDIR}/fw_env.config.default ${DEPLOYDIR}/fw_env.config.default
 }
 
 # Ignore this, only used for testing.

--- a/meta-mender-core/recipes-core/lsb-ld/lsb-ld.bb
+++ b/meta-mender-core/recipes-core/lsb-ld/lsb-ld.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=269720c1a5608250abd54a7818f369f6"
 
 FILESEXTRAPATHS:append := ":${THISDIR}/files"
 SRC_URI = "file://LICENSE"
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 
 # Only x86-64 needs any files.
 ALLOW_EMPTY:${PN} = "1"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact.inc
@@ -7,14 +7,14 @@ inherit go
 inherit go-ptest
 inherit pkgconfig
 
-S = "${WORKDIR}/git"
-B = "${WORKDIR}/build"
-
 GOPATHDIR = "${B}/src/${GO_IMPORT}"
 
 BBCLASSEXTEND = "native nativesdk"
 
 do_compile() {
+    # Force Go to use GOPATH mode:
+    export GO111MODULE=off
+
     # we could check out the sources at some destsuffix and use default
     # do_compile from go.bbclass, but that would prevent us from always building
     # the most recent version due to recursive expansion if SRCPV
@@ -37,3 +37,5 @@ do_install() {
 
     install ${BUILD_BIN_FOLDER}/mender-artifact -m 0755 ${D}${bindir}
 }
+
+INSANE_SKIP:${PN} = "already-stripped textrel ldflags"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_4.4.0.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_4.4.0.bb
@@ -8,7 +8,7 @@ require mender-artifact.inc
 # - DEFAULT_PREFERENCE
 #-------------------------------------------------------------------------------
 
-SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=master;destsuffix=${GO_SRCURI_DESTSUFFIX}"
 
 # Tag: 4.4.0
 SRCREV = "4c2551fc619681ec1b1ac471e8cf0642ee9cee42"

--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -40,12 +40,12 @@ def mender_version_from_preferred_version(d):
         return "master-git%s" % srcpv
 PV = "${@mender_version_from_preferred_version(d)}"
 
-SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;branch=master;destsuffix=${GO_SRCURI_DESTSUFFIX}"
 
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=a8c81350f12516cbb62844f937d81d11 \
+    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e \
 "
 
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & MPL-2.0"

--- a/meta-mender-core/recipes-mender/mender-client-version-inventory-script/mender-client-version-inventory-script.inc
+++ b/meta-mender-core/recipes-mender/mender-client-version-inventory-script/mender-client-version-inventory-script.inc
@@ -9,7 +9,6 @@ FILES:${PN}:append:mender-update-install = " \
 
 DEPENDS = "jq-native gettext-native"
 
-S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 # On production releases we must build the script using RELEASE=${PV} but for

--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -83,7 +83,6 @@ RRECOMMENDS:mender-update:append = "${@mender_version_inventory_script_rrecommen
 PACKAGECONFIG[split-mender-config] = ",,,"
 PACKAGECONFIG:append = " split-mender-config"
 
-S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 inherit pkgconfig
@@ -175,14 +174,14 @@ python do_prepare_mender_conf() {
 
     # If a mender.conf has been provided in SRC_URI, merge this with the
     # settings we generate. The settings specified by variables take precedence.
-    src_conf = os.path.join(d.getVar("WORKDIR"), "mender.conf")
+    src_conf = os.path.join(d.getVar("UNPACKDIR"), "mender.conf")
     if os.path.exists(src_conf):
-        bb.debug(1, "mender.conf already present in ${WORKDIR}, merging with generated settings.")
+        bb.debug(1, "mender.conf already present in ${UNPACKDIR}, merging with generated settings.")
         fd = open(src_conf)
         transient_conf = json.load(fd)
         fd.close()
     else:
-        bb.debug(1, "mender.conf not present in ${WORKDIR}, generating a new one.")
+        bb.debug(1, "mender.conf not present in ${UNPACKDIR}, generating a new one.")
         transient_conf = {}
     def conf_maybe_add(key, value, getvar, integer):
         if getvar:
@@ -198,7 +197,7 @@ python do_prepare_mender_conf() {
             else:
                 transient_conf[key] = value
 
-    key_in_src_uri = os.path.exists(os.path.join(d.getVar("WORKDIR"), "artifact-verify-key.pem"))
+    key_in_src_uri = os.path.exists(os.path.join(d.getVar("UNPACKDIR"), "artifact-verify-key.pem"))
     key_in_var = d.getVar("MENDER_ARTIFACT_VERIFY_KEY") not in [None, ""]
 
     # Add new variable -> config assignments here.
@@ -286,11 +285,11 @@ do_install:append() {
     fi
 
     # install artifact verification key, if any.
-    if [ -e ${WORKDIR}/artifact-verify-key.pem ]; then
+    if [ -e ${UNPACKDIR}/artifact-verify-key.pem ]; then
         if [ -n "${MENDER_ARTIFACT_VERIFY_KEY}" ]; then
             bbfatal "You can not specify both MENDER_ARTIFACT_VERIFY_KEY and have artifact-verify-key.pem in SRC_URI."
         fi
-        install -m 0444 ${WORKDIR}/artifact-verify-key.pem ${D}${sysconfdir}/mender
+        install -m 0444 ${UNPACKDIR}/artifact-verify-key.pem ${D}${sysconfdir}/mender
     elif [ -n "${MENDER_ARTIFACT_VERIFY_KEY}" ]; then
         install -m 0444 "${MENDER_ARTIFACT_VERIFY_KEY}" ${D}${sysconfdir}/mender/artifact-verify-key.pem
     fi
@@ -306,7 +305,7 @@ do_install:append() {
 
 do_install:append:class-target:mender-image:mender-systemd() {
     install -d ${D}${systemd_unitdir}/system/
-    install -m 644 ${WORKDIR}/mender-data-dir.service ${D}${systemd_unitdir}/system/mender-data-dir.service
+    install -m 644 ${UNPACKDIR}/mender-data-dir.service ${D}${systemd_unitdir}/system/mender-data-dir.service
     install -d -m 755 ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants
     ln -sf ../mender-data-dir.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/mender-data-dir.service
 }
@@ -315,27 +314,27 @@ do_install:append:class-target:mender-growfs-data:mender-systemd() {
 
     if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
-            ${WORKDIR}/mender-resize-data-part.sh.in
+            ${UNPACKDIR}/mender-resize-data-part.sh.in
     elif ${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid | grep 'PARTUUID=\"${@mender_get_partuuid_from_device(d, '${MENDER_DATA_PART}')}\"' | awk -F: '{ print \$1 }')#g" \
-            ${WORKDIR}/mender-resize-data-part.sh.in
+            ${UNPACKDIR}/mender-resize-data-part.sh.in
     else
         sed -i "s#@MENDER_DATA_PART@#${MENDER_DATA_PART}#g" \
-            ${WORKDIR}/mender-resize-data-part.sh.in
+            ${UNPACKDIR}/mender-resize-data-part.sh.in
     fi
 
     sed -i "s#@MENDER_DATA_PART_NUMBER@#${MENDER_DATA_PART_NUMBER}#g" \
-        ${WORKDIR}/mender-resize-data-part.sh.in
+        ${UNPACKDIR}/mender-resize-data-part.sh.in
 
 
     install -d ${D}/${bindir}/
 
-    install -m 0755 ${WORKDIR}/mender-resize-data-part.sh.in \
+    install -m 0755 ${UNPACKDIR}/mender-resize-data-part.sh.in \
         ${D}/${bindir}/mender-resize-data-part
 
     install -d ${D}/${systemd_unitdir}/system
-    install -m 644 ${WORKDIR}/mender-grow-data.service ${D}/${systemd_unitdir}/system/
-    install -m 644 ${WORKDIR}/mender-systemd-growfs-data.service ${D}/${systemd_unitdir}/system/
+    install -m 644 ${UNPACKDIR}/mender-grow-data.service ${D}/${systemd_unitdir}/system/
+    install -m 644 ${UNPACKDIR}/mender-systemd-growfs-data.service ${D}/${systemd_unitdir}/system/
 
     install -d ${D}${systemd_unitdir}/system/data.mount.wants/
     ln -sf ../mender-grow-data.service ${D}${systemd_unitdir}/system/data.mount.wants/
@@ -343,11 +342,11 @@ do_install:append:class-target:mender-growfs-data:mender-systemd() {
 }
 
 do_install:append:class-target:mender-persist-systemd-machine-id() {
-    install -m 644 ${WORKDIR}/mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/
+    install -m 644 ${UNPACKDIR}/mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/
     install -d -m 755 ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants
     ln -sf ../mender-systemd-machine-id.service ${D}${systemd_unitdir}/system/${MENDER_CLIENT}.service.wants/
     install -d -m 755 ${D}${bindir}
-    install -m 755 ${WORKDIR}/mender-set-systemd-machine-id.sh ${D}${bindir}/
+    install -m 755 ${UNPACKDIR}/mender-set-systemd-machine-id.sh ${D}${bindir}/
 }
 
 do_install() {

--- a/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
+++ b/meta-mender-core/recipes-mender/mender-configure/mender-configure.inc
@@ -37,7 +37,6 @@ FILES:${PN}-scripts = " \
     /usr/lib/mender-configure/apply-device-config.d/timezone \
 "
 
-S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
 do_install() {

--- a/meta-mender-core/recipes-mender/mender-flash/mender-flash.inc
+++ b/meta-mender-core/recipes-mender/mender-flash/mender-flash.inc
@@ -16,5 +16,4 @@ FILES:${PN} = " \
 
 DEPENDS += "googletest"
 
-S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"

--- a/meta-mender-core/recipes-mender/mender-server-certificate/mender-server-certificate.bb
+++ b/meta-mender-core/recipes-mender/mender-server-certificate/mender-server-certificate.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 DEPENDS = "ca-certificates"
 RDEPENDS:${PN} = "ca-certificates"
 
-S = "${WORKDIR}"
+S = "${UNPACKDIR}"
 localdatadir = "${prefix}/local/share"
 
 inherit allarch
@@ -14,7 +14,7 @@ inherit allarch
 PV = "0.1"
 
 do_install() {
-    if [ ! -f ${WORKDIR}/server.crt ]; then
+    if [ ! -f ${UNPACKDIR}/server.crt ]; then
         bbfatal "No server server.crt found in SRC_URI"
     fi
 
@@ -23,7 +23,7 @@ do_install() {
     # MEN-4580: Multiple certificates in one file are necessary to split in
     # order for `update-ca-certificates` to produce a hashed symlink to them,
     # which is required by some programs, such as curl.
-    if [ $(fgrep 'BEGIN CERTIFICATE' ${WORKDIR}/server.crt | wc -l) -gt 1 ]; then
+    if [ $(fgrep 'BEGIN CERTIFICATE' ${UNPACKDIR}/server.crt | wc -l) -gt 1 ]; then
         certnum=1
         while read LINE; do
             if [ -z "$cert" ] || echo "$LINE" | fgrep -q 'BEGIN CERTIFICATE'; then
@@ -34,9 +34,9 @@ do_install() {
                 certnum=$(expr $certnum + 1)
             fi
             echo "$LINE" >> $cert
-        done < ${WORKDIR}/server.crt
+        done < ${UNPACKDIR}/server.crt
     else
-        install -m 0444 ${WORKDIR}/server.crt ${D}${localdatadir}/ca-certificates/mender/server.crt
+        install -m 0444 ${UNPACKDIR}/server.crt ${D}${localdatadir}/ca-certificates/mender/server.crt
     fi
 }
 


### PR DESCRIPTION
This GitHub pull request adds support for the incoming next Yocto LTS release 6.0 Wrynose:

- Replace references of WORKDIR with UNPACKDIR where it makes sense
- mender-helpers.bbclass: Replace cp -a with cp -R to avoid error in mender-helpers.bbclass
- mender-artifact: Port both versions (git and 4.3.0) of mender-artifact to Yocto release Wrynose
- libubootenv_%.bbappend: Use UNPACKDIR
- u-boot-mender.inc: Upgrade to 2026.01
- mender-bootstrap-artifact: Fix PSEUDO_INCLUDE_PATHS
- conf/layer.conf: Support Wrynose

Tested on Raspberry Pi 5 with the related GitHub pull request from meta-mender-community/meta-mender-raspberrypi: https://github.com/mendersoftware/meta-mender-community/pull/499

# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
