### PR TITLE
fix: extend grep for version check in mender-gateay.inc

### DIFF
--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway.inc
@@ -28,7 +28,7 @@ do_version_check() {
     fi
 
     if ! ${@'true' if d.getVar('MENDER_DEVMODE') else 'false'}; then
-        if ! strings ${S}/${SUB_FOLDER}/mender-gateway | grep -q "^${PV}$"; then
+        if ! strings ${S}/${SUB_FOLDER}/mender-gateway | grep -qE "^${PV}$|main\.Version=${PV}"; then
             bbfatal "String '${PV}' not found in binary. Is it the correct version? Check with --version."
         fi
     fi


### PR DESCRIPTION
Ticket: None
Changelog: Fix an issue where the version check for mender-gateway was too strict for binaries compiled with newer golang versions.