### PR TITLE
chore: remove DSA key from ssh-demo-keys

### DIFF
--- a/meta-mender-demo/recipes-connectivity/ssh-demo-keys/ssh-demo-keys.bb
+++ b/meta-mender-demo/recipes-connectivity/ssh-demo-keys/ssh-demo-keys.bb
@@ -13,6 +13,5 @@ do_install() {
 
     /usr/bin/ssh-keygen -f ${D}${sysconfdir}/ssh/ssh_host_rsa_key -N '' -t rsa
     /usr/bin/ssh-keygen -f ${D}${sysconfdir}/ssh/ssh_host_ecdsa_key -N '' -t ecdsa
-    /usr/bin/ssh-keygen -f ${D}${sysconfdir}/ssh/ssh_host_dsa_key -N '' -t dsa
     /usr/bin/ssh-keygen -f ${D}${sysconfdir}/ssh/ssh_host_ed25519_key -N '' -t ed25519
 }


### PR DESCRIPTION
Nothing consumes the DSA key and as of OpenSSH it is no longer supported.

Ticket: QA-1720

The relevant jobs passed on scarthgap in https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/2766399435