### PR TITLE
fix: copy grow-data template to B before sed substitution

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -313,24 +313,27 @@ do_install:append:class-target:mender-image:mender-systemd() {
 
 do_install:append:class-target:mender-growfs-data:mender-systemd() {
 
+    # Copy to build dir to do replacements in-place
+    cp ${WORKDIR}/mender-resize-data-part.sh.in ${B}/mender-resize-data-part.sh.in
+
     if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
-            ${WORKDIR}/mender-resize-data-part.sh.in
+            ${B}/mender-resize-data-part.sh.in
     elif ${@bb.utils.contains('MENDER_FEATURES', 'mender-partuuid', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid | grep 'PARTUUID=\"${@mender_get_partuuid_from_device(d, '${MENDER_DATA_PART}')}\"' | awk -F: '{ print \$1 }')#g" \
-            ${WORKDIR}/mender-resize-data-part.sh.in
+            ${B}/mender-resize-data-part.sh.in
     else
         sed -i "s#@MENDER_DATA_PART@#${MENDER_DATA_PART}#g" \
-            ${WORKDIR}/mender-resize-data-part.sh.in
+            ${B}/mender-resize-data-part.sh.in
     fi
 
     sed -i "s#@MENDER_DATA_PART_NUMBER@#${MENDER_DATA_PART_NUMBER}#g" \
-        ${WORKDIR}/mender-resize-data-part.sh.in
+        ${B}/mender-resize-data-part.sh.in
 
 
     install -d ${D}/${bindir}/
 
-    install -m 0755 ${WORKDIR}/mender-resize-data-part.sh.in \
+    install -m 0755 ${B}/mender-resize-data-part.sh.in \
         ${D}/${bindir}/mender-resize-data-part
 
     install -d ${D}/${systemd_unitdir}/system


### PR DESCRIPTION
Otherwise subsequent runs will not find the `@...@` markers in the already modified template in workdir and nothing gets updated.

Fixes an issue were `mender-growfs-data` script is not updated after changing relevant `MENDER_*` variables unless we do a full sstate clean and rebuild.