### PR TITLE
build: Change xdelta3 to be a dependency in mender-delta-container-modules

### DIFF
--- a/meta-mender-commercial/conditional/mender-delta-container-modules/mender-delta-container-modules.inc
+++ b/meta-mender-commercial/conditional/mender-delta-container-modules/mender-delta-container-modules.inc
@@ -3,26 +3,16 @@ inherit mender-licensing
 DESCRIPTION = "Mender Delta Container Modules"
 HOMEPAGE = "https://mender.io"
 
-SUB_FOLDER:arm = "arm"
-SUB_FOLDER:aarch64 = "aarch64"
-SUB_FOLDER:x86-64 = "x86_64"
-
-COMPATIBLE_HOST = "arm|aarch64|x86_64"
-
 PACKAGES =+ "mender-delta-docker-compose"
 
-# "lsb-ld" is needed because Yocto by default does not provide a cross platform
-# dynamic linker. On x86_64 this manifests as a missing
-# `/lib64/ld-linux-x86-64.so.2`.
-RDEPENDS:mender-delta-docker-compose = "mender-update docker-compose docker jq lsb-ld"
+RDEPENDS:mender-delta-docker-compose = "mender-update docker-compose docker jq xdelta3"
 
 FILES:mender-delta-docker-compose = " \
     ${datadir}/mender/modules/v3/delta-docker-compose \
-    ${bindir}/xdelta3 \
 "
 
 do_version_check() {
-    if [ ! -e ${S}/delta-docker-compose ] || [ ! -e ${S}/${SUB_FOLDER}/xdelta3 ]; then
+    if [ ! -e ${S}/delta-docker-compose ]; then
         bbfatal "No delta-docker-compose module found. Have you added the package to SRC_URI?"
     fi
 }
@@ -31,7 +21,4 @@ addtask do_version_check after do_patch before do_install
 do_install() {
     install -d -m 755 ${D}${datadir}/mender/modules/v3
     install -m 755 ${S}/delta-docker-compose ${D}${datadir}/mender/modules/v3/delta-docker-compose
-
-    install -d -m 755 ${D}${bindir}
-    install -m 755 ${S}/${SUB_FOLDER}/xdelta3 ${D}${bindir}/xdelta3
 }

--- a/meta-mender-commercial/conditional/mender-delta-container-modules/mender-delta-container-modules_git.bb
+++ b/meta-mender-commercial/conditional/mender-delta-container-modules/mender-delta-container-modules_git.bb
@@ -8,8 +8,6 @@ LICENSE = "Mender-Yocto-Layer-License.md & Apache-2.0"
 LICENSE_FLAGS = "commercial_mender-yocto-layer-license"
 LIC_FILES_CHKSUM = " \
     file://licenses/LICENSE;md5=fd6f2f84e25bc8e0cee29484baf2f0e6 \
-    file://licenses/xdelta/xdelta3/LICENSE;md5=cf96fa0d649f7c7b16616d95e7880a73 \
-    file://licenses/xdelta/xdelta3/cpp-btree/COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57 \
     file://licenses/mender-container-modules/LICENSE;md5=a8c81350f12516cbb62844f937d81d11 \
 "
 

--- a/tests/acceptance/commercial/test_delta_docker_compose_module.py
+++ b/tests/acceptance/commercial/test_delta_docker_compose_module.py
@@ -54,7 +54,6 @@ class TestDeltaDockerComposeModule:
 
         for path in [
             "/usr/share/mender/modules/v3/delta-docker-compose",
-            "/usr/bin/xdelta3",
         ]:
             output = subprocess.check_output(
                 ["debugfs", "-R", f"stat {path}", image]


### PR DESCRIPTION
mendersoftware/mender-delta-container-modules#16 means xdelta3 is no longer shipped as part of the module and is required as an external dependency instead.

Ticket: MEN-10045
Changelog: None