### PR TITLE
fix: derive closed-source S dir from the tarball name

### DIFF
--- a/meta-mender-commercial/classes/mender-closed-source-utils.bbclass
+++ b/meta-mender-commercial/classes/mender-closed-source-utils.bbclass
@@ -57,11 +57,25 @@ def mender_closed_source_pv_from_preferred_version(d, srcrev):
         branch = pref_version.rsplit("-git", 1)[0]
     return "%s%s" % (branch, srcrev)
 
-def mender_closed_source_tarball_dir_from_pv(d, pv):
-    # PV is "<branch>-git+<sha>" for git builds, "<branch>" for branch
-    # tarballs, or a tagged version like "1.2.3" / "1.2.3-build1". The
-    # directory inside the tarball is the trailing "<sha>" for git builds,
-    # otherwise the literal PV.
-    if "-git+" in pv:
-        return pv.split("-git+", 1)[1]
-    return pv
+def mender_closed_source_tarball_dir_version_from_src_uri(d, src_uri, repo_name):
+    # The tarball always unpacks to a directory with the same name as the
+    # tarball itself. So instead of guessing the directory from
+    # PREFERRED_VERSION (which breaks when e.g. a "-master"-named tarball is
+    # selected via "main-git%"), strip the "<repo_name>-" prefix and the
+    # .tar.* extension from the filename and use whatever remains
+    # ("main", "master", a sha or a tag).
+    import glob
+    import re
+    src_uri_list = src_uri.split()
+    if len(src_uri_list) == 0:
+        # No source specified. We won't be building this component.
+        return ""
+    filenames = glob.glob(src_uri_list[0][len("file://"):])
+    if len(filenames) != 1:
+        # mender_closed_source_srcrev_from_src_uri errors on this in the
+        # non-"-build" path; otherwise the fetch/version-check fails later.
+        return ""
+    m = re.match(repo_name + r"-(.+)\.tar\.(?:xz|gz)", os.path.basename(filenames[0]))
+    if not m:
+        bb.fatal("Failed to parse version from %s" % os.path.basename(filenames[0]))
+    return m.group(1)

--- a/meta-mender-commercial/conditional/mender-delta-container-modules/mender-delta-container-modules_git.bb
+++ b/meta-mender-commercial/conditional/mender-delta-container-modules/mender-delta-container-modules_git.bb
@@ -18,8 +18,8 @@ SRCREV = "${@mender_closed_source_srcrev_from_src_uri(d, '${SRC_URI}', 'delta-do
 
 PV = "${@mender_closed_source_pv_from_preferred_version(d, '${SRCREV}')}"
 
-# Define S to work both on git sha and "main" tarballs
-S = "${UNPACKDIR}/delta-docker-compose-${@mender_closed_source_tarball_dir_from_pv(d, '${PV}')}"
+# Define S to match the directory the tarball unpacks to
+S = "${UNPACKDIR}/delta-docker-compose-${@mender_closed_source_tarball_dir_version_from_src_uri(d, '${SRC_URI}', 'delta-docker-compose')}"
 
 # Skip version check
 MENDER_DEVMODE = "true"

--- a/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-binary-delta/mender-binary-delta_git.bb
@@ -19,8 +19,8 @@ SRCREV = "${@mender_closed_source_srcrev_from_src_uri(d, '${SRC_URI}', 'mender-b
 
 PV = "${@mender_closed_source_pv_from_preferred_version(d, '${SRCREV}')}"
 
-# Define S to work both on git sha and "master" tarballs
-S = "${UNPACKDIR}/mender-binary-delta-${@mender_closed_source_tarball_dir_from_pv(d, '${PV}')}"
+# Define S to match the directory the tarball unpacks to
+S = "${UNPACKDIR}/mender-binary-delta-${@mender_closed_source_tarball_dir_version_from_src_uri(d, '${SRC_URI}', 'mender-binary-delta')}"
 
 # Skip version check
 MENDER_DEVMODE = "true"

--- a/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-gateway/mender-gateway_git.bb
@@ -17,8 +17,8 @@ SRCREV = "${@mender_closed_source_srcrev_from_src_uri(d, '${SRC_URI}', 'mender-g
 
 PV = "${@mender_closed_source_pv_from_preferred_version(d, '${SRCREV}')}"
 
-# Define S to work both on git sha and "master" tarballs
-S = "${UNPACKDIR}/mender-gateway-${@mender_closed_source_tarball_dir_from_pv(d, '${PV}')}"
+# Define S to match the directory the tarball unpacks to
+S = "${UNPACKDIR}/mender-gateway-${@mender_closed_source_tarball_dir_version_from_src_uri(d, '${SRC_URI}', 'mender-gateway')}"
 
 # Skip version check
 MENDER_DEVMODE = "true"

--- a/meta-mender-commercial/recipes-mender/mender-orchestrator/mender-orchestrator_git.bb
+++ b/meta-mender-commercial/recipes-mender/mender-orchestrator/mender-orchestrator_git.bb
@@ -17,8 +17,8 @@ SRCREV = "${@mender_closed_source_srcrev_from_src_uri(d, '${SRC_URI}', 'mender-o
 
 PV = "${@mender_closed_source_pv_from_preferred_version(d, '${SRCREV}')}"
 
-# Define S to work both on git sha and "master" tarballs
-S = "${UNPACKDIR}/mender-orchestrator-${@mender_closed_source_tarball_dir_from_pv(d, '${PV}')}"
+# Define S to match the directory the tarball unpacks to
+S = "${UNPACKDIR}/mender-orchestrator-${@mender_closed_source_tarball_dir_version_from_src_uri(d, '${SRC_URI}', 'mender-orchestrator')}"
 
 # Skip version check
 MENDER_DEVMODE = "true"


### PR DESCRIPTION
S used to be derived from PV (which follows PREFERRED_VERSION), so with "main-git%" the recipe would look for e.g. delta-docker-compose-main even when the tarball (and the directory inside it) was named delta-docker-compose-master, failing the build. The tarball always unpacks to a directory with the same name as itself, so instead strip the "<repo_name>-" prefix and the .tar.* extension from the filename and use whatever is left ("main", "master", a sha or a tag) for S. PV is unchanged and still follows PREFERRED_VERSION.

Ticket: None
Changelog: Derive closed-source S dir from the tarball name instead of `PREFERRED_VERSION`. This fixes builds where e.g. `PREFERRED_VERSION` is `main-git%` but the tarball is named `-master`, resulting in the S dir not being found.
