### PR TITLE
fix: write extra partition fstab entries one per line

### DIFF
--- a/meta-mender-core/classes/mender-setup-image.inc
+++ b/meta-mender-core/classes/mender-setup-image.inc
@@ -68,8 +68,9 @@ mender_update_fstab_file() {
             mkdir -p ${IMAGE_ROOTFS}/${mount}
         done
 
-        parts="${extra_part_fstab}"
-        printf "%-20s %-20s %-10s %-21s %-2s %s\n" $parts >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
+        printf "%s\n" "$extra_part_fstab" | while IFS= read -r parts; do
+            printf "%-20s %-20s %-10s %-21s %-2s %s\n" ${parts} >> ${IMAGE_ROOTFS}${sysconfdir}/fstab
+        done
     fi
 
     if [ "${MENDER_SWAP_PART_SIZE_MB}" -ne "0" ]; then


### PR DESCRIPTION
Write each fstab entry separately so that every extra part yields a well-formed line

Changelog: Fixed generation of /etc/fstab when multiple extra partitions are defined
Ticket: None


# External Contributor Checklist

🚨 Please review the [guidelines for contributing](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md) to this repository.

- [x] Make sure that all commits follow the conventional commit [specification](https://github.com/mendersoftware/mendertesting/blob/master/commitlint/grammar.md) for the Mender project.

The majority of our contributions are fixes, which means your commit should have
the form below:

```
fix: <SHORT DESCRIPTION OF FIX>

<OPTIONAL LONGER DESCRIPTION>

<OPTIONAL Changelog: <USER-FRIENDLY CHANGE DESCRIPTION>>
<OPTIONAL Ticket: <TICKET NUMBER>>
```

- [x] Make sure that all commits are signed with [`git --signoff`](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work). Also note that the signoff author must match the author of the commit.

### Description
I have two extra partition like this

```
$ export extra_part_fstab="PARTUUID=089bdc31-04ad-4ac3-872e-dd3700f69765  auto defaults 0 2
             PARTUUID=1ebe2635-da99-4ac0-b87e-b88a4dd79e50  auto defaults 0 2"


# old printf to the fstab file is invalid
$ printf "%-20s %-20s %-10s %-21s %-2s %s\n" $extra_part_fstab

PARTUUID=089bdc31-04ad-4ac3-872e-dd3700f69765 auto                 defaults   0                     2  PARTUUID=1ebe2635-da99-4ac0-b87e-b88a4dd79e50
auto                 defaults             0          2                        

# New printf

$ printf "%s\n" "$extra_part_fstab" | while IFS= read -r parts; do
             printf "%-20s %-20s %-10s %-21s %-2s %s\n" ${parts}                                      
done

PARTUUID=089bdc31-04ad-4ac3-872e-dd3700f69765 auto                 defaults   0                     2  
PARTUUID=1ebe2635-da99-4ac0-b87e-b88a4dd79e50 auto                 defaults   0                     2  

```

