### PR TITLE
fix(qemu): skip -enable-kvm for a foreign guest architecture

### DIFF
--- a/meta-mender-qemu/scripts/mender-qemu
+++ b/meta-mender-qemu/scripts/mender-qemu
@@ -132,8 +132,26 @@ $QEMU_SYSTEM --version || exit 1
 
 echo "--- starting qemu"
 
+# KVM can only accelerate a guest whose architecture matches the host's, and
+# only when /dev/kvm is present. For a foreign target (e.g. qemu-system-arm on
+# an x86_64 build host) "-enable-kvm" always fails with "invalid accelerator
+# kvm"; on qemu >= 8 that failed attempt also races the "" (TCG) retry for the
+# fixed hostfwd port ("Could not set up host forwarding rule tcp::..."), so the
+# guest never starts. Only attempt KVM when it can actually work.
+kvm_usable=false
+if [ -e /dev/kvm ]; then
+    case "$(uname -m):$QEMU_SYSTEM" in
+        x86_64:*qemu-system-x86_64*|x86_64:*qemu-system-i386*|i[3456]86:*qemu-system-i386*|aarch64:*qemu-system-aarch64*|armv[67]*:*qemu-system-arm*)
+            kvm_usable=true
+            ;;
+    esac
+fi
+
 ret=0
 for maybe_kvm in -enable-kvm ""; do
+    if [ "$maybe_kvm" = "-enable-kvm" ] && [ "$kvm_usable" != true ]; then
+        continue
+    fi
     if QEMU_AUDIO_DRV=none \
             $QEMU_SYSTEM \
             -m "${QEMU_MEMORY}" \


### PR DESCRIPTION
mender-qemu tries "-enable-kvm" then falls back to TCG for every target. On an x86_64 build host a foreign target such as qemu-system-arm (vexpress) can never use KVM, so the "-enable-kvm" attempt always fails with "invalid accelerator kvm". On qemu >= 8 (Ubuntu 24.04 runners) that failed attempt races the TCG retry for the fixed hostfwd port, so the retry fails with "Could not set up host forwarding rule tcp::8822-:22" and the guest never starts -- making the vexpress acceptance tests fail since the runners moved from Ubuntu 22.04 (qemu 6.2) to 24.04 (qemu 8.2).

Only attempt KVM when /dev/kvm is present and the guest architecture matches the host's; otherwise go straight to TCG. x86 targets on x86 hosts are unaffected.

Changelog: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
Ticket: <TICKET NUMBER> or <None>
```

- [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description

Please describe your pull request.

Thank you!
