### PR TITLE
[Cherry-pick] chore: update bblayers.conf paths for split poky repos

### DIFF
--- a/tests/acceptance/test_extended.py
+++ b/tests/acceptance/test_extended.py
@@ -40,9 +40,9 @@ class TestMetaMenderExtended:
             ],
             [
                 f'BBLAYERS:append = " {bitbake_variables["LAYERDIR_MENDER"]}/../meta-mender-extended"',
-                f'BBLAYERS:append = " {bitbake_variables["COREBASE"]}/meta-virtualization"',
-                f'BBLAYERS:append = " {bitbake_variables["COREBASE"]}/meta-openembedded/meta-networking"',
-                f'BBLAYERS:append = " {bitbake_variables["COREBASE"]}/meta-openembedded/meta-filesystems"',
+                f'BBLAYERS:append = " {bitbake_variables["COREBASE"]}/../meta-virtualization"',
+                f'BBLAYERS:append = " {bitbake_variables["COREBASE"]}/../meta-openembedded/meta-networking"',
+                f'BBLAYERS:append = " {bitbake_variables["COREBASE"]}/../meta-openembedded/meta-filesystems"',
             ],
         )
 

--- a/tests/build-conf/beagleboneblack/bblayers.conf
+++ b/tests/build-conf/beagleboneblack/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \

--- a/tests/build-conf/qemux86-64-bios-grub-gpt/bblayers.conf
+++ b/tests/build-conf/qemux86-64-bios-grub-gpt/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \

--- a/tests/build-conf/qemux86-64-bios-grub/bblayers.conf
+++ b/tests/build-conf/qemux86-64-bios-grub/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \

--- a/tests/build-conf/qemux86-64-uefi-grub/bblayers.conf
+++ b/tests/build-conf/qemux86-64-uefi-grub/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \

--- a/tests/build-conf/vexpress-qemu-flash/bblayers.conf
+++ b/tests/build-conf/vexpress-qemu-flash/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \

--- a/tests/build-conf/vexpress-qemu-uboot-uefi-grub/bblayers.conf
+++ b/tests/build-conf/vexpress-qemu-uboot-uefi-grub/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \

--- a/tests/build-conf/vexpress-qemu/bblayers.conf
+++ b/tests/build-conf/vexpress-qemu/bblayers.conf
@@ -6,9 +6,9 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
-  @WORKSPACE@/meta \
-  @WORKSPACE@/meta-poky \
-  @WORKSPACE@/meta-yocto-bsp \
+  @WORKSPACE@/openembedded-core/meta \
+  @WORKSPACE@/meta-yocto/meta-poky \
+  @WORKSPACE@/meta-yocto/meta-yocto-bsp \
   @WORKSPACE@/meta-mender/meta-mender-core \
   @WORKSPACE@/meta-mender/meta-mender-demo \
   @WORKSPACE@/meta-openembedded/meta-oe \


### PR DESCRIPTION
The mender-qa workspace layout changed: poky is replaced by separate openembedded-core, bitbake, and meta-yocto checkouts. Update the test build config paths accordingly.

Ticket: QA-1632