### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/meta-mender-core/classes/mender-artifact-uefi-capsule.bbclass
+++ b/meta-mender-core/classes/mender-artifact-uefi-capsule.bbclass
@@ -103,7 +103,7 @@ IMAGE_CMD:mender-capsule () {
     extra_args=""
 
     for dev in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
-        extra_args="$extra_args -t $dev"
+        extra_args="$extra_args -c $dev"
     done
 
     if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then

--- a/meta-mender-core/classes/mender-artifactimg.bbclass
+++ b/meta-mender-core/classes/mender-artifactimg.bbclass
@@ -76,7 +76,7 @@ IMAGE_CMD:mender () {
     extra_args=
 
     for dev in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
-        extra_args="$extra_args -t $dev"
+        extra_args="$extra_args -c $dev"
     done
 
     if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then

--- a/meta-mender-core/classes/mender-bootstrap-artifact.bbclass
+++ b/meta-mender-core/classes/mender-bootstrap-artifact.bbclass
@@ -19,7 +19,7 @@ IMAGE_CMD:bootstrap-artifact() {
     # whether this version of mender-artifact supports bootstrap artifacts.
     if ! mender-artifact write bootstrap-artifact \
             --artifact-name test \
-            --device-type test \
+            --compatible-types test \
             --output-path "${WORKDIR}/test-artifact.mender"
     then
         # Not supported, don't generate.
@@ -38,7 +38,7 @@ IMAGE_CMD:bootstrap-artifact() {
         extra_args=
 
         for dev in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
-            extra_args="$extra_args -t $dev"
+            extra_args="$extra_args -c $dev"
         done
 
         if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344

