### PR TITLE
ci: drop the per repo renovate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
 stages:
-  - renovate
   - test
 
 include:
@@ -14,9 +13,6 @@ include:
     file: '.gitlab-ci-check-python3-format.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
-  - component: gitlab.com/Northern.tech/Mender/mendertesting/renovate@master
-    inputs:
-      stage: "renovate"
 
 test:check-version-bump:
   stage: test


### PR DESCRIPTION
Renovate now runs centrally from NorthernTechHQ/renovate-ring, which reads this repo's renovate.json5 straight from GitHub. Nothing about grouping or managers changes.

The job only ever triggered on a pipeline schedule and that schedule is already deleted, so this removes config that can no longer run.