### PR TITLE
chore: update acceptance test deb requirements for ubuntu 26.04

### DIFF
--- a/tests/acceptance/requirements_deb.txt
+++ b/tests/acceptance/requirements_deb.txt
@@ -26,7 +26,7 @@ libbz2-dev
 libfdt-dev
 libffi-dev
 libglib2.0-dev
-liblz4-tool
+lz4
 liblzma-dev
 liblzo2-dev
 libpixman-1-dev
@@ -46,8 +46,6 @@ psmisc
 python3-dev
 python3-libvirt
 python3-pip
-qemu-kvm
-qemu-system-arm
 qemu-system-x86
 qemu-utils
 rustc


### PR DESCRIPTION
liblz4-tool and qemu-kvm are gone on ubuntu 26.04: lz4 replaces liblz4-tool, and qemu-kvm was already covered by qemu-system-x86. Also drop qemu-system-arm: qemu >= 8.2.1 breaks the vexpress-qemu-flash tests (QA-1690), so the acceptance test image builds a patched qemu.

Ticket: QA-1690