### PR TITLE
fix(mender-artifact): Revert erroneous change to LICENCE checksum for _git recipe

### DIFF
--- a/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
+++ b/meta-mender-core/recipes-mender/mender-artifact/mender-artifact_git.bb
@@ -45,7 +45,7 @@ SRC_URI = "git://github.com/mendersoftware/mender-artifact.git;protocol=https;br
 # DO NOT change the checksum here without make sure that ALL licenses (including
 # dependencies) are included in the LICENSE variable below.
 LIC_FILES_CHKSUM = " \
-    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e \
+    file://src/github.com/mendersoftware/mender-artifact/LICENSE;md5=a8c81350f12516cbb62844f937d81d11 \
 "
 
 LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & ISC & MIT & MPL-2.0"


### PR DESCRIPTION

Ticket: None