### PR TITLE
chore: use updated interface name in mender-orchestrator demo env

### DIFF
--- a/meta-mender-demo/mender-commercial/mender-orchestrator-support/mender-orchestrator-support_%.bbappend
+++ b/meta-mender-demo/mender-commercial/mender-orchestrator-support/mender-orchestrator-support_%.bbappend
@@ -1,6 +1,6 @@
 FILES:${PN} += " \
     /data/mender-orchestrator/mock-instances \
-    ${datadir}/mender-orchestrator/interfaces/v1/rtos \
+    ${datadir}/mender-orchestrator/interfaces/v1/rtos-interface \
 "
 
 python () {


### PR DESCRIPTION
The interface was renamed in https://github.com/mendersoftware/mender-orchestrator-support/pull/29