### PR TITLE
fix: drop stale WORKDIR copy in mender-growfs-data install

### DIFF
--- a/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
+++ b/meta-mender-core/recipes-mender/mender-client/mender-client-cpp.inc
@@ -312,9 +312,6 @@ do_install:append:class-target:mender-image:mender-systemd() {
 
 do_install:append:class-target:mender-growfs-data:mender-systemd() {
 
-    # Copy to build dir to do replacements in-place
-    cp ${WORKDIR}/mender-resize-data-part.sh.in ${B}/mender-resize-data-part.sh.in
-
     if ${@bb.utils.contains('MENDER_FEATURES', 'mender-partlabel', 'true', 'false', d)}; then
         sed -i "s#@MENDER_DATA_PART@#\$(blkid -L ${MENDER_DATA_PART_LABEL})#g" \
             ${UNPACKDIR}/mender-resize-data-part.sh.in


### PR DESCRIPTION
## Description

`do_install:append:class-target:mender-growfs-data:mender-systemd()` in `mender-client-cpp.inc` still copies `mender-resize-data-part.sh.in` from `${WORKDIR}` to `${B}` before its `sed` substitutions:

```sh
# Copy to build dir to do replacements in-place
cp ${WORKDIR}/mender-resize-data-part.sh.in ${B}/mender-resize-data-part.sh.in
```

After the WORKDIR → UNPACKDIR transition (acff677b), sources unpack to `${UNPACKDIR}`, so `${WORKDIR}/mender-resize-data-part.sh.in` no longer exists and the `cp` fails, aborting `do_install`:

```
cp: cannot stat '.../mender/5.1.0/mender-resize-data-part.sh.in': No such file or directory
WARNING: exit code 1 from a shell command.
```

The copy is also dead code: the `sed` and `install` steps in the same function were already repointed to operate in-place on `${UNPACKDIR}/mender-resize-data-part.sh.in` by acff677b, so the `${B}` copy is never read. This patch simply removes it.

## Testing

`do_install` for `mender` (target, `mender-growfs-data` + `mender-systemd` features) completes instead of failing on the missing file.