### PR TITLE
fix: Prevent '-doc' from stealing conf

### DIFF
--- a/meta-mender-demo/mender-commercial/mender-gateway/mender-gateway_%.bbappend
+++ b/meta-mender-demo/mender-commercial/mender-gateway/mender-gateway_%.bbappend
@@ -1,7 +1,6 @@
 
 FILES:${PN}-doc:append = " \
     ${docdir}/mender-gateway/examples \
-    ${sysconfdir}/mender/mender-gateway.conf \
 "
 
 def examples_dir_from_s_dir(d, s):


### PR DESCRIPTION
The line in the .bbappend causes custom made mender-gateway.conf to be stolen into '-doc' when building with demo and commercial layers. Removing the line fixes it.

Changelog: Fix disappearing mender-gateway.conf
Ticket: MEN-6625
