### PR TITLE
docs(pr-template): fix grammar.md link and drop mandatory trailer lines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
 🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.
 
-- [ ] Make sure that all commits follow the conventional commit [specification](https://www.github.com/mendersoftware/mendertesting/commitlint/grammar.md) for the Mender project.
+- [ ] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.
 
 The majority of our contributions are fixes, which means your commit should have
 the form below:
@@ -13,8 +13,8 @@ fix: <SHORT DESCRIPTION OF FIX>
 
 <OPTIONAL LONGER DESCRIPTION>
 
-Changelog: <USER-FRIENDLY-CHANGE-DESCRIPTION> or <None>
-Ticket: <TICKET NUMBER> or <None>
+<OPTIONAL Changelog: <USER-FRIENDLY CHANGE DESCRIPTION>>
+<OPTIONAL Ticket: <TICKET NUMBER>>
 ```
 
 - [ ] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.


### PR DESCRIPTION
The PR template's spec link was malformed (`www.github.com/...` without `/blob/master/` — a 404); it now points to the canonical [commit specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md). Also drops the mandatory `Changelog:`/`Ticket:` fill-in lines; trailers are optional under the new policy.

Ticket: [QA-1675](https://northerntech.atlassian.net/browse/QA-1675)

[QA-1675]: https://northerntech.atlassian.net/browse/QA-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
